### PR TITLE
fix undefined slot

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -367,7 +367,7 @@ export default {
 		},
 		initActions() {
 			// filter out invalid slots
-			this.actions = this.$slots.default.filter(node => node && node.componentOptions) || []
+			this.actions = (this.$slots.default || []).filter(node => node && node.componentOptions)
 		}
 	}
 }

--- a/src/utils/ValidateSlot.js
+++ b/src/utils/ValidateSlot.js
@@ -29,6 +29,9 @@ import Vue from 'vue'
  * @param {Object} vm the vue component instance
  */
 const ValidateSlot = (slots, allowed, vm) => {
+	if (slots === undefined) {
+		return
+	}
 	slots.forEach((node, index) => {
 		const isHtmlElement = !node.componentOptions && node.tag
 		const isVueComponent = node.componentOptions && typeof node.componentOptions.tag === 'string'


### PR DESCRIPTION
I got this error when having children inside a `AppNavigationItem` and #486 applied:

```
21:29:58.390 [Vue warn]: Error in beforeMount hook: "TypeError: this.$slots.default is undefined"

found in

---> <Actions> at src/components/Actions/Actions.vue
       <AppNavigationItem> at src/components/AppNavigationItem/AppNavigationItem.vue... (1 recursive calls)
         <NavigationCategoriesItem> at src/components/NavigationCategoriesItem.vue
           <NavigationList> at src/components/NavigationList.vue
             <AppNavigation> at src/components/AppNavigation/AppNavigation.vue
               <Content> at src/components/Content/Content.vue
                 <App> at src/App.vue
                   <Root> vue.runtime.esm.js:619

21:29:58.393 TypeError: this.$slots.default is undefined
Stack trace:
initActions@https://xxxx/apps/notes/js/notes.js:1255:103
beforeMount@https://xxxx/apps/notes/js/notes.js:1218:1
invokeWithErrorHandling@https://xxxx/apps/notes/js/notes.js:64408:49
callHook@https://xxxx/apps/notes/js/notes.js:66762:7
mountComponent@https://xxxx/apps/notes/js/notes.js:66586:3
[...]
```

Looks like slots are not initialized at a certain point in lifecycle. Therefore, I've introduced a check for this.