### PR TITLE
Allow to provide an order for sidebar tabs

### DIFF
--- a/src/components/AppSidebarTab/AppSidebarTab.vue
+++ b/src/components/AppSidebarTab/AppSidebarTab.vue
@@ -48,6 +48,11 @@ export default {
 			type: String,
 			default: '',
 			required: true
+		},
+		order: {
+			type: Number,
+			default: 0,
+			required: false
 		}
 	},
 


### PR DESCRIPTION
The AppSidebar component already checks for the order value, but the AppSidebarTab doesn't provide one, so this PR adds it as a property to easily provide an order that is different from the naturalSortCompare of the names.