### PR TITLE
AppNavigationItem: sync property for menu's open state

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -57,7 +57,7 @@
 				<!-- menu button if at least two actions -->
 				<li v-else-if="item.utils.actions && item.utils.actions.length > 1"
 					class="app-navigation-entry-utils-menu-button">
-					<button v-click-outside="hideMenu" @click="openedMenu = !openedMenu" />
+					<button v-click-outside="hideMenu" @click="toggleMenu" />
 				</li>
 			</ul>
 		</div>
@@ -109,11 +109,15 @@ export default {
 		item: {
 			type: Object,
 			required: true
+		},
+		menuOpen: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {
 		return {
-			openedMenu: false,
+			openedMenu: this.menuOpen,
 			opened: !!this.item.opened
 		}
 	},
@@ -132,6 +136,9 @@ export default {
 	watch: {
 		item(oldItem, newItem) {
 			this.opened = !!newItem.opened
+		},
+		menuOpen(newVal) {
+			this.openedMenu = newVal
 		}
 	},
 	mounted() {
@@ -141,6 +148,11 @@ export default {
 	methods: {
 		hideMenu() {
 			this.openedMenu = false
+			this.$emit('update:menu-open', this.openedMenu)
+		},
+		toggleMenu() {
+			this.openedMenu = !this.openedMenu
+			this.$emit('update:menu-open', this.openedMenu)
 		},
 		toggleCollapse() {
 			this.opened = !this.opened

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -148,11 +148,11 @@ export default {
 	methods: {
 		hideMenu() {
 			this.openedMenu = false
-			this.$emit('update:menu-open', this.openedMenu)
+			this.$emit('update:menuOpen', this.openedMenu)
 		},
 		toggleMenu() {
 			this.openedMenu = !this.openedMenu
-			this.$emit('update:menu-open', this.openedMenu)
+			this.$emit('update:menuOpen', this.openedMenu)
 		},
 		toggleCollapse() {
 			this.opened = !this.opened


### PR DESCRIPTION
Implements the idea of #278 for the component AppNavigationItem.

Example usage: https://github.com/nextcloud/notes/pull/290/commits/d4b7c439d01e5a66d11b7129d954369500f08de1

Closes #309.