### PR TITLE
improve AppNavigationSettings slide-up transition

### DIFF
--- a/src/components/AppNavigationSettings/AppNavigationSettings.vue
+++ b/src/components/AppNavigationSettings/AppNavigationSettings.vue
@@ -81,8 +81,9 @@ export default {
 
 .slide-up-leave-active,
 .slide-up-enter-active {
-	transition-duration: var(--animation-quick);
+	transition-duration: 200ms;
 	transition-property: max-height, padding;
+	overflow-y: hidden !important;
 }
 
 .slide-up-enter,

--- a/src/components/AppNavigationSettings/AppNavigationSettings.vue
+++ b/src/components/AppNavigationSettings/AppNavigationSettings.vue
@@ -81,7 +81,7 @@ export default {
 
 .slide-up-leave-active,
 .slide-up-enter-active {
-	transition-duration: 200ms;
+	transition-duration: var(--animation-slow);
 	transition-property: max-height, padding;
 	overflow-y: hidden !important;
 }


### PR DESCRIPTION
Thanks for adding the transition, @skjnldsv !

There are three things I would like to improve:

- [x] styleguide/eslint warning: put `v-show` to the front
- [x] make the transition phase a little bit longer (it was 200ms in server, and `var(--animation-quick)` is 100ms which is way too fast -- at least for me)
- [x] Hide the scroll-bar during transition phase. This looks weird if the content is large enough that the scroll-bar is shown when settings are opened. But it looks much more weirder if the content is small (typical use case) and the scroll-bar is not shown when settings are opened, but the scroll-bar appears during transition.