### PR TITLE
Fix action component breaking global tabbability

### DIFF
--- a/src/components/Action/Action.vue
+++ b/src/components/Action/Action.vue
@@ -28,7 +28,7 @@
 		v-on="isSingleAction && firstAction.action ? { click: firstAction.action } : {}">
 		<!-- If more than one action, create a popovermenu -->
 		<template v-if="!isSingleAction">
-			<div v-click-outside="closeMenu" tabindex="1" class="action-item__menutoggle icon-more"
+			<div v-click-outside="closeMenu" tabindex="0" class="action-item__menutoggle icon-more"
 				@click.prevent="toggleMenu" />
 			<div :class="{ 'open': opened }" class="action-item__menu popovermenu">
 				<popover-menu :menu="actions" />


### PR DESCRIPTION
`tabindex="1"` does not mean what you think. :wink: 

From https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex:

> - A negative value (usually `tabindex="-1"`) means that the element […] should not be reachable via sequential keyboard navigation. […]
> - `tabindex="0"` means that the element should be focusable in sequential keyboard navigation […]
> - It is not recommended to give positive values to your elements. You will end up jumping between them, and it will be confusing to manipulate between your element's tabindex attribute values. Instead, focus on writing them in a suitable DOM sequence.

So what you are looking for here is `tabindex="0"` instead. The current component resulted in any app (like the Mail app) breaking the tabbability in that it started with the first "icon-more" and you could never reach the navigation or anything else. (= huge regression ;)

Please review @nextcloud/accessibility @nextcloud/designers :slightly_smiling_face: 