### PR TITLE
Also allow value on checkbox

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -39,6 +39,7 @@ If you're using a long text you can specify a title
 	</Actions>
 ```
 </docs>
+
 <template>
 	<li>
 		<button class="action-button focusable" :disabled="disabled" @click="onClick">

--- a/src/components/ActionCheckbox/ActionCheckbox.vue
+++ b/src/components/ActionCheckbox/ActionCheckbox.vue
@@ -20,11 +20,24 @@
   -
   -->
 
+<docs>
+This component is made to be used inside of the [Actions](#Actions) component slots.
+
+```vue
+	<Actions>
+		<ActionCheckbox @change="alert('(un)checked !')">First choice</ActionCheckbox>
+		<ActionCheckbox value="second" @change="alert('(un)checked !')">Second choice</ActionCheckbox>
+		<ActionCheckbox :checked="true" @change="alert('(un)checked !')">Third choice (checked)</ActionCheckbox>
+		<ActionCheckbox :disabled="true" @change="alert('(un)checked !')">Second choice (disabled)</ActionCheckbox>
+	</Actions>
+```
+</docs>
+
 <template>
 	<li>
 		<span class="action-checkbox" :class="{'action-checkbox--disabled': disabled}">
 			<input :id="id" ref="checkbox"
-				:disabled="disabled" :checked="checked"
+				:disabled="disabled" :checked="checked" :value="value"
 				type="checkbox" class="focusable checkbox action-checkbox__checkbox"
 				@keydown.enter.exact.prevent="checkInput" @change="onChange">
 			<label ref="label" :for="id" class="action-checkbox__label">{{ text }}</label>
@@ -53,6 +66,7 @@ export default {
 			default: () => 'action-' + GenRandomId(),
 			validator: id => id.trim() !== ''
 		},
+
 		/**
 		 * checked state of the the checkbox element
 		 */
@@ -60,6 +74,15 @@ export default {
 			type: Boolean,
 			default: false
 		},
+
+		/**
+		 * value of the checkbox input
+		 */
+		value: {
+			type: [String, Number],
+			default: ''
+		},
+
 		/**
 		 * disabled state of the checkbox element
 		 */
@@ -151,7 +174,7 @@ export default {
 
 		width: 100%;
 		padding: 0 !important;
-		padding-right: $icon-margin;
+		padding-right: $icon-margin !important;
 
 		opacity: $opacity_normal;
 		// checkbox-width is 12px, border is 2


### PR DESCRIPTION
Issue #500 :tada: 

- add value prop
- fix padding right being overrided by the previous line of padding: 0. 
  this is here because of the too specific css rule in the settings: https://github.com/nextcloud/server/commit/8fb788570c449a76b4a2fdfb59842879d82e3fc9#diff-bf0066932907b556b49ffe55b209a501R615

![Capture d’écran_2019-07-24_15-55-21](https://user-images.githubusercontent.com/14975046/61799466-75852e80-ae2b-11e9-9a28-82e9ebdbe3bb.png)
