### PR TITLE
Fix Tab default values

### DIFF
--- a/src/components/AppSidebarTab/AppSidebarTab.vue
+++ b/src/components/AppSidebarTab/AppSidebarTab.vue
@@ -41,22 +41,19 @@ export default {
 	props: {
 		id: {
 			type: String,
-			default: () => this.name.toLowerCase().replace(/ /g, '-')
+			required: true
 		},
 		name: {
 			type: String,
-			default: '',
 			required: true
 		},
 		icon: {
 			type: String,
-			default: '',
 			required: true
 		},
 		order: {
 			type: Number,
-			default: 0,
-			required: false
+			default: 0
 		}
 	},
 


### PR DESCRIPTION
After #833 

```
vue.runtime.esm.js:1888 TypeError: Cannot read property 'name' of undefined
    at a.default (AppSidebarTab.js:formatted:1)
    at vue.runtime.esm.js:1666
    at Pt (vue.runtime.esm.js:1619)
    at i (vue.runtime.esm.js:4665)
    at vue.runtime.esm.js:4698
    at gn (vue.runtime.esm.js:4639)
    at a.t._init (vue.runtime.esm.js:5006)
    at new a (vue.runtime.esm.js:5154)
    at vue.runtime.esm.js:3283
    at init (vue.runtime.esm.js:3114)
```