### PR TITLE
Allow non user mention bubbles

### DIFF
--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -84,7 +84,7 @@ export default {
 		},
 		user: {
 			type: String,
-			required: true
+			default: ''
 		},
 		displayName: {
 			type: String,


### PR DESCRIPTION
Fix #796 

before when you mentioned a guest or "all" in a chat you got spammed by:
```
[Vue warn]: Missing required prop: "user"

found in

---> <UserBubble> at src/components/UserBubble/UserBubble.vue
       <Mention> at src/components/MessagesList/MessagesGroup/Message/MessagePart/Mention.vue
```