### PR TITLE
Build separate entrypoints for each component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ stylelint-fix:
 
 # Cleaning
 clean:
-	rm -f dist/ncvuecomponents.js
-	rm -f dist/ncvuecomponents.js.map
+	rm -rf dist/
 
 clean-dev:
 	rm -rf node_modules

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"dev": "webpack --config webpack.dev.js",
 		"watch": "webpack --progress --watch --config webpack.dev.js",
-		"build": "webpack --progress --hide-modules --config webpack.prod.js",
+		"build": "NODE_ENV=production webpack --progress --hide-modules --config webpack.prod.js",
 		"lint": "eslint --ext .js,.vue src",
 		"lint:fix": "eslint --ext .js,.vue src --fix",
 		"stylelint": "stylelint src",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,17 +47,7 @@ module.exports = {
 		library: ['NextcloudVue', '[name]'],
 		umdNamedDefine: true
 	},
-	optimization: {
-		     splitChunks: {
-			   cacheGroups: {
-				vendor: {
-					test: /node_modules/,
-					chunks: "all",
-					filename: 'vendor[id].js',
-				}
-			  }
-		     }
-		},
+	
 	externals: {
 		vue: {
 			commonjs: 'vue',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const glob = require('glob')
 const { VueLoaderPlugin } = require('vue-loader')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
 
@@ -12,32 +13,19 @@ const md5 = require('md5')
 const PACKAGE = require('./package.json')
 const SCOPE_VERSION = JSON.stringify(md5(PACKAGE.version).substr(0, 7))
 
-function getComponents() {
-	const NcComponents = [
-		'Action', 'AppContent', 'AppNavigationItem', 'AppNavigationNew', 'AppNavigationSettings', 'Avatar', 'DatetimePicker', 'Modal', 'Multiselect', 'PopoverMenu'
-	];
-	let entries = {};
-	Object.values(NcComponents).forEach((component) => {
-		entries['Components/' + component] = path.join(__dirname, 'src', `components/${component}/index.js`)
-	})
-	return entries;
-}
-function getDirectives() {
-	const NcDirectives = [
-		'Tooltip'
-	];
-	let entries = {};
-	Object.values(NcDirectives).forEach((component) => {
-		entries['Directives/' + component] = path.join(__dirname, 'src', `directives/${component}/index.js`)
-	})
-	return entries;
-}
-
 module.exports = {
 	entry: {
 		ncvuecomponents: path.join(__dirname, 'src', 'index.js'),
-		...getComponents(),
-		...getDirectives()
+		...glob.sync('src/components/*/index.js').reduce((acc, item) => {
+			const name = item.replace('/index.js', '').replace('src/components/', 'Components/');
+			acc[name] = path.join(__dirname, item);
+			return acc;
+		}, {}),
+		...glob.sync('src/directives/*/index.js').reduce((acc, item) => {
+			const name = item.replace('/index.js', '').replace('src/directives/', 'Directives/');
+			acc[name] = path.join(__dirname, item);
+			return acc;
+		}, {}),
 	},
 	output: {
 		path: path.resolve(__dirname, './dist'),
@@ -47,7 +35,6 @@ module.exports = {
 		library: ['NextcloudVue', '[name]'],
 		umdNamedDefine: true
 	},
-	
 	externals: {
 		vue: {
 			commonjs: 'vue',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,16 +12,52 @@ const md5 = require('md5')
 const PACKAGE = require('./package.json')
 const SCOPE_VERSION = JSON.stringify(md5(PACKAGE.version).substr(0, 7))
 
+function getComponents() {
+	const NcComponents = [
+		'Action', 'AppContent', 'AppNavigationItem', 'AppNavigationNew', 'AppNavigationSettings', 'Avatar', 'DatetimePicker', 'Modal', 'Multiselect', 'PopoverMenu'
+	];
+	let entries = {};
+	Object.values(NcComponents).forEach((component) => {
+		entries['Components/' + component] = path.join(__dirname, 'src', `components/${component}/index.js`)
+	})
+	return entries;
+}
+function getDirectives() {
+	const NcDirectives = [
+		'Tooltip'
+	];
+	let entries = {};
+	Object.values(NcDirectives).forEach((component) => {
+		entries['Directives/' + component] = path.join(__dirname, 'src', `directives/${component}/index.js`)
+	})
+	return entries;
+}
+
 module.exports = {
-	entry: path.join(__dirname, 'src', 'index.js'),
+	entry: {
+		ncvuecomponents: path.join(__dirname, 'src', 'index.js'),
+		...getComponents(),
+		...getDirectives()
+	},
 	output: {
 		path: path.resolve(__dirname, './dist'),
 		publicPath: '/dist/',
-		filename: 'ncvuecomponents.js',
+		filename: '[name].js',
 		libraryTarget: 'umd',
-		library: 'NextcloudVue',
+		library: ['NextcloudVue', '[name]'],
 		umdNamedDefine: true
 	},
+	optimization: {
+		     splitChunks: {
+			   cacheGroups: {
+				vendor: {
+					test: /node_modules/,
+					chunks: "all",
+					filename: 'vendor[id].js',
+				}
+			  }
+		     }
+		},
 	externals: {
 		vue: {
 			commonjs: 'vue',


### PR DESCRIPTION
With this components can be imported individually and webpack can take care of just including the required code parts. 

```
import Avatar from 'nextcloud-vue/dist/Components/Avatar'
import Tooltip from 'nextcloud-vue/dist/Directives/Tooltip'
```


Unfortunately I'm not sure how compatible this is when an app doesn't use webpack, still needs some testing.

I had to remove the chunking since it didn't work properly when including it in another webpack bundle of an app, but with the current state, webpack seems to be able to deduplicate some parts of the code, even if both the full bundle and indivudal components are included at the same time.