### PR TITLE
fix check for non-tab-content

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -309,7 +309,6 @@ export default {
 
 			// tabs are optional, but you can use either tabs or non-tab-content only
 			if (tabs.length !== 0 && tabs.length !== this.$children.length) {
-				tabs = []
 				Vue.util.warn(`Mixing tabs and non-tab-content is not possible.`)
 			}
 

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -301,22 +301,17 @@ export default {
 		 */
 		updateTabs() {
 			// Init tabs from $children
-			let tabs = this.$children.reduce((tabs, tab) => {
-				if (!tab.name || typeof tab.name !== 'string') {
-					Vue.util.warn(`This tab is missing a valid name: ${tab.name}`, tab)
-					return tabs
-				}
-				if (!IsValidString(tab.id)) {
-					Vue.util.warn(`This tab is missing a valid id: ${tab.id}`, tab)
-					return tabs
-				}
-				if (!IsValidString(tab.icon)) {
-					Vue.util.warn(`This tab is missing a valid icon: ${tab.icon}`, tab)
-					return tabs
-				}
-				tabs.push(tab)
-				return tabs
-			}, [])
+			let tabs = this.$children.filter(child =>
+				(child.name && typeof child.name === 'string')
+				&& IsValidString(child.id)
+				&& IsValidString(child.icon)
+			)
+
+			// tabs are optional, but you can use either tabs or non-tab-content only
+			if (tabs.length !== 0 && tabs.length !== this.$children.length) {
+				tabs = []
+				Vue.util.warn(`Mixing tabs and non-tab-content is not possible.`)
+			}
 
 			this.tabs = tabs.sort((a, b) => {
 				var orderA = a.order || 0


### PR DESCRIPTION
There was still an error message when using no tabs in `AppSidebar`. Since tabs should be optional, the validation has to be changed (see https://github.com/nextcloud/nextcloud-vue/pull/447).

My approach here is to find valid tabs (a tab is valid if it has `name`, `icon` and `id`) and then check if there is either tabs only or non-tab-content only. Otherwise, a warning is given.

Please check in detail, if this is sufficient for you.