### PR TITLE
Fix appnavigationitem's active state

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -430,6 +430,12 @@ export default {
 	box-sizing: border-box;
 	width: 100%;
 	min-height: $clickable-area;
+	// When .active class is applied, change color background of link and utils. The
+	// !important prevents the focus state to override the active state.
+	&.active > a,
+	&.active > a ~ .app-navigation-entry__utils {
+		background-color: var(--color-primary-light) !important;
+	}
 
 	/* hide deletion/collapse of subitems */
 	&.app-navigation-entry--deleted,


### PR DESCRIPTION
### How to test:
1) Open an app that uses the appnavigationitem component;
2) Click on a navigation item (the .active class should be added to the wrapping `<li>`);

### Before this pr: 
The item was not highlighted in light primary color.

### After this pr: 
The item is properly highlighted.