### PR TITLE
Set `opened` on item when toggling a nav item

### DIFF
--- a/src/components/AppNavigation/AppNavigationItem.vue
+++ b/src/components/AppNavigation/AppNavigationItem.vue
@@ -154,6 +154,7 @@ export default {
 		},
 		toggleCollapse() {
 			this.opened = !this.opened
+			this.item.opened = this.opened
 		},
 		cancelEdit(e) {
 			// remove the editing class


### PR DESCRIPTION
Changes on the open state are currently not reflected on the item.