### PR TITLE
Add a two-way prop 'open' to the action component

### DIFF
--- a/src/components/Action/Action.vue
+++ b/src/components/Action/Action.vue
@@ -69,11 +69,15 @@ export default {
 					}
 				]
 			}
+		},
+		open: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {
 		return {
-			opened: false
+			opened: this.open
 		}
 	},
 	computed: {
@@ -84,6 +88,11 @@ export default {
 			return this.actions[0]
 		}
 	},
+	watch: {
+		open(newVal) {
+			this.opened = newVal
+		}
+	},
 	mounted() {
 		// prevent click outside event with popupItem.
 		this.popupItem = this.$el
@@ -91,9 +100,11 @@ export default {
 	methods: {
 		toggleMenu() {
 			this.opened = !this.opened
+			this.$emit('update:open', this.opened)
 		},
 		closeMenu() {
 			this.opened = false
+			this.$emit('update:open', this.opened)
 		},
 		mainActionElement() {
 			return {


### PR DESCRIPTION
Required for https://github.com/nextcloud/server/pull/14392.

This makes it possible to open/close the menu from the outside while also staying in sync with the internal state. This also still works without the property, just like it did before.

Usage:

```html
<Action v-if="!token.current"
    :actions="actions"
    v-bind:open.sync="actionOpen">
```

@skjnldsv as discussed :)