### PR TITLE
Forward potential events to close and open

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -311,7 +311,7 @@ export default {
 
 	methods: {
 		// MENU STATE MANAGEMENT
-		toggleMenu() {
+		toggleMenu(e) {
 			this.opened = !this.opened
 			// focus first on menu open after opening the menu
 			if (this.opened) {
@@ -323,7 +323,7 @@ export default {
 				 * Event emitted when the popover menu is opened
 				 * @type {null}
 				 */
-				this.$emit('open')
+				this.$emit('open', e)
 			} else {
 				this.offsetX = 0
 				this.offsetY = 0
@@ -337,7 +337,7 @@ export default {
 			 */
 			this.$emit('update:open', this.opened)
 		},
-		closeMenu() {
+		closeMenu(e) {
 			/**
 			 * only emit events if it was opened
 			 * or else any click on the page will trigger
@@ -353,7 +353,7 @@ export default {
 				 * Event emitted when the popover menu is closed
 				 * @type {null}
 				 */
-				this.$emit('close')
+				this.$emit('close', e)
 
 			}
 


### PR DESCRIPTION
That way we allow devs to check what triggered the close or open
Click outside, pressed escape...