### PR TITLE
Fix actionInput margins

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -282,12 +282,12 @@ $input-margin: 4px;
 // if a form is the last of the list
 // add the same bottomMargin as the right padding
 // for visual balance
-li:last-child .action-input {
+li:last-child > .action-input {
 	margin-bottom: $icon-margin - $input-margin;
 }
 
 // same for first item
-li:first-child .action-input {
+li:first-child > .action-input {
 	margin-top: $icon-margin - $input-margin;
 }
 


### PR DESCRIPTION
Was triggered even if the item was on the middle as any li could have been a far parent of the menu