### PR TITLE
AppNavigationItem: improve edit functionality

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -154,8 +154,8 @@ Just set the `pinned` prop.
 
 		<!-- edit entry -->
 		<div v-if="editing" class="app-navigation-entry__edit">
-			<form @submit.prevent="handleRename">
-				<input v-model="newTitle" ref="inputTitle" type="text"
+			<form @submit.prevent="handleRename" @keydown.esc.exact.prevent="cancelEdit">
+				<input ref="inputTitle" v-model="newTitle" type="text"
 					class="app-navigation-entry__edit-input"
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
 				<button type="submit" class="icon-confirm"

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -155,7 +155,7 @@ Just set the `pinned` prop.
 		<!-- edit entry -->
 		<div v-if="editing" class="app-navigation-entry__edit">
 			<form @submit.prevent="handleRename">
-				<input v-model="newTitle" type="text"
+				<input v-model="newTitle" ref="inputTitle" type="text"
 					class="app-navigation-entry__edit-input"
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
 				<button type="submit" class="icon-confirm"
@@ -393,6 +393,9 @@ export default {
 			this.newTitle = this.title
 			this.editing = true
 			this.onMenuToggle(false)
+			this.$nextTick(() => {
+				this.$refs.inputTitle.focus()
+			})
 		},
 		cancelEdit() {
 			this.editing = false


### PR DESCRIPTION
- [x] add label for edit mode's action button (important if there are other actions)
- [x] close actions menu when switching to edit mode
- [x] use current title as default in input field
- [x] autofocus input field
- [x] don't show other actions in edit mode (this broke the design)
- [x] accessibility: cancel edit mode on pressing ESC