### PR TITLE
remove obsolete prop 'navigationClass'

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -20,20 +20,13 @@
  -
  -->
 <template>
-	<div id="app-navigation" :class="navigationClass">
+	<div id="app-navigation">
 		<slot />
 	</div>
 </template>
 
 <script>
 export default {
-	name: 'AppNavigation',
-	props: {
-		navigationClass: {
-			type: [String, Array, Object],
-			required: false,
-			default: ''
-		}
-	}
+	name: 'AppNavigation'
 }
 </script>


### PR DESCRIPTION
Component: `AppNavigation`

The property `navigationClass` is not needed anymore due to moving the app navigation element to it's own component. You can use `:class`, directly:

```
<app-navigation :class="{loading: loading}"> ... </app-navigation>
```

see https://github.com/nextcloud/nextcloud-vue/pull/290#discussion_r263565344