### PR TITLE
Do not use default datepicker css

### DIFF
--- a/src/assets/arrow-left-double.svg
+++ b/src/assets/arrow-left-double.svg
@@ -1,1 +1,3 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M12.5 3.5L8 8l4.5 4.5v-1L9 8l3.5-3.5zM8 3.5L3.5 8 8 12.5v-1L4.5 8 8 4.5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path d="M12 3.5L7.5 8l4.5 4.5v-1L8.5 8 12 4.5zm-4.5 0L3 8l4.5 4.5v-1L4 8l3.5-3.5z"/>
+</svg>

--- a/src/assets/arrow-left.svg
+++ b/src/assets/arrow-left.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" viewbox="0 0 16 16"><path d="m5.5 8 6 6v1l-7-7 7-7v1z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path d="M5 8l6 6v1L4 8l7-7v1z"/>
+</svg>

--- a/src/assets/arrow-right-double.svg
+++ b/src/assets/arrow-right-double.svg
@@ -1,1 +1,3 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M3.5 12.5L8 8 3.5 3.5v1L7 8l-3.5 3.5zM8 12.5L12.5 8 8 3.5v1L11.5 8 8 11.5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path d="M4 12.5L8.5 8 4 3.5v1L7.5 8 4 11.5zm4.5 0L13 8 8.5 3.5v1L12 8l-3.5 3.5z"/>
+</svg>

--- a/src/assets/arrow-right.svg
+++ b/src/assets/arrow-right.svg
@@ -1,1 +1,3 @@
-<svg width="16" height="16" version="1.1" viewbox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m10.5 8-6-6v-1l7 7-7 7v-1z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path d="M11 8L5 2V1l7 7-7 7v-1z"/>
+</svg>

--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -21,21 +21,23 @@
   -->
 
 <template>
-	<datepicker
+	<date-picker
 		v-bind="$attrs"
 		:minute-step="10"
 		:clearable="false"
-		v-on="$listeners" />
+		:value="value"
+		v-on="$listeners"
+		@update:value="$emit('update:value', value)" />
 </template>
 
 <script>
-import Datepicker from 'vue2-datepicker'
+import DatePicker from 'vue2-datepicker/lib/datepicker'
 
 /**
  * hijack the display function and avoid the
  * top and left original positionning
  */
-Datepicker.methods.displayPopup = function() {
+DatePicker.methods.displayPopup = function() {
 	const popupElmt = this.$el.querySelector('.mx-datepicker-popup')
 	if (popupElmt && !popupElmt.classList.contains('popovermenu')) {
 		popupElmt.className += ' popovermenu menu-center open'
@@ -46,9 +48,18 @@ export default {
 	name: 'DatetimePicker',
 
 	components: {
-		Datepicker
+		DatePicker
 	},
 
-	inheritAttrs: false
+	inheritAttrs: false,
+
+	props: {
+		// eslint-disable-next-line
+		value: {
+			default() {
+				return new Date()
+			}
+		}
+	}
 }
 </script>

--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -34,8 +34,17 @@
 import DatePicker from 'vue2-datepicker/lib/datepicker'
 
 /**
+ * remove leading zeros on hours and minutes
+ * https://github.com/mengxiong10/vue2-datepicker/blob/65c5762227649430f14158c01401a8486a881336/src/panel/time.js#L38
+ */
+DatePicker.components.CalendarPanel.components.PanelTime.methods.stringifyText = function(data) {
+	return data
+}
+
+/**
  * hijack the display function and avoid the
  * top and left original positionning
+ * https://github.com/mengxiong10/vue2-datepicker/blob/65c5762227649430f14158c01401a8486a881336/src/index.vue#L431
  */
 DatePicker.methods.displayPopup = function() {
 	const popupElmt = this.$el.querySelector('.mx-datepicker-popup')

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -1,62 +1,137 @@
 $opacity_disabled: .5;
 $opacity_normal: .7;
 $opacity_full: 1;
+$cell_height: 32px;
+$cell_height_big: 44px;
 
 
 .mx-datepicker[data-v-#{$scope_version}] {
 	width: 210px;
 	color: inherit;
-	font: inherit;
 	user-select: none;
+	position: relative;
+	display: inline-block;
+
+	&.disabled {
+		opacity: .7;
+		cursor: not-allowed;
+	}
+
+	/* INPUT CONTAINER */
+	.mx-input-wrapper {
+		// input
+		.mx-input {
+			width: 100%;
+		}
+		// reset and calendar icon
+		.mx-input-append {
+			position: absolute;
+			top: 0;
+			right: 0;
+			width: 30px;
+			height: 100%;
+			padding: 6px;
+			background-color: var(--color-main-background);
+			background-clip: content-box;
+			// generic style icon
+			.mx-input-icon {
+				display: inline-block;
+				font-style: normal;
+				text-align: center;
+				cursor: pointer;
+			}
+			// We forbid the cleareable option, so no need
+			// to style the reset icon: only hide it
+			.mx-clear-wrapper {
+				display: none;
+			}
+			.mx-calendar-icon {
+				stroke-width: 8px;
+				stroke: currentColor;
+				fill: currentColor;
+				width: 100%;
+				height: 100%;
+				color: var(--color-text-lighter);
+			}
+		}
+	}
 
 	.mx-datepicker-popup {
 		box-shadow: none;
+		background-color: var(--color-main-background);
+		position: absolute;
+		margin-top: 1px;
+		margin-bottom: 1px;
+		z-index: 1000;
 	}
 
-	// Range selectors
+	// MULTI CALENDAR DISPLAY FOR RANGE PICK
+	.mx-range-wrapper {
+		display: flex;
+		overflow: hidden;
+		.mx-calendar:first-child {
+			// override inline styling that separate the two calendars
+			box-shadow: var(--color-border) 1px 0px !important;
+		}
+		// first active cell
+		.mx-calendar-content .mx-panel .cell {
+			&.actived {
+				border-radius: var(--border-radius) 0 0 var(--border-radius);
+			}
+			// second selected cell
+			&.inrange + .cell.actived {
+				border-radius: 0 var(--border-radius) var(--border-radius) 0;
+			}
+		}
+	}
+	
+	// RANGE SELECTOR
 	.mx-shortcuts-wrapper {
+		display: flex;
+		justify-content: space-evenly;
+		padding: 5px;
+		border-bottom: 1px solid var(--color-border);
 		.mx-shortcuts {
 			font-weight: normal;
-			color: var(--color-text-lighter);
-			&:hover {
-				color: var(--color-text-light);
-			}
-			// divider
-			&:after {
-				color: var(--color-text-lighter);
-				opacity: $opacity_normal;
-			}
 		}
 	}
 
-	// Confirm button
-	.mx-datepicker-btn-confirm {
-		background-color: var(--color-primary-element);
-		color: var(--color-primary-text);
-		&:hover {
-			color: var(--color-primary-text);
-			border-color: var(--color-primary-element);
-		}
-	}
-
-	// global design rule
+	// GLOBAL CONTAINER
 	.mx-calendar {
 		font: inherit;
 		color: var(--color-main-text);
+		padding: 5px;
+		width: 240px;
 	}
 
-	// Headers: year, month and arrows
+	// HEADER: year, month and arrows
 	.mx-calendar-header {
+		padding: 0 4px;
+		margin-bottom: 4px;
+		text-align: center;
+		overflow: hidden;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		> a {
+			text-decoration: none;
+			cursor: pointer;
 			color: var(--color-text-lighter);
 			padding: 7px 10px;
-			border-radius: 30px;
-			height: 34px;
-			line-height: 22px;
-			min-width: 22px;
+			margin: 0 auto; // center also single element
+			border-radius: $cell_height;
+			height: $cell_height;
+			line-height: $cell_height - 12px; // padding minus 2px for better visual
+			min-width: $cell_height;
+			// Mouse feedback
+			&:hover,
+			&:focus {
+				opacity: 1;
+				color: var(--color-main-text);
+				background-color: var(--color-background-darker);
+			}
+
+			// Header arrows 
 			&.mx-icon-last-year,
 			&.mx-icon-last-month,
 			&.mx-icon-next-month,
@@ -84,88 +159,167 @@ $opacity_full: 1;
 				// send them to the end of the row
 				order: 4;
 			}
-			&:hover,
-			&:focus {
-				opacity: 1;
-				color: var(--color-main-text);
-				background-color: var(--color-background-darker);
-			}
 		}
 	}
 
+	// PANELS CONTAINER
 	.mx-calendar-content {
-		// regular cell style
-		.cell {
-			opacity: $opacity_normal;
-			border-radius: 50px;
-			transition: all 100ms ease-in-out;
-			// Selected and mouse event
-			&:hover,
-			&:focus,
-			&.actived {
-				font-weight: bold;
-				opacity: $opacity_full;
-				color: var(--color-primary-text);
-				background-color: var(--color-primary-element);
-			}
-			&.inrange {
-				background-color: transparent;
-			}
-			&.disabled {
-				color: var(--color-text-lighter);
-				background-color: var(--color-background-darker);
-				opacity: $opacity_disabled;
-				border-radius: 0;
-				font-weight: normal;
-			}	
-		}
-	}
 
-	.mx-panel-date {
-		// Rows: do not change on mouse event
-		tr:hover,
-		tr:focus,
-		tr:active {
-			background: none;
-		}
-		// Days of the week
-		th {
-			color: var(--color-text-lighter);
-			opacity: .5;
-		}
-		// Days number
-		td {
-			&.today {
-				color: var(--color-primary);
-				opacity: 1;
-				font-weight: bold;
-			}
-			&.last-month,
-			&.next-month {
-				color: var(--color-text-lighter);
-				opacity: $opacity_disabled;
-			}
-		}
-	}
+		// Various panels
+		.mx-panel {
+			width: 100%;
+			height: 100%;
+			text-align: center;
 
-	.mx-time-list {
-		padding: 5px;
-		li {
+			// regular cell style
+			.cell {
+				opacity: $opacity_normal;
+				border-radius: 50px;
+				transition: all 100ms ease-in-out;
+				cursor: pointer;
+				// Selected and mouse event
+				&:hover,
+				&:focus,
+				&.actived,
+				&.inrange  {
+					font-weight: bold;
+					opacity: $opacity_full;
+					color: var(--color-primary-text);
+					background-color: var(--color-primary-element);
+				}
+				&.inrange, 
+				&.disabled {
+					border-radius: 0;
+					font-weight: normal;
+				}	
+				&.inrange {
+					opacity: $opacity_normal;
+				}
+				&.disabled {
+					color: var(--color-text-lighter);
+					opacity: $opacity_disabled;
+					background-color: var(--color-background-darker);
+				}	
+			}
+			
+			// cell that are not in a table
+			span.cell,
+			li.cell {
+				height: $cell_height;
+			}
+		}
+
+		/* DATE SELECTOR */
+		.mx-panel-date {
+			table-layout: fixed;
+			border-collapse: collapse;
+			border-spacing: 0;
+			td, th {
+				font-size: 12px;
+				width: 32px;
+				height: 32px;
+				padding: 0;
+				overflow: hidden;
+				text-align: center;
+			}
+			// Days of the week
+			th {
+				color: var(--color-text-lighter);
+				opacity: .5;
+			}
+			// Days number
+			td {
+				&.today {
+					color: var(--color-primary);
+					opacity: 1;
+					font-weight: bold;
+				}
+				&.last-month,
+				&.next-month {
+					color: var(--color-text-lighter);
+					opacity: $opacity_disabled;
+				}
+			}
+			// Rows: do not change on mouse event
+			tr:hover,
+			tr:focus,
+			tr:active {
+				background: none;
+			}
+		}
+
+		// Global rules for year and month panel
+		.mx-panel-year,
+		.mx-panel-month {
 			display: flex;
-			justify-content: center;
-			margin-bottom: 1px;
+			flex-wrap: wrap;
+			justify-content: space-around;
+			span.cell  {
+				display: block;
+				padding: 5px;
+				height: $cell_height_big;
+				line-height: $cell_height_big - 8px; // padding + 2px for better visual
+				margin-bottom: 1%;
+			}
 		}
-		&::-webkit-scrollbar {
-			width: 5px;
-			height: 5px;
+
+		/* YEAR SELECTOR */
+		.mx-panel-year {
+			.cell {
+				width: 45%; // two rows
+				
+			}
 		}
-		&::-webkit-scrollbar-thumb {
-			background-color: var(--color-background-darker);
-			border-radius: var(--border-radius);
-			box-shadow: none;
+
+		/* MONTH SELECTOR */
+		.mx-panel-month {
+			.cell  {
+				width: 30%; // three rows
+			}
 		}
-		&:hover::-webkit-scrollbar-thumb {
-			background-color: var(--color-background-darker);
+
+		/* TIME SELECTOR */
+		.mx-panel-time {
+			display: flex;
+			.mx-time-list {
+				position: relative;
+				width: 100%;
+				height: 100%;
+				padding: 5px;
+				margin: 0;
+				list-style: none;
+				// border-top: 1px solid var(--color-border);
+				// border-left: 1px solid var(--color-border);
+				overflow-y: auto;
+				// half height so we can know there is a scrolling area
+				// minus mx-time-list padding and overall popover padding
+				max-height: 7.5 * $cell_height - 10px - 10px;
+				// TODO: find why we had this :D
+				.mx-time-picker-item {
+					display: block;
+					text-align: left;
+					padding-left: 10px;
+				}
+				.cell {
+					display: flex;
+					justify-content: center;
+					margin-bottom: 1px;
+					width: 100%;
+					font-size: 12px;
+					height: $cell_height;
+					line-height: $cell_height;
+				}
+			}
 		}
+	}
+
+	/* FOOTER if confirm option enabled*/
+	.mx-datepicker-footer {
+		padding: 4px;
+		clear: both;
+		text-align: right;
+		border-top: 1px solid var(--color-border);
+		// we don't style the confirm button
+		// leaving that to core
 	}
 }


### PR DESCRIPTION
I dropped the use of the distant design because we had some conflict and I hate having to override design. Building our own is far better.

What I did:
1. copied the original style
2. cleaned it up
3. integrated our previous changes to it
4. increased the sizes of the buttons
5. used flex for better visual and reactivity
6. removed old buttons style so we can use nextcloud default

I took the liberty to properly implement the range picker. Even if nowhere else we use it YET, I think it looks very nice now.

This is the first step so we can then check the dark theme (we had some conflict before)

@nextcloud/designers @nextcloud/vue Any requests?

| Before | After |
|:---------:|:------:|
|![peek 06-12-2018 19-01-old](https://user-images.githubusercontent.com/14975046/49603092-9119f280-f98a-11e8-8ff0-09fbd2100708.gif)|![peek 06-12-2018 19-01](https://user-images.githubusercontent.com/14975046/49603091-9119f280-f98a-11e8-8223-584b3314e598.gif)|
|![peek 06-12-2018 19-03](https://user-images.githubusercontent.com/14975046/49603093-9119f280-f98a-11e8-8f8a-0dbb3e51e3a6.gif)|![peek 06-12-2018 19-05-new](https://user-images.githubusercontent.com/14975046/49603094-91b28900-f98a-11e8-953d-24b9a2c115e0.gif)|
|![peek 06-12-2018 19-07-old](https://user-images.githubusercontent.com/14975046/49603096-91b28900-f98a-11e8-8890-698dddda74a5.gif)|![peek 06-12-2018 19-06](https://user-images.githubusercontent.com/14975046/49603095-91b28900-f98a-11e8-8fc4-d7a056ffbb57.gif)|
