### PR TITLE
Update vue2-datepicker to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"vue-color": "^2.7.0",
 		"vue-multiselect": "^2.1.3",
 		"vue-visible": "^1.0.2",
-		"vue2-datepicker": "^2.10.0"
+		"vue2-datepicker": "^3.2.0"
 	},
 	"engines": {
 		"node": ">=10.0.0"


### PR DESCRIPTION
The vue2-datepicker ist outdated and so the documentation. Would be great, if we could update this, but some props  (especially the lang settings) have changed. 