### PR TITLE
Allow to bind attributes to the ActionInput timepicker if present

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -36,6 +36,7 @@
 				<DatetimePicker v-if="isDatePickerType"
 					:disabled="disabled" :type="isDatePickerType"
 					:value="value" class="action-input__picker"
+					v-bind="$attrs"
 					@input="onInput" @change="onChange" />
 
 				<template v-else>


### PR DESCRIPTION
![Capture d’écran_2019-07-24_18-06-37](https://user-images.githubusercontent.com/14975046/61809548-cf8eef80-ae3d-11e9-8e8b-a40c3a52cfbb.png)
``` vue
					<ActionInput
						:value="share.expireDate"
						icon="icon-calendar-dark"
						type="date"
						:not-before="new Date()" />
```