### PR TITLE
Fix duplicate bakground color on action menu toggle

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -357,21 +357,22 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 
 	// put a grey round background when menu is opened
 	// or hover-focused
-	&:hover,
-	&:focus,
-	&:active,
+	&--single:hover,
+	&--single:focus,
+	&--single:active,
+	&__menutoggle:hover,
 	&__menutoggle:focus,
-	&__menutoggle:active,
-	&.action-item--open {
+	&__menutoggle:active{
 		border-radius: $clickable-area / 2;
 		// good looking on dark AND white bg
 		background-color: $icon-focus-bg !important; // override default server
-		&,
-		.action-item__menutoggle {
-			opacity: $opacity_full;
-			border-radius: $clickable-area / 2;
-			background-color: $action-background-hover;
-		}
+		opacity: $opacity_full;
+	}
+
+	&.action-item--open .action-item__menutoggle {
+		opacity: $opacity_full;
+		border-radius: $clickable-area / 2;
+		background-color: $action-background-hover;
 	}
 
 	// icons


### PR DESCRIPTION
Before that change both the .action-item as well as the .action-item__menutoggle elements had a background color defined, which leaded to a slightly different background color for the menu toggle compared to single action items.

Before:
![image](https://user-images.githubusercontent.com/3404133/62852615-350e2780-bcea-11e9-8aa1-41a99252776c.png)

After:
![image](https://user-images.githubusercontent.com/3404133/62852642-48b98e00-bcea-11e9-94ce-c36335bc8c0b.png)
