### PR TITLE
Mobile fixes for Viewer header

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -499,7 +499,7 @@ $header-size: 50px;
 		overflow-x: hidden;
 		box-sizing: border-box;
 		width: 100%;
-		padding: 0 #{$clickable-area * 3} 0 12px; // maximum actions is 2 but we violate it here
+		padding: 0 #{$clickable-area * 3} 0 12px; // maximum actions is 3
 		transition: padding ease 100ms;
 		white-space: nowrap;
 		text-overflow: ellipsis;
@@ -511,7 +511,7 @@ $header-size: 50px;
 	@media only screen and (min-width: $breakpoint-mobile/2) {
 		.modal-title {
 			text-align: center;
-			padding-left: #{$clickable-area * 3}; // maximum actions is 2 but we violate it here
+			padding-left: #{$clickable-area * 3}; // maximum actions is 3
 		}
 	}
 

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -74,12 +74,6 @@ export default {
 						{{ title }}
 					</div>
 					<div class="icons-menu">
-						<!-- Actions menu -->
-						<Actions class="header-actions">
-							<!-- @slot List of actions to show -->
-							<slot name="actions" />
-						</Actions>
-
 						<!-- Play-pause toggle -->
 						<button v-if="hasNext && enableSlideshow"
 							v-tooltip.auto="playPauseTitle"
@@ -102,6 +96,12 @@ export default {
 									r="15" cx="25" cy="25" />
 							</svg>
 						</button>
+
+						<!-- Actions menu -->
+						<Actions class="header-actions">
+							<!-- @slot List of actions to show -->
+							<slot name="actions" />
+						</Actions>
 
 						<!-- Close modal -->
 						<Actions v-if="canClose" class="header-close">

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -498,13 +498,21 @@ $header-size: 50px;
 	.modal-title {
 		overflow-x: hidden;
 		box-sizing: border-box;
-		max-width: 100%;
-		padding: 0 #{$clickable-area * 2}; // maximum actions is 2
+		width: 100%;
+		padding: 0 #{$clickable-area * 3} 0 12px; // maximum actions is 2 but we violate it here
 		transition: padding ease 100ms;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		color: #fff;
 		font-size: $icon-margin;
+	}
+
+	// On wider screens the title can be centered
+	@media only screen and (min-width: $breakpoint-mobile/2) {
+		.modal-title {
+			text-align: center;
+			padding-left: #{$clickable-area * 3}; // maximum actions is 2 but we violate it here
+		}
 	}
 
 	.icons-menu {

--- a/styleguide/assets/variables.css
+++ b/styleguide/assets/variables.css
@@ -20,6 +20,7 @@
     --color-box-shadow:rgba(77, 77, 77, 0.5);
     --color-border:#ededed;
     --color-border-dark:#dbdbdb;
+    --breakpoint-mobile:1024px;
     --border-radius:3px;
     --border-radius-large:10px;
     --border-radius-pill:100px;


### PR DESCRIPTION
Fix position of action elements by moving the sidebar toggle to the right, and fix title overlap on mobile screens.

## Before
![Viewer header before](https://user-images.githubusercontent.com/925062/70500095-40187d80-1b4d-11ea-8c82-f9be479ca089.png)

## After
![Viewer header after](https://user-images.githubusercontent.com/925062/70500096-40b11400-1b4d-11ea-8226-fe6536ac8ca6.png)
