### PR TITLE
Make "more icon" of actions customizable

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -72,6 +72,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 		<!-- If more than one action, create a popovermenu -->
 		<a v-click-outside="closeMenu"
 			class="icon action-item__menutoggle"
+			:class="defaultIcon"
 			href="#" aria-haspopup="true"
 			:aria-controls="randomId"
 			:aria-expanded="opened"
@@ -151,6 +152,14 @@ export default {
 			validator: align => {
 				return ['left', 'center', 'right'].indexOf(align) > -1
 			}
+		},
+		/**
+		 * Specify the icon to be shown as placeholder
+		 * when more than one action is inside the actions component
+		 */
+		defaultIcon: {
+			type: String,
+			default: 'action-item__menutoggle--default-icon'
 		}
 	},
 
@@ -467,9 +476,10 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 
 		opacity: $opacity_normal;
 
-		font-size: $icon-size;
-
-		@include iconfont('more');
+		&--default-icon {
+			font-size: $icon-size;
+			@include iconfont('more');
+		}
 	}
 
 	&--single {


### PR DESCRIPTION
Default:
![16C35659-0F6C-4319-AA8B-EDBB846C7807](https://user-images.githubusercontent.com/1250540/66036957-d78aa000-e50e-11e9-9254-527db57b5181.png)

Custom icon:
![98A0FCCB-088B-45FD-B29E-1D19145DB3E2](https://user-images.githubusercontent.com/1250540/66037090-25070d00-e50f-11e9-9bb5-5a16690d554b.png)

fixes #618
