### PR TITLE
Enhancement/multiselect/ellipsis middle

### DIFF
--- a/src/components/Multiselect/AvatarSelectOption.vue
+++ b/src/components/Multiselect/AvatarSelectOption.vue
@@ -1,3 +1,25 @@
+<!--
+  - @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @author John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
 <template>
 	<span class="option">
 		<avatar :display-name="option.displayName" :user="option.user" :disable-tooltip="true"

--- a/src/components/Multiselect/EllipsisedOption.vue
+++ b/src/components/Multiselect/EllipsisedOption.vue
@@ -78,5 +78,9 @@ export default {
 		white-space: nowrap;
 		text-overflow: ellipsis;
 	}
+	&__last {
+		// prevent whitespace from being trimmed
+		white-space: pre;
+	}
 }
 </style>

--- a/src/components/Multiselect/EllipsisedOption.vue
+++ b/src/components/Multiselect/EllipsisedOption.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<div class="name-parts">
+	<div class="name-parts" :title="name">
 		<span class="name-parts__first">{{ part1 }}</span>
 		<span v-if="part2" class="name-parts__last">{{ part2 }}</span>
 	</div>

--- a/src/components/Multiselect/EllipsisedOption.vue
+++ b/src/components/Multiselect/EllipsisedOption.vue
@@ -1,0 +1,82 @@
+<!--
+  - @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @author John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div class="name-parts">
+		<span class="name-parts__first">{{ part1 }}</span>
+		<span v-if="part2" class="name-parts__last">{{ part2 }}</span>
+	</div>
+</template>
+<script>
+export default {
+	name: 'EllipsisedOption',
+	props: {
+		option: {
+			type: [String, Object],
+			required: true,
+			default: ''
+		},
+		label: {
+			type: String,
+			default: ''
+		}
+	},
+	computed: {
+		name() {
+			if (this.label) {
+				return this.option[this.label]
+			}
+			return this.option
+		},
+		needsTruncate() {
+			return this.name.length >= 10
+		},
+		part1() {
+			if (this.needsTruncate) {
+				// leave maximum 10 letters
+				var split = Math.min(Math.floor(this.name.length / 2), 10)
+				return this.name.substr(0, this.name.length - split)
+			}
+			return this.name
+		},
+		part2() {
+			if (this.needsTruncate) {
+				var split = Math.min(Math.floor(this.name.length / 2), 10)
+				return this.name.substr(this.name.length - split)
+			}
+			return ''
+		}
+
+	}
+}
+</script>
+<style lang="scss" scoped>
+.name-parts {
+	display: flex;
+	max-width: 100%;
+	&__first {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+}
+</style>

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -58,7 +58,7 @@
 			<avatar-select-option v-if="userSelect && !$scopedSlots['option']"
 				:option="scope.option" />
 
-			<!-- ellipsis in the middle if no option slot
+			<!-- Ellipsis in the middle if no option slot
 				is defined in the parent -->
 			<ellipsised-option v-else-if="!$scopedSlots['option']"
 				:option="scope.option" :label="label" />
@@ -69,14 +69,16 @@
 
 		<!-- Registering the limit slot to get the +xxx tooltip.
 			You CANNOT use this scope, we will replace it by this -->
-		<span v-if="multiple" slot="limit" v-tooltip.auto="formatLimitTitle(value)"
-			class="multiselect__limit">
-			{{ limitString }}
-		</span>
+		<template v-if="multiple" #limit>
+			<span v-tooltip.auto="formatLimitTitle(value)"
+				class="multiselect__limit">
+				{{ limitString }}
+			</span>
+		</template>
 
 		<!-- Passing the singleLabel slot, this is used to format the selected
 			option on NON-multiple multiselects -->
-		<template v-if="$scopedSlots['singleLabel']" slot="singleLabel" slot-scope="scope">
+		<template v-if="$scopedSlots['singleLabel']" #singleLabel="scope">
 			<slot name="singleLabel" v-bind="scope" />
 		</template>
 


### PR DESCRIPTION
- Fix #261 
- Moved to vue 2.6.x slot syntax
  https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots 
  https://github.com/vuejs/rfcs/blob/master/active-rfcs/0001-new-slot-syntax.md

![Capture d’écran_2019-04-18_12-06-31](https://user-images.githubusercontent.com/14975046/56353811-8726bc80-61d2-11e9-82e6-26cf0c8c864e.png)

@nextcloud/vue 