### PR TITLE
Allow wrapped children in validation script

### DIFF
--- a/src/utils/ValidateChildren.js
+++ b/src/utils/ValidateChildren.js
@@ -29,9 +29,16 @@ import Vue from 'vue'
  */
 const ValidateChildren = (vm, allowed) => {
 	vm.$children.forEach((child, index) => {
-		if (allowed.indexOf(child.$options.name) === -1) {
+		const isChildren = allowed.indexOf(child.$options.name) !== 1
+		const isWrappedChildren = child.$children.length === 1
+			&& allowed.indexOf(child.$children[0].$options.name) === -1
+
+		// allow direct children action or wrapped action in case of using
+		// a fake component with :is="myActionWrapper" and some custom methods
+		// that you import  with import myActionWrapper from 'myActionWrapper'
+		if (!(isChildren || isWrappedChildren)) {
 			// warn
-			Vue.util.warn(`${child.$options._componentTag} is not allowed inside the ${vm.$options._componentTag} component`, vm)
+			Vue.util.warn(`${child.$options.name} is not allowed inside the ${vm.$options.name} component`, vm)
 
 			// cleanup
 			vm.$children.splice(index, 1)


### PR DESCRIPTION
If you're passing a component as variable, you will have to wrap it in your app
Because you can import `ActionButton`, but if you do
```vue
<Actions>
	<component :is="ActionButton" />
</Actions>
<script>
import ActionButton from 'nextcloud-vue/dist/components/ActionButton'
```
Then importing make no sense as you need to have your own methods, provide a click handler, etc etc.

So you will need to wrap it into your own `myComponent` that uses `ActionButton`
```vue
<template>
	<ActionButton icon="icon-up" @click="copyNtoFN">
		{{ t('contacts', 'Copy to full name') }}
	</ActionButton>
</template>
<script>
import ActionButton from 'nextcloud-vue/dist/components/ActionButton'
export default {
	name: 'myComponent',
```
```vue
<Actions>
	<component :is="myComponent" />
</Actions>
<script>
import myComponent from './myComponent'
```
But then you'll end up with `myComponent` as direct children of `Actions` and that was forbidden before

![Capture d’écran_2019-08-30_18-25-23](https://user-images.githubusercontent.com/14975046/64036464-8d9b4c80-cb53-11e9-9b88-2ba520844ebe.png)

