### PR TITLE
Add @babel/runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1198,15 +1198,6 @@
         }
       }
     },
-    "@babel/polyfill": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
-      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
@@ -1286,10 +1277,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
-      "dev": true,
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -3511,7 +3501,8 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@babel/polyfill": "^7.4.4",
+		"@babel/runtime": "^7.6.3",
 		"@nextcloud/axios": "^0.4.0",
 		"escape-html": "^1.0.3",
 		"hammerjs": "^2.0.8",


### PR DESCRIPTION
Fixes #691 

According to https://babeljs.io/docs/en/babel-plugin-transform-runtime @babel/plugin-transform-runtime requires @babel/runtime as a production dependency. 

@skjnldsv @ChristophWurst I though babel/polyfill should no longer be needed. Still seems to work fine with IE11 if the app is taking care of a proper babel tranformation. It was not imported in @nextcloud/vue anyway.