### PR TITLE
Switch month and year arrow icons

### DIFF
--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -151,19 +151,19 @@ $cell_height: 32px;
 
 			}
 			&.mx-icon-last-year {
-				@include iconfont('arrow-left');
-			}
-			&.mx-icon-last-month {
 				@include iconfont('arrow-left-double');
 			}
+			&.mx-icon-last-month {
+				@include iconfont('arrow-left');
+			}
 			&.mx-icon-next-month {
-				@include iconfont('arrow-right-double');
+				@include iconfont('arrow-right');
 				// arrows are all before month and year
 				// send them to the end of the row
 				order: 3;
 			}
 			&.mx-icon-next-year {
-				@include iconfont('arrow-right');
+				@include iconfont('arrow-right-double');
 				// arrows are all before month and year
 				// send them to the end of the row
 				order: 4;


### PR DESCRIPTION
Solves https://github.com/nextcloud/nextcloud-vue/issues/859

The arrow icons in the datepicker seem to be switched.
There are two types of arrow: single and double.
Based on the length of a year and a month one would expect the "next month" arrow to be single and the "next year" arrow to be double. This was not the case, this MR fixes this.