### PR TITLE
AppNavigation: fix style for CSS class "active"

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -399,6 +399,7 @@ export default {
 	width: 100%;
 	min-height: $clickable-area;
 
+	&.active,
 	a:hover,
 	a:focus,
 	a:active {


### PR DESCRIPTION
Since  #486, `#app-navigation` has CSS class `vue` and Nextcloud server has the following style:

```
#app-navigation:not(.vue) > ul > li.active, #app-navigation:not(.vue) > ul > li a:hover, #app-navigation:not(.vue) > ul > li a:focus, #app-navigation:not(.vue) > ul > li a:active, #app-navigation:not(.vue) > ul > li a.selected, #app-navigation:not(.vue) > ul > li a.active, #app-navigation:not(.vue) > ul > li.active > a, #app-navigation:not(.vue) > ul > li a:hover > a, #app-navigation:not(.vue) > ul > li a:focus > a, #app-navigation:not(.vue) > ul > li a:active > a, #app-navigation:not(.vue) > ul > li a.selected > a, #app-navigation:not(.vue) > ul > li a.active > a {
	opacity: 1;
	box-shadow: inset 4px 0 var(--color-primary);
}
```

This means, that the `active` style from server is not applied anymore to `AppNavigationItem`. However, the component doesn't include it's own style for `active` CSS class. This is fixed with this PR.