### PR TITLE
remove menu button

### DIFF
--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -62,7 +62,7 @@ export default {
 // mobile only
 @media only screen and (max-width: 768px) {
 	#app-navigation-toggle {
-		display: inline-block !important;
+		display: none !important;
 	}
 }
 </style>


### PR DESCRIPTION
ref #[2110](https://github.com/nextcloud/mail/issues/2110)
On narrow screens, the message view has both a menu button and a back arrow button. In this view only the back arrow button is necessary and it should be in place of the menu button.