### PR TITLE
Allow to close the actions menu after click

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -27,7 +27,7 @@ This component is made to be used inside of the [Actions](#Actions) component sl
 ```vue
 	<Actions>
 		<ActionButton icon="icon-delete" @click="alert('Delete')">Delete</ActionButton>
-		<ActionButton icon="icon-delete" @click="alert('Delete')">Delete</ActionButton>
+		<ActionButton icon="icon-delete" :close-after-click="true" @click="alert('Delete and close menu')">Delete and close</ActionButton>
 		<ActionButton icon="icon-delete" :disabled="true" @click="alert('Disabled')">Disabled button</ActionButton>
 	</Actions>
 ```

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -21,6 +21,7 @@
  *
  */
 import actionGlobal from './actionGlobal'
+import GetParent from 'Utils/GetParent'
 
 export default {
 	mixins: [actionGlobal],
@@ -68,7 +69,10 @@ export default {
 			this.$emit('click', event)
 
 			if (this.closeAfterClick) {
-				this.$parent.closeMenu()
+				const parent = GetParent(this, 'Actions')
+				if (parent) {
+					parent.closeMenu()
+				}
 			}
 		}
 	}

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -39,6 +39,13 @@ export default {
 		title: {
 			type: String,
 			default: ''
+		},
+		/**
+		 * Whether we close the Actions menu after the click
+		 */
+		closeAfterClick: {
+			type: Boolean,
+			default: false
 		}
 	},
 
@@ -59,6 +66,10 @@ export default {
 			 * @type {Event}
 			 */
 			this.$emit('click', event)
+
+			if (this.closeAfterClick) {
+				this.$parent.closeMenu()
+			}
 		}
 	}
 }

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -70,7 +70,7 @@ export default {
 
 			if (this.closeAfterClick) {
 				const parent = GetParent(this, 'Actions')
-				if (parent) {
+				if (parent && parent.closeMenu) {
 					parent.closeMenu()
 				}
 			}


### PR DESCRIPTION
Implements #615

Since it is apparently not possible to listen for an emitted event on a slot (https://github.com/vuejs/vue/issues/4332), I just call the `closeMenu` method of the  `Actions` component directly from the `ActionButton`. I guess this is ok, since an `ActionButton` will always have an `Actions` component as parent.

Also, it is working as expected 😉 