### PR TITLE
Fix position of actions when repeatedly opened

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -299,6 +299,8 @@ export default {
 				 * @type {null}
 				 */
 				this.$emit('open')
+			} else {
+				this.offsetX = 0
 			}
 
 			/**


### PR DESCRIPTION
When you open and close an Actions menu which is on the edge of the viewport (e.g. top right) repeatedly by clicking on the action toggle button (not by clicking outside), the position of the dropdown menu is wrong for every second opening. This PR fixes it.