### PR TITLE
AppNavigationItem: remove duplicate code

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -33,15 +33,8 @@
 
 		<button v-if="collapsible" class="collapse" @click.prevent.stop="toggleCollapse" />
 
-		<!-- Is this a simple action ? -->
-		<a v-if="simpleAction" :class="item.icon" href="#"
-			@click.prevent.stop="simpleAction">
-			<img v-if="item.iconUrl" :alt="item.text" :src="item.iconUrl">
-			{{ item.text }}
-		</a>
-
-		<!-- Main link -->
-		<a v-else :href="(item.href) ? item.href : '#' " :class="item.icon">
+		<a :class="item.icon" :href="(item.href) ? item.href : '#'"
+			@click="callPreventStop(simpleAction, $event)">
 			<img v-if="item.iconUrl" :alt="item.text" :src="item.iconUrl">
 			{{ item.text }}
 		</a>
@@ -161,6 +154,13 @@ export default {
 		},
 		toggleCollapse() {
 			this.opened = !this.opened
+		},
+		callPreventStop(action, event) {
+			if (action) {
+				event.preventDefault()
+				event.stopPropagation()
+				action()
+			}
 		},
 		cancelEdit(e) {
 			// remove the editing class


### PR DESCRIPTION
Supports both `action` and `href` in the same code snippet. However, this required a new JS-helper-method `callPreventStop` which stops the links to be processed if there is an action given.

This was done in the context of #246, which is now obsolete.