### PR TITLE
new component: ActionSeparator

### DIFF
--- a/src/components/ActionSeparator/ActionSeparator.vue
+++ b/src/components/ActionSeparator/ActionSeparator.vue
@@ -1,0 +1,43 @@
+<!--
+  - @copyright Copyright (c) 2019 Nextcloud et al.
+  -
+  - @author John Molakvoæ <skjnldsv@protonmail.com>
+  - @author Marco Ambrosini <marcoambrosini@pm.me>
+  - @author Kristof Hamann
+  - @author Joas Schilling <coding@schilljs.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<li class="action-separator action--disabled" />
+</template>
+
+<script>
+export default {
+	name: 'ActionSeparator'
+}
+</script>
+
+<style lang="scss" scoped>
+.action-separator {
+	height: 0;
+	margin: 5px 10px 5px 15px;
+	border-bottom: 1px solid var(--color-border-dark);
+	cursor: default;
+}
+</style>

--- a/src/components/ActionSeparator/index.js
+++ b/src/components/ActionSeparator/index.js
@@ -1,0 +1,25 @@
+/**
+ * @copyright Copyright (c) 2019 Nextcloud et al.
+ *
+ * @author Kristof Hamann
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import ActionSeparator from './ActionSeparator'
+
+export default ActionSeparator
+export { ActionSeparator }

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -122,6 +122,7 @@ const allowedChildren = [
 	'ActionLink',
 	'ActionRadio',
 	'ActionRouter',
+	'ActionSeparator',
 	'ActionText',
 	'ActionTextEditable'
 ]

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import ActionInput from './ActionInput'
 import ActionLink from './ActionLink'
 import ActionRadio from './ActionRadio'
 import ActionRouter from './ActionRouter'
+import ActionSeparator from './ActionSeparator'
 import ActionText from './ActionText'
 import ActionTextEditable from './ActionTextEditable'
 import Actions from './Actions'
@@ -60,6 +61,7 @@ export {
 	ActionLink,
 	ActionRadio,
 	ActionRouter,
+	ActionSeparator,
 	ActionText,
 	ActionTextEditable,
 	Actions,


### PR DESCRIPTION
Add new component for a separator between actions. This is already used in the talk app (see https://github.com/nextcloud/nextcloud-vue/issues/376 and https://github.com/nextcloud/spreed/blob/bc978f1d9808f898232e35c204a92985dcc25649/src/components/Navigation/ConversationsList/Conversation.vue#L50) and I would like to use it in notes. Hence, a generalization would be good.

![Screenshot](https://user-images.githubusercontent.com/6277619/68535004-d46ba680-033b-11ea-9fc0-632b296cb462.png)
