### PR TITLE
Center popoverby default and implement popovermenu variables

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,0 +1,27 @@
+/**
+ * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+ 
+/* POPOVERMENU */
+$popoveritem-height: 44px;
+$popovericon-size: 16px;
+$outter-margin: ($popoveritem-height - $popovericon-size) / 2;
+$arrow-width: 9px;

--- a/src/components/Action/Action.vue
+++ b/src/components/Action/Action.vue
@@ -169,6 +169,7 @@ export default {
 
 .action-item {
 	display: inline-block;
+	position: relative;
 	&:hover,
 	&:focus,
 	&__menutoggle:focus,
@@ -208,6 +209,75 @@ export default {
 	// properly position the menu
 	&--multiple {
 		position: relative;
+	}
+}
+</style>
+
+<style lang="scss" scoped>
+.ie,
+.edge {
+	.popovermenu,
+	.popovermenu:after,
+	#app-navigation .app-navigation-entry-menu,
+	#app-navigation .app-navigation-entry-menu:after {
+		border: 1px solid var(--color-border);
+	}
+}
+
+.popovermenu {
+	position: absolute;
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
+	border-radius: var(--border-radius);
+	z-index: 110;
+	margin: 0;
+	margin-top: -5px;
+	right: 50%;
+	transform: translateX(50%);
+	filter: drop-shadow(0 1px 3px var(--color-box-shadow));
+	display: none;
+
+	&.open {
+		display: block;
+	}
+
+	/* Arrow */
+	&:after {
+		bottom: 100%;
+		right: 50%;
+		margin-right: 1 - $arrow-width;
+		/* change this to adjust the arrow position */
+		border: solid transparent;
+		content: ' ';
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+		border-bottom-color: var(--color-main-background);
+		border-width: $arrow-width;
+	}
+
+	/* Align the popover to the right */
+	&.menu-right {
+		right: 0;
+		left: auto;
+		transform: none;
+		&:after {
+			right: $arrow-width - 1; // align to menu icon
+			margin-right: 0;
+		}
+	}
+
+	/* Align the popover to the left */
+	&.menu-left {
+		right: auto;
+		left: 0;
+		transform: none;
+		&:after {
+			left: $arrow-width - 1; // align to menu icon
+			right: auto;
+			margin-right: 0;
+		}
 	}
 }
 </style>

--- a/src/components/PopoverMenu/PopoverMenu.vue
+++ b/src/components/PopoverMenu/PopoverMenu.vue
@@ -49,3 +49,10 @@ export default {
 	}
 }
 </script>
+
+<style lang="scss" scoped>
+ul {
+	display: flex;
+	flex-direction: column;
+}
+</style>

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -179,3 +179,178 @@ export default {
 	}
 }
 </script>
+<style lang="scss" scoped>
+li {
+	display: flex;
+	flex: 0 0 auto;
+
+	&.hidden {
+		display: none;
+	}
+
+	> button,
+	> a,
+	> .menuitem {
+		cursor: pointer;
+		line-height: $popoveritem-height;
+		border: 0;
+		border-radius: 0; // otherwise Safari will cut the border-radius area
+		background-color: transparent;
+		display: flex;
+		align-items: flex-start;
+		height: auto;
+		margin: 0;
+		padding: 0;
+		font-weight: normal;
+		box-shadow: none;
+		width: 100%;
+		color: var(--color-main-text);
+		white-space: nowrap;
+		opacity: .7;
+
+		// TODO split into individual components for readability
+		span[class^='icon-'],
+		span[class*=' icon-'],
+		&[class^='icon-'],
+		&[class*=' icon-'] {
+			min-width: 0; /* Overwrite icons*/
+			min-height: 0;
+			background-position: #{($popoveritem-height - $popovericon-size) / 2} center;
+			background-size: $popovericon-size;
+		}
+
+		span[class^='icon-'],
+		span[class*=' icon-'] {
+			/* Keep padding to define the width to
+				assure correct position of a possible text */
+			padding: #{$popoveritem-height / 2} 0 #{$popoveritem-height / 2} $popoveritem-height;
+		}
+
+		// If no icons set, force left margin to align
+		&:not([class^='icon-']):not([class*='icon-']) {
+			> span,
+			> input,
+			> form {
+				&:not([class^='icon-']):not([class*='icon-']):first-child {
+					margin-left: $popoveritem-height;
+				}
+			}
+		}
+
+		&[class^='icon-'],
+		&[class*=' icon-'] {
+			padding: 0 #{($popoveritem-height - $popovericon-size) / 2} 0 $popoveritem-height;
+		}
+
+		&:hover,
+		&:focus,
+		&.active {
+			opacity: 1 !important;
+		}
+
+		/* prevent .action class to break the design */
+		&.action {
+			padding: inherit !important;
+		}
+
+		> span {
+			cursor: pointer;
+			white-space: nowrap;
+		}
+
+		// long text area
+		> p {
+			width: 150px;
+			line-height: 1.6em;
+			padding: 8px 0;
+			white-space: normal;
+		}
+
+		// TODO: do we really supports it?
+		> select {
+			margin: 0;
+			margin-left: 6px;
+		}
+
+		/* Add padding if contains icon+text */
+		&:not(:empty) {
+			padding-right: $outter-margin !important;
+		}
+
+		/* DEPRECATED! old img in popover fallback
+			* TODO: to remove */
+		> img {
+			width: $popovericon-size;
+			padding: #{($popoveritem-height - $popovericon-size) / 2};
+		}
+
+		/* checkbox/radio fixes */
+		> input.radio + label,
+		> input.checkbox + label {
+			padding: 0 !important;
+			width: 100%;
+		}
+		> input.checkbox + label::before {
+			margin: -2px 13px 0;
+		}
+		> input.radio + label::before {
+			margin: -2px 12px 0;
+		}
+		> input:not([type=radio]):not([type=checkbox]):not([type=image]) {
+			width: 150px;
+		}
+
+		// Forms & text inputs
+		form {
+			display: flex;
+			flex: 1 1 auto;
+			/* put a small space between text and form
+				if there is an element before */
+			&:not(:first-child)  {
+				margin-left: 5px;
+			}
+		}
+		/* no margin if hidden span before */
+		> span.hidden + form,
+		> span[style*='display:none'] + form {
+			margin-left: 0;
+		}
+		/* Inputs inside popover supports text, submit & reset */
+		input {
+			min-width: $popoveritem-height;
+			max-height: #{$popoveritem-height - 4px}; /* twice the element margin-y */
+			margin: 2px 0;
+			flex: 1 1 auto;
+			// space between inline inputs
+			&:not(:first-child) {
+				margin-left: 5px;
+			}
+		}
+	}
+
+	// TODO: do that in js, should be cleaner
+	/* css hack, only first not hidden */
+	&:not(.hidden):not([style*='display:none']) {
+		&:first-of-type {
+			> button, > a, > .menuitem {
+				> form, > input {
+					margin-top: $outter-margin - 2px; // minus the input margin
+				}
+			}
+		}
+		&:last-of-type {
+			> button, > a, > .menuitem {
+				> form, > input {
+					margin-bottom: $outter-margin - 2px; // minus the input margin
+				}
+			}
+		}
+	}
+	> button {
+		padding: 0;
+		span {
+			opacity: 1;
+		}
+	}
+}
+</style>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -63,12 +63,14 @@ module.exports = {
 					{
 						loader: 'sass-loader',
 						options: {
-							data: '$scope_version: ' + SCOPE_VERSION + ';',
+							loader: 'sass-loader',
+							data: `$scope_version:${SCOPE_VERSION}; @import 'variables';`,
 							/**
 							 * ! needed for resolve-url-loader
 							 */
 							sourceMap: true,
-							sourceMapContents: false
+							sourceMapContents: false,
+							includePaths: [path.resolve(__dirname, './src/assets')]
 						}
 					}
 				]


### PR DESCRIPTION
We should really change the way we do things here
We should split each action type into its own component.

QUESTIONS @nextcloud/vue :
- shall we move out from using actions objects and use slots with real components?
  I feel like it would be muuuuch cleaner
  ```vue
   <action>
      <action-button :class="icon-add">Add thing</action-button>
      <action-input :class="icon-user" @submit="onSubmit" @input="onInput"></action-input>
   <action>
  ```