### PR TITLE
Fix different height of actions with custom icon

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -476,6 +476,10 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 
 		opacity: $opacity_normal;
 
+		&:before {
+			content: '';
+		}
+
 		&--default-icon {
 			font-size: $icon-size;
 			@include iconfont('more');

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -42,6 +42,16 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 	<ActionLink icon="icon-external" title="Link" href="https://nextcloud.com" />
 </Actions>
 ```
+
+### Multiple actions with custom icon
+
+```
+<Actions default-icon="icon-edit">
+	<ActionButton icon="icon-edit" @click="alert('Edit')">Edit</ActionButton>
+	<ActionButton icon="icon-delete" @click="alert('Delete')">Delete</ActionButton>
+	<ActionLink icon="icon-external" title="Link" href="https://nextcloud.com" />
+</Actions>
+```
 </docs>
 <template>
 	<!-- if only one action, check if we need to bind to click or not -->
@@ -154,8 +164,9 @@ export default {
 			}
 		},
 		/**
-		 * Specify the icon to be shown as placeholder
-		 * when more than one action is inside the actions component
+		 * Icon to show for the toggle menu button
+		 * when more than one action is inside the actions component.
+		 * Only replace the default three-dot icon if really necessary.
 		 */
 		defaultIcon: {
 			type: String,


### PR DESCRIPTION
With #619 the actions menu causes a parent element to have a larger height than without a custom icon (custom icon on second Actions):
![Screenshot_2019-10-03 Inventar - Nextcloud](https://user-images.githubusercontent.com/2496460/66112727-ae7c1500-e5cb-11e9-860c-9cc146d5f55f.png)

This PR fixes this issue:
![Screenshot_2019-10-03 Inventar - Nextcloud(1)](https://user-images.githubusercontent.com/2496460/66112795-d0759780-e5cb-11e9-8da7-34d9d36af37b.png)
