### PR TITLE
🐛 FIX: exact-active-class support to not always highlight root element as active

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -3,6 +3,7 @@
   -
   - @author John Molakvoæ <skjnldsv@protonmail.com>
   - @author Marco Ambrosini <marcoambrosini@pm.me>
+  - @author Jonas Sulzer <jonas@violoncello.ch>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -340,7 +341,7 @@ export default {
 					is: 'router-link',
 					tag: 'li',
 					to: this.to,
-					exact: this.exactRoute
+					exact: this.exact
 				}
 			}
 			return {


### PR DESCRIPTION
properly pass the exact prop to the `router-link`