### PR TITLE
Add Datepicker to ActionInput and ActionTextEditable + design fixes and more checkbox events

### DIFF
--- a/src/components/ActionCheckbox/ActionCheckbox.vue
+++ b/src/components/ActionCheckbox/ActionCheckbox.vue
@@ -81,6 +81,20 @@ export default {
 			 */
 			this.$emit('change', event)
 
+			if (this.$refs.checkbox.checked) {
+				/**
+				 * Emitted when the checkbox is checked
+				 * @type {Event}
+				 */
+				this.$emit('check', true)
+			} else {
+				/**
+				 * Emitted when the checkbox is unchecked
+				 * @type {Event}
+				 */
+				this.$emit('uncheck', true)
+			}
+
 			/**
 			 * Emitted when the checkbox state is changed
 			 * @type {boolean}

--- a/src/components/ActionTextEditable/index.js
+++ b/src/components/ActionTextEditable/index.js
@@ -1,0 +1,25 @@
+/**
+ * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import ActionTextEditable from './ActionTextEditable'
+
+export default ActionTextEditable
+export { ActionTextEditable }

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -107,7 +107,8 @@ const allowedChildren = [
 	'ActionInput',
 	'ActionLink',
 	'ActionRouter',
-	'ActionText'
+	'ActionText',
+	'ActionTextEditable'
 ]
 
 /**

--- a/src/components/AppNavigationCounter/AppNavigationCounter.vue
+++ b/src/components/AppNavigationCounter/AppNavigationCounter.vue
@@ -41,12 +41,10 @@ your number or string
 </docs>
 
 <template>
-
 	<li :class="{ highlighted }"
 		class="app-navigation-entry-utils-counter">
 		<span><slot /></span>
 	</li>
-
 </template>
 
 <script>

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -99,7 +99,7 @@ $cell_height: 32px;
 		font: inherit;
 		color: var(--color-main-text);
 		padding: 5px;
-		width: 240px;
+		width: $cell_height * 7  + 2 * 5px; // 7 days + padding
 	}
 
 	// HEADER: year, month and arrows
@@ -225,9 +225,14 @@ $cell_height: 32px;
 			border-spacing: 0;
 			td, th {
 				font-size: 12px;
-				width: 32px;
-				height: 32px;
+				width: $cell_height;
+				height: $cell_height;
+				// compensate the padding-top shifting
+				line-height: $cell_height - 2px;
+				border: 0;
 				padding: 0;
+				// shift a little bit down for visual balance
+				padding-top: 2px;
 				overflow: hidden;
 				text-align: center;
 			}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import ActionInput from './ActionInput'
 import ActionLink from './ActionLink'
 import ActionRouter from './ActionRouter'
 import ActionText from './ActionText'
+import ActionTextEditable from './ActionTextEditable'
 import Actions from './Actions'
 import AppContent from './AppContent'
 import AppContentDetails from './AppContentDetails'
@@ -53,6 +54,7 @@ export {
 	ActionLink,
 	ActionRouter,
 	ActionText,
+	ActionTextEditable,
 	Actions,
 	AppContent,
 	AppContentDetails,


### PR DESCRIPTION
|ActionTextEditable|ActionTextEditable with title|ActionInput type date|
|:--:|:--:|:--:|
|![Capture d’écran_2019-07-11_22-42-45](https://user-images.githubusercontent.com/14975046/61084032-6c5c9080-a42d-11e9-8b67-92c3c49e4aee.png)|![Capture d’écran_2019-07-11_22-43-41](https://user-images.githubusercontent.com/14975046/61084033-6c5c9080-a42d-11e9-8a49-8fc50c5ebd5b.png)|![Capture d’écran_2019-07-12_10-56-35](https://user-images.githubusercontent.com/14975046/61115868-bbd5a780-a493-11e9-9bb5-ea9c7ec0e347.png)|

- Design fixes
- Added `@check` and `@uncheck` event for the checkbox to speed up any integration and remove the need to implement the handlers ourselves in our apps :)
