### PR TITLE
Fix Actions empty display and text length

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -38,7 +38,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 	</element>
 
 	<!-- more than one action -->
-	<div v-else
+	<div v-else v-show="actions.length > 0"
 		:class="{'action-item--open': opened}"
 		class="action-item"
 		@keydown.up.exact.prevent="focusPreviousAction"
@@ -270,7 +270,7 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 	&__menutoggle:active,
 	&.action-item--open {
 		border-radius: $clickable-area / 2;
-		background-color: var(--color-background-darker);
+		background-color: var(--color-box-shadow);
 		&,
 		.action-item__menutoggle {
 			opacity: $opacity_full;

--- a/src/mixins/actionGlobal.js
+++ b/src/mixins/actionGlobal.js
@@ -35,10 +35,10 @@ export default {
 
 	computed: {
 		text() {
-			return this.$slots.default ? this.$slots.default[0].text : ''
+			return this.$slots.default ? this.$slots.default[0].text.trim() : ''
 		},
 		isLongText() {
-			return this.text && this.text.length > 20
+			return this.text && this.text.trim().length > 20
 		}
 	}
 }


### PR DESCRIPTION
@nextcloud/vue 

Trim text and prevent action to be shown if there is no valid children :)
Also fix the default background to a translucent one.

| Before | After |
|:---------:|:------:|
|![Capture d’écran_2019-05-13_14-32-24](https://user-images.githubusercontent.com/14975046/57621594-251c6580-758c-11e9-8256-ad9aed0ab062.png)|![Capture d’écran_2019-05-13_14-27-04](https://user-images.githubusercontent.com/14975046/57621593-251c6580-758c-11e9-9708-f37f3371d8bb.png)|