### PR TITLE
Add Tooltip directive

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -39,7 +39,7 @@
 
 /* global OC oc_userconfig */
 
-import { VTooltip } from 'v-tooltip'
+import Tooltip from 'Directives/Tooltip'
 import { PopoverMenu } from 'Components/PopoverMenu'
 import ClickOutside from 'vue-click-outside'
 import axios from 'nextcloud-axios'
@@ -48,7 +48,7 @@ import uidToColor from './uidToColor'
 export default {
 	name: 'Avatar',
 	directives: {
-		tooltip: VTooltip,
+		tooltip: Tooltip,
 		ClickOutside: ClickOutside
 	},
 	components: {

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -79,7 +79,7 @@
 
 <script>
 import VueMultiselect from 'vue-multiselect'
-import { VTooltip } from 'v-tooltip'
+import Tooltip from 'Directives/Tooltip'
 import AvatarSelectOption from './AvatarSelectOption'
 
 export default {
@@ -89,7 +89,7 @@ export default {
 		AvatarSelectOption
 	},
 	directives: {
-		tooltip: VTooltip
+		tooltip: Tooltip
 	},
 	inheritAttrs: false,
 	/**

--- a/src/directives/Tooltip/index.js
+++ b/src/directives/Tooltip/index.js
@@ -1,0 +1,6 @@
+import { VTooltip } from 'v-tooltip'
+import './index.scss'
+
+VTooltip.options.defaultClass = `v-${SCOPE_VERSION}`
+
+export default VTooltip

--- a/src/directives/Tooltip/index.scss
+++ b/src/directives/Tooltip/index.scss
@@ -1,0 +1,138 @@
+/**
+* @copyright Copyright (c) 2016, John Molakvoæ <skjnldsv@protonmail.com>
+* @copyright Copyright (c) 2016, Robin Appelman <robin@icewind.nl>
+* @copyright Copyright (c) 2016, Jan-Christoph Borchardt <hey@jancborchardt.net>
+* @copyright Copyright (c) 2016, Erik Pellikka <erik@pellikka.org>
+* @copyright Copyright (c) 2015, Vincent Petry <pvince81@owncloud.com>
+*
+* Bootstrap v3.3.5 (http://getbootstrap.com)
+* Copyright 2011-2015 Twitter, Inc.
+* Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+*/
+
+.v-#{$scope_version}.tooltip {
+	position: absolute;
+	display: block;
+	font-family: 'Nunito', 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
+	font-style: normal;
+	font-weight: normal;
+	letter-spacing: normal;
+	line-break: auto;
+	line-height: 1.6;
+	text-align: left;
+	text-align: start;
+	text-decoration: none;
+	text-shadow: none;
+	text-transform: none;
+	white-space: normal;
+	word-break: normal;
+	word-spacing: normal;
+	word-wrap: normal;
+	font-size: 12px;
+	opacity: 0;
+	z-index: 100000;
+	/* default to top */
+	margin-top: -3px;
+	padding: 10px 0;
+	filter: drop-shadow(0 1px 10px var(--color-box-shadow));
+	&.in,
+	&.tooltip[aria-hidden='false'] {
+		visibility: visible;
+		opacity: 1;
+		transition: opacity .15s;
+	}
+	&.top .tooltip-arrow,
+	&[x-placement^='top'] {
+		left: 50%;
+		margin-left: -10px;
+	}
+	&.bottom,
+	&[x-placement^='bottom'] {
+		margin-top: 3px;
+		padding: 10px 0;
+	}
+	&.right,
+	&[x-placement^='right'] {
+		margin-left: 3px;
+		padding: 0 10px;
+		.tooltip-arrow {
+			top: 50%;
+			left: 0;
+			margin-top: -10px;
+			border-width: 10px 10px 10px 0;
+			border-right-color: var(--color-main-background);
+		}
+	}
+	&.left,
+	&[x-placement^='left'] {
+		margin-left: -3px;
+		padding: 0 5px;
+		.tooltip-arrow {
+			top: 50%;
+			right: 0;
+			margin-top: -10px;
+			border-width: 10px 0 10px 10px;
+			border-left-color: var(--color-main-background);
+		}
+	}
+	/* TOP */
+	&.top,
+	&.top-left,
+	&[x-placement^='top'],
+	&.top-right {
+		.tooltip-arrow {
+			bottom: 0;
+			border-width: 10px 10px 0;
+			border-top-color: var(--color-main-background);
+		}
+	}
+	&.top-left .tooltip-arrow {
+		right: 10px;
+		margin-bottom: -10px;
+	}
+	&.top-right .tooltip-arrow {
+		left: 10px;
+		margin-bottom: -10px;
+	}
+	/* BOTTOM */
+	&.bottom,
+	&[x-placement^='bottom'],
+	&.bottom-left,
+	&.bottom-right {
+		.tooltip-arrow {
+			top: 0;
+			border-width: 0 10px 10px;
+			border-bottom-color: var(--color-main-background);
+		}
+	}
+	&[x-placement^='bottom'] .tooltip-arrow,
+	&.bottom .tooltip-arrow {
+		left: 50%;
+		margin-left: -10px;
+	}
+	&.bottom-left .tooltip-arrow {
+		right: 10px;
+		margin-top: -10px;
+	}
+	&.bottom-right .tooltip-arrow {
+		left: 10px;
+		margin-top: -10px;
+	}
+}
+
+.v-#{$scope_version}.tooltip-inner {
+	max-width: 350px;
+	padding: 5px 8px;
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
+	text-align: center;
+	border-radius: var(--border-radius);
+}
+
+.v-#{$scope_version}.tooltip-arrow {
+	position: absolute;
+	width: 0;
+	height: 0;
+	border-color: transparent;
+	border-style: solid;
+}

--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -19,21 +19,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import * as NcComponents from './components'
 
-function install(Vue) {
-	Object.values(NcComponents).forEach((component) => {
-		Vue.component(component.name, component)
-	})
-}
+import Tooltip from './Tooltip'
 
-if (typeof window !== 'undefined' && window.Vue) {
-	install(window.Vue)
+export {
+	Tooltip
 }
-
-export default {
-	install,
-	...NcComponents
-}
-export * from './components'
-export * from './directives'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -94,6 +94,7 @@ module.exports = {
 	resolve: {
 		alias: {
 			Components: path.resolve(__dirname, 'src/components/'),
+			Directives: path.resolve(__dirname, 'src/directives/'),
 			Utils: path.resolve(__dirname, 'src/utils/'),
 			Fonts: path.resolve(__dirname, 'src/fonts/')
 		},


### PR DESCRIPTION
Implements #248 

This allows apps to use the tooltip directive included in the nextcloud-vue bundle without needing to add another v-tooltip to their bundle. 