### PR TITLE
Force all modals to mount in body

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -196,6 +196,7 @@ export default {
 	},
 	mounted() {
 		this.showModal = true
+
 		// init clear view
 		this.handleMouseMove()
 
@@ -203,6 +204,9 @@ export default {
 		this.mc.on('swipeleft swiperight', e => {
 			this.handleSwipe(e)
 		})
+
+		// force mount the component to body
+		document.body.insertBefore(this.$el, document.body.lastChild)
 	},
 	unmounted() {
 		this.mc.off('swipeleft swiperight')


### PR DESCRIPTION
That way, if any app uses it into a child element that is within #app-content, it will still be displayed above all the UI like any other modal! :grin: 
:tada: 