### PR TITLE
Remove the background on loaded images

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -257,7 +257,7 @@ export default {
 				fontSize: Math.round(this.size * 0.55) + 'px'
 			}
 
-			if (!this.iconClass) {
+			if (!this.iconClass && !this.avatarSrcSetLoaded) {
 				const rgb = uidToColor(this.getUserIdentifier)
 				style.backgroundColor = 'rgb(' + rgb.r + ', ' + rgb.g + ', ' + rgb.b + ')'
 			}


### PR DESCRIPTION
Upload an avatar with transparency, e.g.:
![2019_cfhn1](https://user-images.githubusercontent.com/213943/68432469-c3dcf400-01b4-11ea-84ee-75674cc0fec2.png)


Before | After
---|---
![Bildschirmfoto von 2019-11-07 23-16-49](https://user-images.githubusercontent.com/213943/68432513-e242ef80-01b4-11ea-9482-bbabca89a33f.png) | ![Bildschirmfoto von 2019-11-07 23-15-53](https://user-images.githubusercontent.com/213943/68432524-e4a54980-01b4-11ea-97a1-ed2fd980bff8.png)

(Dont mind the icon being smaller, its from the transparent space around it.)
