### PR TITLE
Mark dependencies as webpack externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14499,6 +14499,12 @@
         }
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
 		"vue-template-compiler": "^2.6.7",
 		"webpack": "^4.29.5",
 		"webpack-cli": "^3.2.3",
-		"webpack-merge": "^4.2.1"
+		"webpack-merge": "^4.2.1",
+		"webpack-node-externals": "^1.7.2"
 	},
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,6 +8,8 @@ const IconfontName = 'iconfont-vue'
 
 const { DefinePlugin } = require('webpack')
 
+const nodeExternals = require('webpack-node-externals')
+
 // scope variable
 const md5 = require('md5')
 const PACKAGE = require('./package.json')
@@ -40,24 +42,9 @@ module.exports = {
 		library: ['NextcloudVue', '[name]'],
 		umdNamedDefine: true
 	},
-	externals: {
-		vue: {
-			commonjs: 'vue',
-			commonjs2: 'vue',
-			amd: 'vue',
-			root: 'Vue'
-		},
-		'@nextcloud/axios': '@nextcloud/axios',
-		'escape-html': 'escape-html',
-		'hammerjs': 'hammerjs',
-		'md5': 'md5',
-		'v-click-outside': 'v-click-outside',
-		'v-tooltip': 'v-tooltip',
-		'vue-color': 'vue-color',
-		'vue-multiselect': 'vue-multiselect',
-		'vue-visible': 'vue-visible',
-		'vue2-datepicker': 'vue2-datepicker'
-	},
+	externals: [
+		nodeExternals()
+	],
 	module: {
 		rules: [
 			{

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -46,7 +46,17 @@ module.exports = {
 			commonjs2: 'vue',
 			amd: 'vue',
 			root: 'Vue'
-		}
+		},
+		'@nextcloud/axios': '@nextcloud/axios',
+		'escape-html': 'escape-html',
+		'hammerjs': 'hammerjs',
+		'md5': 'md5',
+		'v-click-outside': 'v-click-outside',
+		'v-tooltip': 'v-tooltip',
+		'vue-color': 'vue-color',
+		'vue-multiselect': 'vue-multiselect',
+		'vue-visible': 'vue-visible',
+		'vue2-datepicker': 'vue2-datepicker'
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
This PR adds the external dependencies we use to the webpack externals list, so they are not included in the bundle. Since they are part of the dependency section they will still be installed by npm when app developers install our package and webpack will take care of resolving them properly then.

Before
![image](https://user-images.githubusercontent.com/3404133/67329646-6f324b80-f51b-11e9-84a1-6e4b57983897.png)

After
![image](https://user-images.githubusercontent.com/3404133/67329690-7d806780-f51b-11e9-8a31-6de649c119c5.png)

The size of the saving in the app bundles of course depends on which components are used, but when using multiple components that include the usage of v-tooltip, popper.js will only be included once with this PR.

A quick test run on the deck vue branch saved me ~300kb in duplicate dependencies.