### PR TITLE
Focus proper action on mouse move instead of removing focus

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -80,7 +80,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 			:style="{marginRight: `${ offsetX }px`}"
 			class="action-item__menu"
 			tabindex="-1"
-			@mousemove="unFocus">
+			@mousemove="onMouseFocusAction">
 			<!-- arrow -->
 			<div class="action-item__menu_arrow"
 				:style="{ transform: `translateX(${ offsetX }px)`}" />
@@ -272,11 +272,27 @@ export default {
 		},
 
 		// MENU KEYS & FOCUS MANAGEMENT
-		// remove the focus on any element if the mouse
-		// is used to select an action
-		unFocus() {
-			this.$refs.menu.focus()
-			this.removeCurrentActive()
+		// focus nearest focusable item on mouse move
+		// DO NOT change the focus if the target is already focused
+		// this will prevent issues with input being unfocused
+		// on mouse move
+		onMouseFocusAction(event) {
+			if (document.activeElement === event.target) {
+				return
+			}
+
+			const menuItem = event.target.closest('li')
+			if (menuItem) {
+				const focusableItem = menuItem.querySelector('.focusable:not(:disabled)')
+				if (focusableItem) {
+					const focusList = this.$refs.menu.querySelectorAll('.focusable:not(:disabled)')
+					const focusIndex = Array.prototype.indexOf.call(focusList, focusableItem)
+					if (focusIndex > -1) {
+						this.focusIndex = focusIndex
+						this.focusAction()
+					}
+				}
+			}
 		},
 		removeCurrentActive() {
 			const currentActiveElement = this.$refs.menu.querySelector('li.active')


### PR DESCRIPTION
![Peek 26-07-2019 11-18](https://user-images.githubusercontent.com/14975046/61941114-25c37600-af97-11e9-9953-37bd44c0715c.gif)

Before we removed the focus to make sure we did not conflicted between the mouse and the keyboard navigation. But if you had a focus on an input and moving your mouse, you were losing the focus and had to click again, this is not good :)

Now we focus the nearest item and ignore if it is the currently focused item already :wink: 