### PR TITLE
toggleCollapse as default action for collapsible

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -34,8 +34,8 @@
 		<button v-if="collapsible" class="collapse" @click.prevent.stop="toggleCollapse" />
 
 		<!-- Is this a simple action ? -->
-		<a v-if="item.action" :class="item.icon" href="#"
-			@click.prevent.stop="item.action">
+		<a v-if="simpleAction" :class="item.icon" href="#"
+			@click.prevent.stop="simpleAction">
 			<img v-if="item.iconUrl" :alt="item.text" :src="item.iconUrl">
 			{{ item.text }}
 		</a>
@@ -134,6 +134,13 @@ export default {
 	computed: {
 		collapsible() {
 			return this.item.collapsible && this.item.children && this.item.children.length > 0
+		},
+		simpleAction() {
+			if (this.collapsible && !this.item.action) {
+				return this.toggleCollapse
+			} else {
+				return this.item.action
+			}
 		}
 	},
 	watch: {


### PR DESCRIPTION
This is on collapsible items in `AppNavigationItem`.

Currently, you can open a collapsible item by clicking on the triangle icon, only. With this PR, I'm introducing a default (simple) action which allows for toggling collapse state by clicking on the item's label, too. This action is only active, if there is no (other) action defined by the developer.