### PR TITLE
AppNavigationSettings: remove obsolete code; fix jiggle

### DIFF
--- a/src/components/AppNavigationSettings/AppNavigationSettings.vue
+++ b/src/components/AppNavigationSettings/AppNavigationSettings.vue
@@ -21,13 +21,10 @@
  -->
 
 <template>
-	<div id="app-settings"
-		v-click-outside="closeMenu"
-		:class="{open}">
+	<div id="app-settings">
 		<div id="app-settings-header">
 			<button class="settings-button"
-				data-apps-slide-toggle="#app-settings-content"
-				@click="toggleMenu">
+				data-apps-slide-toggle="#app-settings-content">
 				{{ title }}
 			</button>
 		</div>
@@ -38,31 +35,13 @@
 </template>
 
 <script>
-import ClickOutside from 'vue-click-outside'
-
 export default {
-	directives: {
-		ClickOutside
-	},
 	props: {
 		title: {
 			type: String,
 			required: false,
 			// TODO: translate
 			default: t('core', 'Settings')
-		}
-	},
-	data() {
-		return {
-			open: false
-		}
-	},
-	methods: {
-		toggleMenu() {
-			this.open = !this.open
-		},
-		closeMenu() {
-			this.open = false
 		}
 	}
 }


### PR DESCRIPTION
I found a strange behavior when using the component `AppNavigationSettings`: When I click the first time on "Settings", the settings-details opens, but immediately closes again.  Clicking the next time, it works as expected.

Then, I tried to debug the code of this component and found a strange use of the boolean variable `open`: `:class="{open}"`. For me, this doesn't make any sense. So I removed it, and now the bug has disappeared.

But moreover, I found that the local variable `open` is not used anymore in this component, so it can be removed completely (handling open/close is done in nextcloud/server by `registerAppsSlideToggle`).

This looks like a big change, so please review this carefully. Maybe, I've overseen something.