### PR TITLE
Do not hide on touchmove and click too

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -22,7 +22,8 @@
 
 <template>
 	<transition name="fade">
-		<div id="modal-mask" ref="mask" @mousemove="handleMouseMove">
+		<div id="modal-mask" ref="mask" @click="handleMouseMove"
+			@mousemove="handleMouseMove" @touchmove="handleMouseMove">
 			<!-- Header -->
 			<transition name="fade">
 				<div v-if="!clearView" id="modal-header">


### PR DESCRIPTION
When clicking the next/prev buttons without moving the mouse, the event was not caught and therefore the ui was fading away despite having the user clicking the screen.