### PR TITLE
Add actions menu margin

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -411,7 +411,9 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 
 		display: none;
 
-		margin: 0;
+		// make sure to not have the menu right
+		// on the edge of the window
+		margin: 10px;
 		margin-top: -5px;
 
 		transform: translateX(50%);


### PR DESCRIPTION
Fix #410 

That way, if the actions popover is the blocker for the content height, it would look better than this

| Before | After |
|:---------:|:------:|
|![dev skjnldsv com_settings_user_security (1)](https://user-images.githubusercontent.com/14975046/58160205-4eb94900-7c7e-11e9-87dd-c5d866b457d8.png)|![dev skjnldsv com_settings_user_security (2)](https://user-images.githubusercontent.com/14975046/58160206-4eb94900-7c7e-11e9-86da-201b4050165c.png)|