### PR TITLE
Adjust font size of navigation elements

### DIFF
--- a/src/components/AppNavigationCounter/AppNavigationCounter.vue
+++ b/src/components/AppNavigationCounter/AppNavigationCounter.vue
@@ -67,6 +67,7 @@ export default {
 	text-align: center;
 	text-overflow: ellipsis;
 	line-height: 1em;
+	font-size: 0.8125rem; //13px with root font size set at 16px
 
 	&--highlighted {
 		padding: 4px 6px;

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -398,6 +398,7 @@ export default {
 	box-sizing: border-box;
 	width: 100%;
 	min-height: $clickable-area;
+	font-size: 0.875rem; //14px with root font size set at 16px
 
 	&.active,
 	a:hover,


### PR DESCRIPTION
As a result of the increment of the body's font-size to 15px, the navigation elements were too big. This pr brings the navigation item's titles down to 14px and the counter's text back down to 13px.

Before: 
![Screenshot_20190930_103302](https://user-images.githubusercontent.com/26852655/65866682-85624700-e375-11e9-9225-3acc2044d1f6.png)

After (you can see how nav sizes and content size relate to each other):
![Screenshot_20190930_105219](https://user-images.githubusercontent.com/26852655/65866785-ba6e9980-e375-11e9-8941-0355e5873774.png)



Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>