### PR TITLE
Fix actions events and performances

### DIFF
--- a/src/utils/ValidateSlot.js
+++ b/src/utils/ValidateSlot.js
@@ -1,0 +1,48 @@
+/**
+ * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import Vue from 'vue'
+
+/**
+ * Validate children of a vue component
+ *
+ * @param {Object[]} slots the vue component slot
+ * @param {String[]} allowed the allowed components name
+ * @param {Object} vm the vue component instance
+ */
+const ValidateSlot = (slots, allowed, vm) => {
+	slots.forEach((node, index) => {
+		const isHtmlElement = !node.componentOptions && node.tag
+		const isVueComponent = node.componentOptions && typeof node.componentOptions.tag === 'string'
+		const isForbiddenComponent = isVueComponent && allowed.indexOf(node.componentOptions.tag) === -1
+
+		// if not a vue component or component not in allowed tags
+		if (isHtmlElement || isForbiddenComponent) {
+			// warn
+			Vue.util.warn(`${isHtmlElement ? node.tag : node.componentOptions.tag} is not allowed inside the ${vm.$options.name} component`, vm)
+
+			// cleanup
+			slots.splice(index, 1)
+		}
+	})
+}
+
+export default ValidateSlot


### PR DESCRIPTION
- Slow performances because all menus are hidden with v-show: switching to v-if
- We were using `$children`, so v-if don't display anything and since we create `this.actions` from `$children`, it was empty: now using `$slots.default` as the array is filled regardless of the template being shown or not.
