### PR TITLE
Rename slideshow play/pause

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -265,7 +265,7 @@ export default {
 			return `modal-${this.outTransition ? 'out' : 'in'}`
 		},
 		playPauseTitle() {
-			return this.playing ? t('core', 'Pause') : t('core', 'Play')
+			return this.playing ? t('core', 'Pause slideshow') : t('core', 'Start slideshow')
 		}
 	},
 


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/16076

> "Play" should be called "Start slideshow"