### PR TITLE
UserBubble component

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -46,7 +46,8 @@
 		:style="avatarStyle"
 		class="avatardiv popovermenu-wrapper" @click="toggleMenu">
 		<!-- avatar -->
-		<img v-if="isAvatarLoaded && !userDoesNotExist" :src="avatarUrlLoaded" :srcset="avatarSrcSetLoaded">
+		<div v-if="iconClass" :class="iconClass" class="avatar-class-icon"></div>
+		<img v-else-if="isAvatarLoaded && !userDoesNotExist" :src="avatarUrlLoaded" :srcset="avatarSrcSetLoaded">
 		<div v-if="hasMenu" class="icon-more" />
 
 		<!-- avatar status -->
@@ -94,6 +95,13 @@ export default {
 		 * either the url, user or displayName property must be defined
 		 */
 		url: {
+			type: String,
+			default: undefined
+		},
+		/**
+		 * Set a css icon-class for an icon to be used instead of the avatar.
+		 */
+		iconClass: {
 			type: String,
 			default: undefined
 		},
@@ -249,8 +257,10 @@ export default {
 				fontSize: Math.round(this.size * 0.55) + 'px'
 			}
 
-			const rgb = uidToColor(this.getUserIdentifier)
-			style.backgroundColor = 'rgb(' + rgb.r + ', ' + rgb.g + ', ' + rgb.b + ')'
+			if (!this.iconClass) {
+				const rgb = uidToColor(this.getUserIdentifier)
+				style.backgroundColor = 'rgb(' + rgb.r + ', ' + rgb.g + ', ' + rgb.b + ')'
+			}
 			return style
 		},
 		tooltip() {
@@ -482,6 +492,11 @@ export default {
 		margin: 0;
 		font-size: initial;
 	}
+}
+
+.avatar-class-icon {
+	border-radius: 50%;
+	background-color: var(--color-background-darker);
 }
 
 </style>

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -38,7 +38,8 @@
 <template>
 	<div v-tooltip="tooltip" v-click-outside="closeMenu"
 		:class="{
-			'icon-loading': !isAvatarLoaded,
+			'icon-loading': !isAvatarLoaded && size > 16,
+			'icon-loading-small': !isAvatarLoaded && size <= 16,
 			'avatardiv--unknown': userDoesNotExist,
 			'avatardiv--with-menu': hasMenu
 		}"

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -21,11 +21,13 @@
 -->
 
 <template>
-	<Popover trigger="hover focus" :open="open" class="test"
-		@update:open="onOpenChange">
-		<div slot="trigger" class="user-bubble">
-			<Avatar v-bind="$attrs" :user="user" :size="16"
-				:disable-tooltip="true" :disable-menu="true" class="avatar" />
+	<Popover trigger="hover focus" :open="open" :disabled="popoverEmpty"
+		class="user-bubble-popover" @update:open="onOpenChange">
+		<div slot="trigger" v-bind="linkOrNot" class="user-bubble">
+			<slot name="avatar">
+				<Avatar v-bind="$attrs" :user="user" :size="16"
+					:disable-tooltip="true" :disable-menu="true" class="avatar" />
+			</slot>
 			<h6 class="user">
 				{{ displayName ? displayName : user }}
 			</h6>
@@ -51,15 +53,35 @@ export default {
 		},
 		displayName: {
 			type: String,
-			required: false
+			required: true
 		},
 		url: {
 			type: String,
-			required: false
+			default: ''
 		},
 		open: {
 			type: Boolean,
 			default: false
+		}
+	},
+	computed: {
+		componentType() {
+			if (this.url) {
+				return 'div'
+			}
+			return 'a'
+		},
+		linkOrNot() {
+			if (this.url !== '') {
+				return { is: 'a', href: this.url }
+			}
+			return { is: 'div' }
+		},
+		popoverEmpty() {
+			if (typeof this.$slots.default === 'undefined') {
+				return true
+			}
+			return false
 		}
 	},
 	methods: {
@@ -71,6 +93,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.user-bubble-popover {
+	display: inline;
+	vertical-align: top;
+}
+
 .user-bubble {
 	display: flex;
 	height: 20px;
@@ -79,16 +106,11 @@ export default {
 }
 
 .avatar {
-    align-self: center;
-    margin-left: 2px;
+	align-self: center;
+	margin-left: 2px;
 }
 
 .user {
-    margin: 0 8px 0 4px;
-}
-
-.test {
-    display: inline;
-    vertical-align: top;
+	margin: 0 8px 0 4px;
 }
 </style>

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -134,6 +134,10 @@ export default {
 	background-color: var(--color-background-dark);
 }
 
+h6 {
+	line-height: 20px;
+}
+
 .avatar {
 	align-self: center;
 	margin-left: 2px;

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -1,6 +1,7 @@
 <!--
   - @copyright Copyright (c) 2019 Jonas Sulzer <jonas@violoncello.ch>
   -
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
   - @author Jonas Sulzer <jonas@violoncello.ch>
   -
   - @license GNU AGPL version 3 or any later version
@@ -20,16 +21,16 @@
 -->
 
 <template>
-	<Popover>
-		<template slot="trigger">
-			<div class="user-bubble">
-				<Avatar :user="userName" :display-name="userName" />
-				<h6>{{userName}}</h6>
-			</div>
-		</template>
-		<template>
-			<h2>I am the content</h2>
-		</template>
+	<Popover trigger="hover focus" :open="open" class="test"
+		@update:open="onOpenChange">
+		<div slot="trigger" class="user-bubble">
+			<Avatar v-bind="$attrs" :user="user" :size="16"
+				:disable-tooltip="true" :disable-menu="true" class="avatar" />
+			<h6 class="user">
+				{{ displayName ? displayName : user }}
+			</h6>
+		</div>
+		<slot />
 	</Popover>
 </template>
 
@@ -44,20 +45,50 @@ export default {
 		Avatar
 	},
 	props: {
-		userName: {
+		user: {
 			type: String,
 			required: true
+		},
+		displayName: {
+			type: String,
+			required: false
+		},
+		url: {
+			type: String,
+			required: false
+		},
+		open: {
+			type: Boolean,
+			default: false
+		}
+	},
+	methods: {
+		onOpenChange(state) {
+			this.$emit('update:open', state)
 		}
 	}
-
 }
 </script>
 
 <style lang="scss" scoped>
 .user-bubble {
 	display: flex;
-	height: 1.8em;
-	border-radius: 50%;
+	height: 20px;
+	border-radius: 10px;
 	background-color: var(--color-background-dark);
+}
+
+.avatar {
+    align-self: center;
+    margin-left: 2px;
+}
+
+.user {
+    margin: 0 8px 0 4px;
+}
+
+.test {
+    display: inline;
+    vertical-align: top;
 }
 </style>

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -1,0 +1,63 @@
+<!--
+  - @copyright Copyright (c) 2019 Jonas Sulzer <jonas@violoncello.ch>
+  -
+  - @author Jonas Sulzer <jonas@violoncello.ch>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+	<Popover>
+		<template slot="trigger">
+			<div class="user-bubble">
+				<Avatar :user="userName" :display-name="userName" />
+				<h6>{{userName}}</h6>
+			</div>
+		</template>
+		<template>
+			<h2>I am the content</h2>
+		</template>
+	</Popover>
+</template>
+
+<script>
+import { Popover } from '../Popover'
+import { Avatar } from '../Avatar'
+
+export default {
+	name: 'UserBubble',
+	components: {
+		Popover,
+		Avatar
+	},
+	props: {
+		userName: {
+			type: String,
+			required: true
+		}
+	}
+
+}
+</script>
+
+<style lang="scss" scoped>
+.user-bubble {
+	display: flex;
+	height: 1.8em;
+	border-radius: 50%;
+	background-color: var(--color-background-dark);
+}
+</style>

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -24,14 +24,12 @@
 
 ### General description
 
-This component displays a user together with a small avatar in a grey bubble. 
-It's possible to replace the avatar with something else, 
-to link the bubble to e.g. a users profile 
+This component displays a user together with a small avatar in a grey bubble.
+It's possible to use an actual user's avatar, just an image/icon as a url or an icon-class,
+to link the bubble to e.g. a users profile
 and to show a popover on hover with e.g. the full user name handle / email address or something else.
 
-This components has two slots:
-* 'avatar' which allows you to replace the user-avatar with e.g. an icon;
-
+This component has the following slot:
 * a default slot which is for the content of the popover (this is passed to the popover component directly).
 
 ### Examples
@@ -41,22 +39,21 @@ This components has two slots:
 	<p>
 		Some text before
 		<user-bubble :user="'admin'" :displayName="'Admin Example'" :url="'/test'" >
-  			@admin@foreign-host.com
+			@admin@foreign-host.com
 		</user-bubble>
-		 and after the bubble.
+		and after the bubble.
 	</p>
 </template>
 ```
 </docs>
-
 <template>
 	<Popover trigger="hover focus" :open="open" :disabled="popoverEmpty"
 		class="user-bubble-popover" @update:open="onOpenChange">
 		<div slot="trigger" v-bind="linkOrNot" class="user-bubble">
-			<slot name="avatar">
-				<Avatar v-bind="$attrs" :user="user" :size="16"
-					:disable-tooltip="true" :disable-menu="true" class="avatar" />
-			</slot>
+			<Avatar :url="!isUserAvatar && isIconUrl ? avatarImage : ''"
+				:icon-class="!isUserAvatar && !isIconUrl ? avatarImage : ''"
+				:user="isUserAvatar ? user : ''" :size="16" :disable-tooltip="true"
+				:disable-menu="true" class="avatar" />
 			<h6 class="user">
 				{{ displayName ? displayName : user }}
 			</h6>
@@ -76,6 +73,10 @@ export default {
 		Avatar
 	},
 	props: {
+		avatarImage: {
+			type: String,
+			default: ''
+		},
 		user: {
 			type: String,
 			required: true
@@ -94,6 +95,21 @@ export default {
 		}
 	},
 	computed: {
+		isUserAvatar() {
+			if (!this.avatarImage) {
+				return true
+			}
+			return false
+		},
+		isIconUrl() {
+			try {
+				// eslint-disable-next-line
+				new URL(this.avatarImage)
+				return true
+			} catch (error) {
+				return false
+			}
+		},
 		componentType() {
 			if (this.url) {
 				return 'div'

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -20,6 +20,35 @@
   - along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 
+<docs>
+
+### General description
+
+This component displays a user together with a small avatar in a grey bubble. 
+It's possible to replace the avatar with something else, 
+to link the bubble to e.g. a users profile 
+and to show a popover on hover with e.g. the full user name handle / email address or something else.
+
+This components has two slots:
+* 'avatar' which allows you to replace the user-avatar with e.g. an icon;
+
+* a default slot which is for the content of the popover (this is passed to the popover component directly).
+
+### Examples
+
+```vue
+<template>
+	<p>
+		Some text before
+		<user-bubble :user="'admin'" :displayName="'Admin Example'" :url="'/test'" >
+  			@admin@foreign-host.com
+		</user-bubble>
+		 and after the bubble.
+	</p>
+</template>
+```
+</docs>
+
 <template>
 	<Popover trigger="hover focus" :open="open" :disabled="popoverEmpty"
 		class="user-bubble-popover" @update:open="onOpenChange">

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -38,10 +38,10 @@ This component has the following slot:
 <template>
 	<p>
 		Some text before
-		<user-bubble :user="'admin'" :displayName="'Admin Example'" :url="'/test'" :primary="true" >
+		<user-bubble :user="'admin'" :displayName="'Admin Example'" :url="'/test'">
 			@admin@foreign-host.com
 		</user-bubble>
-		and after the bubble.
+		and after the bubble. <user-bubble :avatarImage="'icon-group'" :displayName="'test group xy'" :primary="true">Hey there!</user-bubble>
 	</p>
 </template>
 ```

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -38,7 +38,7 @@ This component has the following slot:
 <template>
 	<p>
 		Some text before
-		<user-bubble :user="'admin'" :displayName="'Admin Example'" :url="'/test'" >
+		<user-bubble :user="'admin'" :displayName="'Admin Example'" :url="'/test'" :primary="true" >
 			@admin@foreign-host.com
 		</user-bubble>
 		and after the bubble.
@@ -49,7 +49,8 @@ This component has the following slot:
 <template>
 	<Popover trigger="hover focus" :open="open" :disabled="popoverEmpty"
 		class="user-bubble-popover" @update:open="onOpenChange">
-		<div slot="trigger" v-bind="linkOrNot" class="user-bubble">
+		<div slot="trigger" v-bind="linkOrNot" class="user-bubble"
+			:class="primary ? 'user-bubble-primary' : ''">
 			<Avatar :url="!isUserAvatar && isIconUrl ? avatarImage : ''"
 				:icon-class="!isUserAvatar && !isIconUrl ? avatarImage : ''"
 				:user="isUserAvatar ? user : ''" :size="16" :disable-tooltip="true"
@@ -90,6 +91,10 @@ export default {
 			default: ''
 		},
 		open: {
+			type: Boolean,
+			default: false
+		},
+		primary: {
 			type: Boolean,
 			default: false
 		}
@@ -148,6 +153,11 @@ export default {
 	height: 20px;
 	border-radius: 10px;
 	background-color: var(--color-background-dark);
+}
+
+.user-bubble-primary {
+	color: var(--color-primary-text);
+	background-color: var(--color-primary-element);
 }
 
 h6 {

--- a/src/components/UserBubble/index.js
+++ b/src/components/UserBubble/index.js
@@ -1,0 +1,26 @@
+/**
+ * @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import UserBubble from './UserBubble'
+
+export default UserBubble
+export { UserBubble }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -50,6 +50,7 @@ import Multiselect from './Multiselect'
 import Popover from './Popover'
 import PopoverMenu from './PopoverMenu'
 import ColorPicker from './ColorPicker'
+import UserBubble from './UserBubble'
 
 export {
 	ActionButton,
@@ -81,5 +82,6 @@ export {
 	Multiselect,
 	Popover,
 	PopoverMenu,
-	ColorPicker
+	ColorPicker,
+	UserBubble
 }


### PR DESCRIPTION
introduces a new UserBubble component to be used e.g. for @-mentions in social or talk
it features an optional popover to e.g. display the full username-handle for remote users in social

it should also be possible to link the UserBubble to the user's profile (social), but I'd like to have this optional, but didn't manage to do this, because the `<a>` element would need to wrap the whole bubble and therefore I can't just use `v-if` on it. Any idea @skjnldsv or @ma12-co ?