### PR TITLE
Make the app navigation (slot) a real component and add a spacer

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -1,5 +1,5 @@
 <!--
- - @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ - @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  -
  - @author Christoph Wurst <christoph@winzerhof-wurst.at>
  -
@@ -19,31 +19,17 @@
  - along with this program. If not, see <http://www.gnu.org/licenses/>.
  -
  -->
-
 <template>
-	<div id="content" :class="'app-' + appName">
-		<slot name="navigation" />
-		<div v-if="$slots['content'] !== undefined"
-			id="app-content"
-			:class="contentClass">
-			<slot name="content" />
-		</div>
+	<div id="app-navigation" :class="navigationClass">
 		<slot />
-		<div v-if="$slots['sidebar'] !== undefined"
-			id="app-sidebar">
-			<slot name="sidebar" />
-		</div>
 	</div>
 </template>
 
 <script>
 export default {
+	name: 'AppNavigation',
 	props: {
-		appName: {
-			type: String,
-			required: true
-		},
-		contentClass: {
+		navigationClass: {
 			type: [String, Array, Object],
 			required: false,
 			default: ''

--- a/src/components/AppNavigation/index.js
+++ b/src/components/AppNavigation/index.js
@@ -1,0 +1,24 @@
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import AppNavigation from './AppNavigation'
+
+export default AppNavigation
+export { AppNavigation }

--- a/src/components/AppNavigationSpacer/AppNavigationSpacer.vue
+++ b/src/components/AppNavigationSpacer/AppNavigationSpacer.vue
@@ -1,5 +1,5 @@
 <!--
- - @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ - @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  -
  - @author Christoph Wurst <christoph@winzerhof-wurst.at>
  -
@@ -19,35 +19,18 @@
  - along with this program. If not, see <http://www.gnu.org/licenses/>.
  -
  -->
-
 <template>
-	<div id="content" :class="'app-' + appName">
-		<slot name="navigation" />
-		<div v-if="$slots['content'] !== undefined"
-			id="app-content"
-			:class="contentClass">
-			<slot name="content" />
-		</div>
-		<slot />
-		<div v-if="$slots['sidebar'] !== undefined"
-			id="app-sidebar">
-			<slot name="sidebar" />
-		</div>
-	</div>
+	<li />
 </template>
 
 <script>
 export default {
-	props: {
-		appName: {
-			type: String,
-			required: true
-		},
-		contentClass: {
-			type: [String, Array, Object],
-			required: false,
-			default: ''
-		}
-	}
+	name: 'AppNavigationSpacer'
 }
 </script>
+
+<style scoped>
+	li {
+		height: 22px;
+	}
+</style>

--- a/src/components/AppNavigationSpacer/AppNavigationSpacer.vue
+++ b/src/components/AppNavigationSpacer/AppNavigationSpacer.vue
@@ -20,7 +20,7 @@
  -
  -->
 <template>
-	<li />
+	<li class="app-navigation-spacer" />
 </template>
 
 <script>
@@ -30,7 +30,7 @@ export default {
 </script>
 
 <style scoped>
-	li {
+	.app-navigation-spacer {
 		height: 22px;
 	}
 </style>

--- a/src/components/AppNavigationSpacer/index.js
+++ b/src/components/AppNavigationSpacer/index.js
@@ -1,0 +1,24 @@
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import AppNavigationSpacer from './AppNavigationSpacer'
+
+export default AppNavigationSpacer
+export { AppNavigationSpacer }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,9 +22,11 @@
 
 import Action from './Action'
 import AppContent from './AppContent'
+import AppNavigation from './AppNavigation'
 import AppNavigationItem from './AppNavigationItem'
 import AppNavigationNew from './AppNavigationNew'
 import AppNavigationSettings from './AppNavigationSettings'
+import AppNavigationSpacer from './AppNavigationSpacer'
 import Avatar from './Avatar'
 import DatetimePicker from './DatetimePicker'
 import Modal from './Modal'
@@ -34,9 +36,11 @@ import PopoverMenu from './PopoverMenu'
 export {
 	Action,
 	AppContent,
+	AppNavigation,
 	AppNavigationItem,
 	AppNavigationNew,
 	AppNavigationSettings,
+	AppNavigationSpacer,
 	Avatar,
 	DatetimePicker,
 	Modal,


### PR DESCRIPTION
This makes it a lot easier for apps to create their own reusable navigation component.

Without this change, using an own component to make the navigation slot contents reusable resulted in an extra element wrapping the contents. This can easily break the design. I think the clean version is to just have a dedicated component as we have for many other things now.