### PR TITLE
Fix icon font generation

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,7 +4,6 @@ const { VueLoaderPlugin } = require('vue-loader')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
 
 const IconfontPlugin = require('iconfont-plugin-webpack')
-const IconfontName = 'iconfont-vue'
 
 const { DefinePlugin } = require('webpack')
 
@@ -12,8 +11,12 @@ const nodeExternals = require('webpack-node-externals')
 
 // scope variable
 const md5 = require('md5')
-const PACKAGE = require('./package.json')
-const SCOPE_VERSION = JSON.stringify(md5(PACKAGE.version).substr(0, 7))
+const appVersion = JSON.stringify(process.env.npm_package_version)
+const versionHash = md5(appVersion).substr(0, 7)
+const SCOPE_VERSION = JSON.stringify(versionHash)
+const ICONFONT_NAME = `iconfont-vue-${versionHash}`
+
+console.info('This build version hash is', versionHash, '\n')
 
 module.exports = {
 	entry: {
@@ -95,10 +98,10 @@ module.exports = {
 	plugins: [
 		new IconfontPlugin({
 			src: './src/assets/iconfont',
-			family: IconfontName,
+			family: ICONFONT_NAME,
 			dest: {
 				font: './src/fonts/[family].[type]',
-				css: './src/fonts/scss/[family].scss'
+				css: './src/fonts/scss/iconfont-vue.scss'
 			},
 			watch: {
 				pattern: './src/assets/iconfont/*.svg'


### PR DESCRIPTION
Because the font name was the same over all versions, loading multiple nextcloud-vue components versions on the same page was causing conflicts.
Example: the close icon on the viewer

This is now fixed.
