### PR TITLE
AppSidebar: fix sidebar close button

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -266,6 +266,7 @@ $desc-vertical-padding: 18px;
 			height: 44px;
 			top: 0;
 			right: 0;
+			z-index: 1000;
 			opacity: .7;
 			&:hover,
 			&:active,


### PR DESCRIPTION
The close button wasn't functional, because the header was on a layer on top of the button.