### PR TITLE
Fix Cannot read property 'length' of undefined on truncated entry - multiselect

### DIFF
--- a/src/components/Multiselect/EllipsisedOption.vue
+++ b/src/components/Multiselect/EllipsisedOption.vue
@@ -48,7 +48,7 @@ export default {
 			return this.option
 		},
 		needsTruncate() {
-			return this.name.length >= 10
+			return this.name && this.name.length >= 10
 		},
 		part1() {
 			if (this.needsTruncate) {


### PR DESCRIPTION
![Capture d’écran_2019-08-07_16-21-36](https://user-images.githubusercontent.com/14975046/62630676-b3a44700-b92f-11e9-888d-93d8bf0e4eda.png)

Signed-off-by: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>

When you are tagging a new option (users management, add new group) it happens. :man_shrugging: 