### PR TITLE
Add standardized app content component

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -1,0 +1,38 @@
+<!--
+ - @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ -
+ - @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<template>
+	<div id="content" :class="'app-' + appName">
+		<slot />
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		appName: {
+			type: String,
+			required: true
+		}
+	}
+}
+</script>

--- a/src/components/AppContent/index.js
+++ b/src/components/AppContent/index.js
@@ -1,7 +1,7 @@
-/**
- * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+/*
+ * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
- * @author John Molakvoæ <skjnldsv@protonmail.com>
+ * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -12,28 +12,13 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import AppContent from './AppContent'
-import AppNavigation from './AppNavigation'
-import PopoverMenu from './PopoverMenu'
-import DatetimePicker from './DatetimePicker'
-import Multiselect from './Multiselect'
-import Avatar from './Avatar'
-import Action from './Action'
 
-export {
-	AppContent,
-	AppNavigation,
-	PopoverMenu,
-	DatetimePicker,
-	Multiselect,
-	Avatar,
-	Action
-}
+export default AppContent
+export { AppContent }


### PR DESCRIPTION
This is a minimal implementation of our generic app content component, following https://docs.nextcloud.com/server/15/developer_manual/design/content.html.