### PR TITLE
custom actions for navigation item's primary icon

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -33,16 +33,12 @@
 
 		<button v-if="collapsible" class="collapse" @click.prevent.stop="toggleCollapse" />
 
-		<!-- Is this a simple action ? -->
-		<a v-if="simpleAction" :class="item.icon" href="#"
-			@click.prevent.stop="simpleAction">
-			<img v-if="item.iconUrl" :alt="item.text" :src="item.iconUrl">
-			{{ item.text }}
-		</a>
-
-		<!-- Main link -->
-		<a v-else :href="(item.href) ? item.href : '#' " :class="item.icon">
-			<img v-if="item.iconUrl" :alt="item.text" :src="item.iconUrl">
+		<a :class="item.icon" :href="(item.href) ? item.href : '#'"
+			@click="callPreventStop(simpleAction, $event)">
+			<img v-if="item.iconUrl || item.iconClass"
+				:src="item.iconUrl" :class="item.iconClass"
+				:title="item.iconTitle"
+				@click="callPreventStop(item.iconAction, $event)">
 			{{ item.text }}
 		</a>
 
@@ -161,6 +157,13 @@ export default {
 		},
 		toggleCollapse() {
 			this.opened = !this.opened
+		},
+		callPreventStop(action, event) {
+			if (action) {
+				event.preventDefault()
+				event.stopPropagation()
+				action()
+			}
 		},
 		cancelEdit(e) {
 			// remove the editing class


### PR DESCRIPTION
For the notes app, @jancborchardt suggested to put the star (favorite) on the left side of the navigation item (please see https://github.com/nextcloud/notes/issues/2). This is no problem to realize, because I can add an icon to a navigation item.

However, I would like to connect this icon with an action (toggle favorite) that differs from the main action behind the item's label (open note). Therefore I would like to extend the component `AppNavigationItem`.

I found the `<img>` inside the `AppNavigationItem` and extended it with some more properties in order to be suitable for my purposes. However, there may be other possibilities to realize this, e.g. extending the `<button>` which is used for the `collapse` icon, now (see https://github.com/nextcloud/nextcloud-vue/blob/icon-action/src/components/AppNavigationItem/AppNavigationItem.vue#L34). A disadvantage of using the button is that we need some more CSS in order to work. However, my current solution using the existing `<img>` has a quite small click area.

If you want to see how I'm using this, please have a look on https://github.com/nextcloud/notes/pull/290 and especially

https://github.com/nextcloud/notes/blob/1a84b2487c4a03fb1382614a16208db2eef9917e/src/App.vue#L200-L202

and

https://github.com/nextcloud/notes/blob/1a84b2487c4a03fb1382614a16208db2eef9917e/css/app-navigation.scss#L27-L45

Another improvement would be to group the `item.icon*` (e.g. `item.iconAction`) properties to `item.icon.*` (e.g. `item.icon.action`).

What do you think?