### PR TITLE
Rework the modal sizes and layout

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -58,7 +58,13 @@
 
 			<!-- Content wrapper -->
 			<transition :name="modalTransitionName">
-				<div v-show="showModal" :class="`modal-wrapper--${size}`" class="modal-wrapper"
+				<div
+					v-show="showModal"
+					:class="[
+						`modal-wrapper--${size}`,
+						spreadNavigation ? 'modal-wrapper--spread-navigation' : ''
+					]"
+					class="modal-wrapper"
 					@click.self="close">
 					<!-- Navigation button -->
 					<transition name="fade-visibility">
@@ -147,6 +153,10 @@ export default {
 		enableSwipe: {
 			type: Boolean,
 			default: true
+		},
+		spreadNavigation: {
+			type: Boolean,
+			default: false
 		},
 		size: {
 			type: String,
@@ -334,7 +344,7 @@ export default {
 			height: 50px;
 			width: 50px;
 			box-sizing: border-box;
-			padding: 16px 14px;
+			padding: 15px 14px;
 			font-size: 24px;
 			color: #fff;
 			background-image: none;
@@ -452,6 +462,9 @@ export default {
 			max-height: 100%;
 			border-radius: 0;
 		}
+	}
+	&--full,
+	&--spread-navigation {
 		.prev,
 		.next {
 			position: absolute;

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -56,11 +56,16 @@
 				</div>
 			</transition>
 
-			<!-- Navigation buttons -->
-			<transition name="fade">
-				<div v-if="!clearView" :class="`modal-navigation--${size}`" class="modal-navigation">
-					<transition name="fade">
-						<a v-if="hasPrevious" class="prev" @click="previous">
+			<!-- Content wrapper -->
+			<transition :name="modalTransitionName">
+				<div v-show="showModal" :class="`modal-wrapper--${size}`" class="modal-wrapper"
+					@click.self="close">
+					<!-- Navigation button -->
+					<transition name="fade-visibility">
+						<a v-show="hasPrevious && !clearView" class="prev" :class="{
+								invisible: clearView || !hasPrevious
+							}"
+							@click="previous">
 							<div class="icon icon-previous">
 								<span class="hidden-visually">
 									{{ t('core', 'Previous') }}
@@ -68,8 +73,18 @@
 							</div>
 						</a>
 					</transition>
-					<transition name="fade">
-						<a v-if="hasNext" class="next" @click="next">
+
+					<!-- Content -->
+					<div class="modal-container">
+						<slot />
+					</div>
+
+					<!-- Navigation button -->
+					<transition name="fade-visibility">
+						<a v-show="hasNext && !clearView" class="next" :class="{
+								invisible: clearView || !hasNext
+							}"
+							@click="next">
 							<div class="icon icon-next">
 								<span class="hidden-visually">
 									{{ t('core', 'Next') }}
@@ -77,16 +92,6 @@
 							</div>
 						</a>
 					</transition>
-				</div>
-			</transition>
-
-			<!-- Content -->
-			<transition :name="modalTransitionName">
-				<div v-show="showModal" :class="`modal-wrapper--${size}`" class="modal-wrapper"
-					@click.self="close">
-					<div class="modal-container">
-						<slot />
-					</div>
 				</div>
 			</transition>
 		</div>
@@ -130,6 +135,10 @@ export default {
 		enableSlideshow: {
 			type: Boolean,
 			default: false
+		},
+		clearViewDelay: {
+			type: Number,
+			default: 5000
 		},
 		slideshowDelay: {
 			type: Number,
@@ -241,11 +250,13 @@ export default {
 			}
 		},
 		handleMouseMove() {
-			this.clearView = false
-			clearTimeout(this.clearViewTimeout)
-			this.clearViewTimeout = setTimeout(() => {
-				this.clearView = true
-			}, 5000)
+			if (this.clearViewDelay > 0) {
+				this.clearView = false
+				clearTimeout(this.clearViewTimeout)
+				this.clearViewTimeout = setTimeout(() => {
+					this.clearView = true
+				}, this.clearViewDelay)
+			}
 		},
 		handleSlideshow() {
 			this.playing = true
@@ -275,62 +286,6 @@ export default {
 	height: 100%;
 	background-color: rgba(0, 0, 0, .92);
 	display: block;
-}
-
-/* Navigation buttons */
-.modal-navigation {
-	.prev,
-	.next {
-		position: absolute;
-		top: 0;
-		z-index: 10000;
-		width: 15%;
-		min-width: 60px;
-		height: 100%;
-		display: block;
-	}
-	.prev {
-		left: 0;
-	}
-	.next {
-		right: 0;
-	}
-
-	&.modal-navigation--full,
-	&.modal-navigation--large {
-		.prev,
-		.next {
-			width: 10%;
-		}
-	}
-
-	// buttons/icons
-	.icon-next,
-	.icon-previous {
-		background-image: none;
-		font-size: 24px;
-		padding: 12px 11px;
-		box-sizing: border-box;
-		color: white;
-		width: 44px;
-		height: 44px;
-		border-radius: 50%;
-		top: 50%;
-		position: absolute;
-		margin: auto;
-	}
-	.icon-previous {
-		@include iconfont('arrow-left');
-		// center horizontally
-		left: 25%;
-		margin-left: -22px;
-	}
-	.icon-next {
-		@include iconfont('arrow-right');
-		// center horizontally
-		right: 25%;
-		margin-right: -22px;
-	}
 }
 
 .modal-header {
@@ -431,21 +386,52 @@ export default {
 	height: 100%;
 	width: 100%;
 	box-sizing: border-box;
-	&--full {
-		.modal-container {
-			max-width: 100%;
-			max-height: 100%;
-			border-radius: 0;
+
+	/* Navigation buttons */
+	.prev,
+	.next {
+		z-index: 10000;
+		width: 15%;
+		min-width: 60px;
+		height: 100%;
+		// ignore display: none
+		display: flex !important;
+		align-items: center;
+		justify-content: center;
+		transition: opacity 250ms,
+			visibility 250ms;
+
+		// we want to keep the elements on page
+		// even if hidden to avoid having a unbalanced
+		// centered content
+		// replace display by visibility
+		&.invisible[style*='display:none'],
+		&.invisible[style*='display: none'] {
+			visibility: hidden;
 		}
 	}
-	&--large {
-		.modal-container {
-			max-width: 70%;
-			max-height: 90%;
-		}
+
+	// buttons/icons
+	.icon-next,
+	.icon-previous {
+		background-image: none;
+		font-size: 24px;
+		padding: 12px 11px;
+		box-sizing: border-box;
+		color: white;
+		width: 44px;
+		height: 44px;
+		border-radius: 50%;
 	}
+	.icon-previous {
+		@include iconfont('arrow-left');
+	}
+	.icon-next {
+		@include iconfont('arrow-right');
+	}
+
+	/* Content */
 	.modal-container {
-		margin: 0 auto;
 		padding: 0;
 		background-color: var(--color-main-background);
 		border-radius: var(--border-radius-large);
@@ -454,9 +440,39 @@ export default {
 		transition: transform 300ms ease;
 		display: block;
 	}
-	&:not(&--large):not(&--full).modal-container {
+	&:not(&--large):not(&--full) .modal-container {
 		max-width: 900px;
 		max-height: 80%;
+	}
+
+	// Sizing
+	&--full {
+		.modal-container {
+			max-width: 100%;
+			max-height: 100%;
+			border-radius: 0;
+		}
+		.prev,
+		.next {
+			position: absolute;
+			width: 10%;
+		}
+		.prev {
+			left: 0;
+		}
+		.next {
+			right: 0;
+		}
+	}
+	&--large {
+		.modal-container {
+			max-width: 70%;
+			max-height: 90%;
+		}
+		.prev,
+		.next {
+			width: 10%;
+		}
 	}
 }
 


### PR DESCRIPTION
- Put the arrows to flex next to the container so we can have an adaptive positioning
- Reworked the layout of the `full` size so that the arrows are absolute and over the container

Layouts:

| Normal | ![Capture d’écran_2019-03-20_10-33-10](https://user-images.githubusercontent.com/14975046/54674039-df976b00-4afb-11e9-97a7-13d6e5491f33.png) |
|:---------:|:------:|
| Large | ![Capture d’écran_2019-03-20_10-34-08](https://user-images.githubusercontent.com/14975046/54674041-df976b00-4afb-11e9-9adb-b1d3d2880881.png) |
| Full (mobile mode) | ![Capture d’écran_2019-03-20_10-34-55](https://user-images.githubusercontent.com/14975046/54674043-df976b00-4afb-11e9-9efa-79f1595e4337.png) |

