### PR TITLE
Multiselect padding loading

### DIFF
--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -36,6 +36,11 @@
 	<vue-multiselect
 		:value="value"
 		v-bind="$attrs"
+		:class="{
+			'icon-loading-small': loading,
+			'multiselect--multiple': multiple,
+			'multiselect--single': !multiple
+		}"
 		:limit="maxOptions"
 		:close-on-select="!multiple"
 		:multiple="multiple"
@@ -110,6 +115,15 @@ export default {
 		 * @type {Boolean}
 		 */
 		userSelect: {
+			type: Boolean,
+			default: false
+		},
+		/**
+		 * Overriding the default slot. Only showing a spiner.
+		 * @default true
+		 * @type {Boolean}
+		 */
+		loading: {
 			type: Boolean,
 			default: false
 		},

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -49,13 +49,27 @@
 		tag-placeholder="create"
 		v-on="$listeners"
 		@update:value="$emit('update:value', value)">
-		<template v-if="userSelect" slot="option" slot-scope="{ option }">
-			<avatar-select-option :option="option" />
+
+		<template slot="option" slot-scope="scope">
+			<!-- Avatar display select slot override.
+				You CANNOT use this scope, we will replace it by this -->
+			<avatar-select-option v-if="userSelect" :option="scope.option" />
+
+			<!-- Passing the singleLabel slot -->
+			<slot v-else name="option" v-bind="scope" />
 		</template>
+
+		<!-- Registering the limit slot to get the +xxx tooltip.
+			You CANNOT use this scope, we will replace it by this -->
 		<span v-if="multiple" slot="limit" v-tooltip.auto="formatLimitTitle(value)"
 			class="multiselect__limit">
 			{{ limitString }}
 		</span>
+
+		<!-- Passing the singleLabel slot -->
+		<template slot="singleLabel" slot-scope="scope">
+			<slot name="singleLabel" v-bind="scope" />
+		</template>
 		<!-- TODO add translation system
 		<span slot="noResult">{{ t('core', 'No results') }}</span> -->
 	</vue-multiselect>

--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -2,10 +2,11 @@
 // as the nested properties are not inside it
 // Therefore we need to use an external scoping
 .multiselect[data-v-#{$scope_version}] {
-	margin: 1px 2px;
+	margin: 0;
 	padding: 0 !important;
 	display: inline-block;
-	width: 160px;
+	/* override this rule with your width styling if you need */
+	min-width: 160px; 
 	position: relative;
 	background-color: var(--color-main-background);
 	&.multiselect--active {
@@ -18,6 +19,11 @@
 	&.multiselect--disabled,
 	&.multiselect--disabled .multiselect__single {
 		background-color: var(--color-background-dark) !important;
+	}
+	// loading state
+	&.icon-loading-small::after {
+		left: 100%;
+		margin-left: -24px;
 	}
 	.multiselect__tags {
 		/* space between tags and limit tag */
@@ -117,6 +123,8 @@
 			display: block !important;
 			/* only when not active */
 			cursor: pointer;
+			/* override inline styling of the lib */
+			padding: 7px 6px !important;
 		}
 	}
 	/* results wrapper */
@@ -163,7 +171,6 @@
 				/* selected checkmark icon */
 				&::before {
 					content: ' ';
-					background-image: var(--icon-checkmark-000);
 					background-repeat: no-repeat;
 					background-position: center;
 					min-width: 16px;
@@ -200,5 +207,12 @@
 				}
 			}
 		}
+	}
+	/* Icon before option select */
+	&.multiselect--multiple .multiselect__content-wrapper li > span::before {
+		background-image: var(--icon-checkmark-000);
+	}
+	&.multiselect--single .multiselect__content-wrapper li > span::before {
+		background-image: var(--icon-triangle-e-000);
 	}
 }

--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -49,7 +49,9 @@
 			input is used to display single value */
 			&:empty ~ input.multiselect__input {
 				opacity: 1 !important;
-				/* hide default empty text, show input instead */
+				/* hide default empty text like .multiselect__placeholder,
+				and show input instead. It looks better without a transition between
+				a span and the input that have different styling */
 				+ span:not(.multiselect__single) {
 					display: none;
 				}
@@ -88,14 +90,17 @@
 				}
 			}
 		}
-		/* Single select default value */
-		.multiselect__single {
-			padding: 8px 10px;
+		/* Single select default value
+		or default placeholder if search disabled*/
+		.multiselect__single,
+		.multiselect__placeholder {
+			padding: 7px 6px; // like the input
 			flex: 0 0 100%;
 			z-index: 1; /* above input */
 			background-color: var(--color-main-background);
 			cursor: pointer;
-			line-height: 17px;
+			line-height: 18px; // 32px - 2*6px (padding) - 2*1px (border)
+			color: var(--color-text-lighter); // like the input
 		}
 		/* displayed text if tag limit reached */
 		.multiselect__strong,
@@ -214,5 +219,12 @@
 	}
 	&.multiselect--single .multiselect__content-wrapper li > span::before {
 		background-image: var(--icon-triangle-e-000);
+	}
+	/* Mouse feedback */
+	&:hover,
+	input.multiselect__input {
+		.multiselect__placeholder {
+			color: var(--color-main-text);
+		}
 	}
 }


### PR DESCRIPTION
1. Added the support of two slots:
    - option (only if `user-select` is false (since we override the option slot)
    - singleLabel
        #### Any other slots are not supported because we think they're not relevant. It's better to have proper standards than letting people do anything they want. If you have any idea of a custom option layout that you think will benefit on other place of nextcloud, please suggest :wink: 

2. fixed styling.
    - now min-width is 160px, not the width. Adapt it to your design.
    - padding fixes
    - implemented the loading state like so:
    ![capture d ecran_2018-11-21_13-25-39](https://user-images.githubusercontent.com/14975046/48909856-a103e380-ee6e-11e8-9019-864c7f5d95e0.png)
    - select icon switched to a triangle on single selects
    ![capture d ecran_2018-11-22_08-48-03](https://user-images.githubusercontent.com/14975046/48909797-80d42480-ee6e-11e8-9178-b9332a6678be.png)



@nextcloud/vue 

| Before | After |
|:---------:|:------:|
|![capture d ecran_2018-11-22_15-24-00](https://user-images.githubusercontent.com/14975046/48909555-e4aa1d80-ee6d-11e8-805f-6961618727f5.png)|![capture d ecran_2018-11-22_15-23-23](https://user-images.githubusercontent.com/14975046/48909560-e70c7780-ee6d-11e8-97d1-10dd940751d8.png)|

