### PR TITLE
Add AppContentList and AppContentDetails components

### DIFF
--- a/src/components/AppContentDetails/AppContentDetails.vue
+++ b/src/components/AppContentDetails/AppContentDetails.vue
@@ -1,0 +1,33 @@
+<!--
+ - @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ -
+ - @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<template>
+	<div class="app-content-details">
+		<slot />
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'AppContentDetails'
+}
+</script>

--- a/src/components/AppContentDetails/index.js
+++ b/src/components/AppContentDetails/index.js
@@ -1,0 +1,24 @@
+/*
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import AppContentDetails from './AppContentDetails'
+
+export default AppContentDetails
+export { AppContentDetails }

--- a/src/components/AppContentList/AppContentList.vue
+++ b/src/components/AppContentList/AppContentList.vue
@@ -1,0 +1,44 @@
+<!--
+ - @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ -
+ - @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<template>
+	<div class="app-content-list"
+		:class="{selection, showdetails: showDetails}">
+		<slot />
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'AppContentList',
+	props: {
+		selection: {
+			type: Boolean,
+			default: false
+		},
+		showDetails: {
+			type: Boolean,
+			default: false
+		}
+	}
+}
+</script>

--- a/src/components/AppContentList/index.js
+++ b/src/components/AppContentList/index.js
@@ -1,0 +1,24 @@
+/*
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import AppContentList from './AppContentList'
+
+export default AppContentList
+export { AppContentList }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -28,6 +28,8 @@ import ActionRouter from './ActionRouter'
 import ActionText from './ActionText'
 import Actions from './Actions'
 import AppContent from './AppContent'
+import AppContentDetails from './AppContentDetails'
+import AppContentList from './AppContentList'
 import AppNavigation from './AppNavigation'
 import AppNavigationItem from './AppNavigationItem'
 import AppNavigationNew from './AppNavigationNew'
@@ -51,6 +53,8 @@ export {
 	ActionText,
 	Actions,
 	AppContent,
+	AppContentDetails,
+	AppContentList,
 	AppNavigation,
 	AppNavigationItem,
 	AppNavigationNew,


### PR DESCRIPTION
Implements
* https://docs.nextcloud.com/server/stable/developer_manual/design/content.html
* https://docs.nextcloud.com/server/stable/developer_manual/design/list.html (without the actual items, they will follow later)

These components were extracted from Mail. This is the bare minimum of functionality you would need.

<details>

Follow-up tasks:
- Find a common way to handle empty content lists (special `emtpy` slot, switched with prop?)
- Find a common way to display "new" items are available in a list. Maybe too specific, but we need that for mail
- Find (and hopefully enforce) a decent animation for new/removed items in the details list
- Find a common design for the details, e.g. to show a header that somewhat looks the same across all apps (with arbitrary content, of course -> slot?)

</details>

cc @nextcloud/vue 