### PR TITLE
AppSidebar. fix error when no tabs

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -167,8 +167,10 @@ export default {
 			return tabs
 		}, [])
 
-		// init active tab
-		this.updateActive()
+		// init active tab if exists
+		if (this.tabs.length > 0) {
+			this.updateActive()
+		}
 	},
 	methods: {
 		closeSidebar() {


### PR DESCRIPTION
There was an error when a `AppSidebar` doesn't contain any `AppSidebarTab`s and uses just the content directly.

See https://github.com/nextcloud/nextcloud-vue/pull/340#issuecomment-484798872