### PR TITLE
Only set the width when tags wrap is actually available

### DIFF
--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -361,7 +361,7 @@ export default {
 		 */
 		updateWidth() {
 			// width of the tags wrapper minus the padding
-			if (this.$el) {
+			if (this.$el && this.$el.querySelector('.multiselect__tags-wrap')) {
 				this.elWidth = this.$el.querySelector('.multiselect__tags-wrap').offsetWidth - 10
 			}
 		}


### PR DESCRIPTION
Fixes a console error when using a multiselect with the following attributes without tagging:

			:multiple="true"
			:auto-limit="false"
			