### PR TITLE
Prevent modal to go over the title

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -408,6 +408,9 @@ export default {
 	justify-content: center;
 	height: 100%;
 	width: 100%;
+	// do not go over the header
+	padding-top: 50px;
+	box-sizing: border-box;
 	#modal-container {
 		max-width: 900px;
 		max-height: 80%;


### PR DESCRIPTION
I'm not sure about this, it seems a good thing to do to avoid the content to go over the header content, but in the end i might look a bit shifted to the bottom. Any thoughts?

![capture d ecran_2019-03-06_11-57-56](https://user-images.githubusercontent.com/14975046/53876755-c83e8500-4007-11e9-9a6b-f87da9311b05.png)
