### PR TITLE
don't disable user-select

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -49,7 +49,7 @@ export default {
 		}
 	},
 	mounted() {
-		this.mc = new Hammer(this.$el)
+		this.mc = new Hammer(this.$el, { cssProps: { userSelect: 'text' } })
 		this.mc.on('swipeleft swiperight', e => {
 			this.handleSwipe(e)
 		})


### PR DESCRIPTION
The component `AppContent` uses HammerJS for providing swipe gestures for hiding/showing the app navigation. This is only useful for (small) mobile screens, since on large screens, the app navigation is always visible.

However, HammerJS disables the user's possibility to select some text (CSS `user-select: none`) by default, which may not be intended for Nextcloud apps (i.e., it is not intended for the notes app [preview mode]).

There is a paragraph on http://hammerjs.github.io/tips/ about this:

> **“I can’t select my text anymore!”**
> Hammer is setting a property to improve the UX of the panning on desktop. Regularly, the desktop browser would select the text while you drag over the page. The `user-select` css property disables this.
> If you care about the text-selection and not so much about the desktop experience, you can simply remove this option from the defaults. Make sure you do this before creating an instance.

Since the swipe feature is only for mobiles and not for the desktop, I think it's fine to disable this feature resp. to re-enable text selection again.

I've tested this change with the notes app (preview mode) and it works as intended.