### PR TITLE
Add a component for #app-content

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -1,5 +1,5 @@
 <!--
- - @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ - @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  -
  - @author Christoph Wurst <christoph@winzerhof-wurst.at>
  -
@@ -21,24 +21,11 @@
  -->
 
 <template>
-	<div id="content" :class="'app-' + appName">
-		<slot name="navigation" />
-		<slot name="content" />
+	<div id="app-content">
 		<slot />
-		<div v-if="$slots['sidebar'] !== undefined"
-			id="app-sidebar">
-			<slot name="sidebar" />
-		</div>
 	</div>
 </template>
 
 <script>
-export default {
-	props: {
-		appName: {
-			type: String,
-			required: true
-		}
-	}
-}
+export default {}
 </script>

--- a/src/components/AppContent/index.js
+++ b/src/components/AppContent/index.js
@@ -1,0 +1,24 @@
+/*
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import AppContent from './AppContent'
+
+export default AppContent
+export { AppContent }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,13 +21,14 @@
  */
 
 import Action from './Action'
-import Content from './Content'
+import AppContent from './AppContent'
 import AppNavigation from './AppNavigation'
 import AppNavigationItem from './AppNavigationItem'
 import AppNavigationNew from './AppNavigationNew'
 import AppNavigationSettings from './AppNavigationSettings'
 import AppNavigationSpacer from './AppNavigationSpacer'
 import Avatar from './Avatar'
+import Content from './Content'
 import DatetimePicker from './DatetimePicker'
 import Modal from './Modal'
 import Multiselect from './Multiselect'
@@ -35,13 +36,14 @@ import PopoverMenu from './PopoverMenu'
 
 export {
 	Action,
-	Content,
+	AppContent,
 	AppNavigation,
 	AppNavigationItem,
 	AppNavigationNew,
 	AppNavigationSettings,
 	AppNavigationSpacer,
 	Avatar,
+	Content,
 	DatetimePicker,
 	Modal,
 	Multiselect,


### PR DESCRIPTION
This makes our component design a bit more aligned with the AppNavigation added in #290 (sidebar will follow shortly).

Apps can use this component to wrap their content elements. Without this change, they have to use a wrapping element (e.g. div) if they want to extract the content to a component (happened to Mail recently).

![Bildschirmfoto von 2019-04-08 10-50-50](https://user-images.githubusercontent.com/1374172/55712066-571b3480-59ee-11e9-81df-324c80f91766.png)
