### PR TITLE
🐛 FIX: allow proper linebreak in multiselect for narrow mobile screens

### DIFF
--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -63,7 +63,7 @@
 		cursor: pointer;
 		position: relative;
 		border-radius: 3px;
-		height: 34px;
+		min-height: 34px;
 		/* tag wrapper */
 		.multiselect__tags-wrap {
 			align-items: center;


### PR DESCRIPTION
e.g. in Mail app
![image](https://user-images.githubusercontent.com/22591354/68404558-08e63380-017f-11ea-9eee-42685b26b230.png)
vs
![image](https://user-images.githubusercontent.com/22591354/68404638-2915f280-017f-11ea-93be-03a34f97cdf6.png)
