### PR TITLE
Don't throw error for users without email adress

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -314,14 +314,14 @@ export default {
 		this.loadAvatarUrl()
 	},
 	methods: {
-		toggleMenu() {
+		async toggleMenu() {
 			if (!this.hasMenu) {
 				return
 			}
-			this.contactsMenuOpenState = !this.contactsMenuOpenState
-			if (this.contactsMenuOpenState) {
-				this.fetchContactsMenu()
+			if (!this.contactsMenuOpenState) {
+				await this.fetchContactsMenu()
 			}
+			this.contactsMenuOpenState = !this.contactsMenuOpenState
 		},
 		closeMenu() {
 			this.contactsMenuOpenState = false
@@ -500,7 +500,7 @@ export default {
 	.popovermenu {
 		display: block;
 		margin: 0;
-		font-size: initial;
+		font-size: 14px;
 	}
 }
 

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -330,7 +330,7 @@ export default {
 			try {
 				const user = encodeURIComponent(this.user)
 				const { data } = await axios.post(OC.generateUrl('contactsmenu/findOne'), `shareType=0&shareWith=${user}`)
-				this.contactsMenuActions = [data.topAction].concat(data.actions)
+				this.contactsMenuActions = data.topAction ? [data.topAction].concat(data.actions) : data.actions
 			} catch (e) {
 				this.contactsMenuOpenState = false
 			}


### PR DESCRIPTION
Closes #699 

For users without email adress `data.topAction` is `null`. Doing `[data.topAction].concat(data.actions)` then didn't result in an empty array as expected, but in an array with one entry being `null`.

I also first query the available actions before opening the menu now, otherwise a white arrow would shortly be visible for users without actions. And I adjusted the font-size of the action entry to 14px, so far it was 18 px which was to big.

@juliushaertl @georgehrke 