### PR TITLE
Make sure tabs can have a unique id that is not depending on the name

### DIFF
--- a/src/components/AppSidebarTab/AppSidebarTab.vue
+++ b/src/components/AppSidebarTab/AppSidebarTab.vue
@@ -39,6 +39,10 @@ export default {
 	name: 'AppSidebarTab',
 
 	props: {
+		id: {
+			type: String,
+			default: () => this.name.toLowerCase().replace(/ /g, '-')
+		},
 		name: {
 			type: String,
 			default: '',
@@ -57,9 +61,6 @@ export default {
 	},
 
 	computed: {
-		id() {
-			return this.name.toLowerCase().replace(/ /g, '-')
-		},
 		isActive() {
 			return this.$parent.activeTab === this.id
 		}


### PR DESCRIPTION
Tab names are usually translated so they are a pretty bad id in general. This PR makes sure that the id can be set as a separate prop.