### PR TITLE
AppSidebar: Add loading property for starred icon

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -39,7 +39,7 @@
 				<!-- sidebar details -->
 				<div :class="{ 'app-sidebar-header__desc--with-star': canStar }" class="app-sidebar-header__desc">
 					<!-- favourite icon -->
-					<a v-if="canStar" :class="[ isStarred ? 'icon-starred' : 'icon-star', { 'icon-loading-small': starLoading } ]"
+					<a v-if="canStar" :class="{ 'icon-starred': isStarred, 'icon-star': !isStarred, 'icon-loading-small': starLoading }"
 						class="app-sidebar-header__star" @click.prevent="toggleStarred" />
 					<!-- main title -->
 					<h3 class="app-sidebar-header__title">

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -39,7 +39,7 @@
 				<!-- sidebar details -->
 				<div :class="{ 'app-sidebar-header__desc--with-star': canStar }" class="app-sidebar-header__desc">
 					<!-- favourite icon -->
-					<a v-if="canStar" :class="isStarred ? 'icon-starred' : 'icon-star'"
+					<a v-if="canStar" :class="[ isStarred ? 'icon-starred' : 'icon-star', { loading: starLoading } ]"
 						class="app-sidebar-header__star" @click.prevent="toggleStarred" />
 					<!-- main title -->
 					<h3 class="app-sidebar-header__title">
@@ -120,6 +120,10 @@ export default {
 		starred: {
 			type: Boolean,
 			default: null
+		},
+		starLoading: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -39,7 +39,7 @@
 				<!-- sidebar details -->
 				<div :class="{ 'app-sidebar-header__desc--with-star': canStar }" class="app-sidebar-header__desc">
 					<!-- favourite icon -->
-					<a v-if="canStar" :class="[ isStarred ? 'icon-starred' : 'icon-star', { loading: starLoading } ]"
+					<a v-if="canStar" :class="[ isStarred ? 'icon-starred' : 'icon-star', { 'icon-loading-small': starLoading } ]"
 						class="app-sidebar-header__star" @click.prevent="toggleStarred" />
 					<!-- main title -->
 					<h3 class="app-sidebar-header__title">


### PR DESCRIPTION
Let the app show that the starred property is currently changed/saved/....

![Screenshot](https://user-images.githubusercontent.com/6277619/56752572-e1062400-6788-11e9-9075-f6d64d2ae534.png)

Example usage:
```
<AppSidebar [...] :star-loading="loading.favorite">
```