### PR TITLE
Action and popovermenu accessibility

### DIFF
--- a/src/components/Action/Action.vue
+++ b/src/components/Action/Action.vue
@@ -126,7 +126,7 @@ export default {
 			this.opened = !this.opened
 			// focus first on menu open after opening the menu
 			if (this.opened) {
-				this.$nextTick(function() {
+				this.$nextTick(() => {
 					this.focusFirstAction()
 				})
 			}

--- a/src/components/Action/Action.vue
+++ b/src/components/Action/Action.vue
@@ -20,10 +20,14 @@
   -
   -->
 
+<!-- Accessibility guidelines:
+https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions.html -->
+
 <template>
 	<!-- if only one action, check if we need to bind to click or not -->
-	<a v-if="isSingleAction" href="#" :class="firstAction.icon"
-		class="action-item action-item--single" @click="firstAction.action ? firstAction.action : null" />
+	<a v-if="isSingleAction" :href="firstAction.href ? firstAction.href : '#'"
+		:class="firstAction.icon" class="action-item action-item--single"
+		@[firstActionEvent]="execFirstAction" />
 	<!-- more than one action -->
 	<div v-else
 		:class="{'action-item--open': opened}"
@@ -91,7 +95,7 @@ export default {
 		return {
 			opened: this.open,
 			focusIndex: 0,
-			randomId: Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5)
+			randomId: 'menu-' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5)
 		}
 	},
 	computed: {
@@ -100,6 +104,12 @@ export default {
 		},
 		firstAction() {
 			return this.actions[0]
+		},
+		// return the event to bind if the firstAction have an action
+		firstActionEvent() {
+			return this.firstAction.action
+				? 'click'
+				: null
 		}
 	},
 	watch: {
@@ -127,8 +137,6 @@ export default {
 			this.$emit('update:open', this.opened)
 		},
 		focusAction() {
-			// eslint-disable-next-line
-			console.info(this.$el.querySelectorAll('.focusable')[this.focusIndex])
 			this.$el.querySelectorAll('.focusable')[this.focusIndex].focus()
 		},
 		focusPreviousAction() {
@@ -146,6 +154,11 @@ export default {
 		focusLastAction() {
 			this.focusIndex = this.$el.querySelectorAll('.focusable').length - 1
 			this.focusAction()
+		},
+		// exec the first action and prevent default
+		execFirstAction(e) {
+			this.firstAction.action(e)
+			e.preventDefault()
 		}
 	}
 }
@@ -177,7 +190,10 @@ export default {
 	}
 	// icon-more
 	&__menutoggle {
-		display: inline-block;
+		// align menu icon in center
+		display: flex;
+		justify-content: center;
+		align-items: center;
 		opacity: .7;
 		@include iconfont('more');
 	}

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -26,6 +26,7 @@
 		<a v-if="item.href" :href="(item.href) ? item.href : '#' "
 			:target="(item.target) ? item.target : '' "
 			:download="item.download"
+			class="focusable"
 			rel="noreferrer noopener" @click="action">
 			<span v-if="!iconIsUrl" :class="item.icon" />
 			<img v-else :src="item.icon">
@@ -69,7 +70,7 @@
 		</span>
 
 		<!-- If item.action is set instead, a button will be used -->
-		<button v-else-if="item.action" class="menuitem" :class="{active: item.active}"
+		<button v-else-if="item.action" class="menuitem focusable" :class="{active: item.active}"
 			@click.stop.prevent="item.action">
 			<span :class="item.icon" />
 			<p v-if="item.text && item.longtext">


### PR DESCRIPTION
See aria guidelines https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20161214/examples/menu-button/menu-button-1/menu-button-1.html

Added:
- visual feedback on the menu
- can navigate through popovermenu with up/down pageUp/pageDown tab/shiftTab
- can close popovermenu with escape
- can open popovermenu with space and enter

Missing?
- A-Z navigation
- `tabindex="-1"` on all menu items

@nextcloud/accessibility @nextcloud/vue thoughts and reviews? :heart: 