### PR TITLE
Add breadcrumb component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7248,6 +7248,11 @@
 			"integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
 			"dev": true
 		},
+		"debounce": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+			"integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+		},
 		"debug": {
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"@nextcloud/l10n": "^1.1.0",
 		"@nextcloud/router": "^1.0.0",
 		"core-js": "^3.4.4",
+		"debounce": "1.2.0",
 		"escape-html": "^1.0.3",
 		"hammerjs": "^2.0.8",
 		"md5": "^2.2.1",

--- a/src/assets/iconfont/breadcrumb.svg
+++ b/src/assets/iconfont/breadcrumb.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 44" width="14" version="1.1" height="44"><path d="m1.3 0-1.3 0.75 12.27 21.25-12.27 21.25 1.3 0.75 12.7-22z"/></svg>

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -1,0 +1,203 @@
+<!--
+ - @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<docs>
+
+### General description
+
+This component is meant to be used inside a Breadcrumbs component.
+
+</docs>
+
+<template>
+	<div ref="crumb"
+		class="crumb"
+		:class="{'crumb--with-action': $slots.default, 'crumb--hovered': hovering}"
+		draggable="false"
+		@dragstart.prevent="() => {/** Prevent the breadcrumb from being draggable. */}"
+		@drop.prevent="dropped"
+		@dragover.prevent="() => {}"
+		@dragenter="dragEnter"
+		@dragleave="dragLeave">
+		<element :is="tag" :to="to" :href="href">
+			<span v-if="icon" :class="icon" class="icon" />
+			<span v-else>{{ title }}</span>
+		</element>
+		<Actions :force-menu="forceMenu">
+			<!-- @slot All action elements passed into the default slot will be used -->
+			<slot />
+		</Actions>
+	</div>
+</template>
+
+<script>
+import Actions from '../Actions'
+
+export default {
+	name: 'Breadcrumb',
+	components: {
+		Actions,
+	},
+	props: {
+		/**
+		 * The displayed title of the breadcrumb.
+		 */
+		title: {
+			type: String,
+			required: true,
+		},
+		/**
+		 * The router-link to prop [https://router.vuejs.org/api/#to](https://router.vuejs.org/api/#to)
+		 * If set, the breadcrumbs will be rendered by router-link.
+		 */
+		to: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Set this prop if your app doesn't use vue-router, breadcrumbs will show as normal links.
+		 */
+		href: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Set a css icon-class to show an icon instead of the title text.
+		 */
+		icon: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Disable dropping on this breadcrumb.
+		 */
+		disableDrop: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * Force the actions to display in a three dot menu
+		 */
+		forceMenu: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			/**
+			 * Variable to track if we hover over the breadcrumb
+			 */
+			hovering: false,
+		}
+	},
+	computed: {
+		/**
+		 * Determines which element tag to use
+		 *
+		 * @returns {String} the tag
+		 */
+		tag() {
+			return this.to ? 'router-link' : 'a'
+		},
+	},
+	methods: {
+		/**
+		 * Function to handle a drop on the breadcrumb.
+		 * $emit the event and the path, remove the hovering state.
+		 *
+		 * @param {Object} e The drop event
+		 * @returns {boolean}
+		 */
+		dropped(e) {
+			/**
+			 * Don't do anything if dropping is disabled.
+			 */
+			if (this.disableDrop) {
+				return false
+			}
+			/**
+			 * Event emitted when something is dropped on the breadcrumb.
+			 * @type {null}
+			 */
+			this.$emit('dropped', e, this.to || this.href)
+			this.$parent.$emit('dropped', e, this.to || this.href)
+			this.hovering = false
+			return false
+		},
+		/**
+		 * Add the hovering state on drag enter
+		 *
+		 * @param {Object} e The drag enter event
+		 */
+		dragEnter(e) {
+			/**
+			 * Don't do anything if dropping is disabled.
+			 */
+			if (this.disableDrop) {
+				return
+			}
+			this.hovering = true
+		},
+		/**
+		 * Remove the hovering state on drag leave
+		 *
+		 * @param {Object} e The drag leave event
+		 */
+		dragLeave(e) {
+			/**
+			 * Don't do anything if dropping is disabled.
+			 */
+			if (this.disableDrop) {
+				return
+			}
+			// Don't do anything if we
+			// - leave towards a child element.
+			// - or are still within the crumb
+			if (e.target.contains(e.relatedTarget)
+				|| this.$refs.crumb.contains(e.relatedTarget)) {
+				return
+			}
+			this.hovering = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.breadcrumb div.crumb {
+	&--with-action a {
+		padding-right: 2px;
+	}
+
+	a {
+		align-items: center;
+		display: inline-flex;
+
+		> span {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+}
+</style>

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -20,6 +20,6 @@
  *
  */
 
-import Breadcrumbs from './Breadcrumbs'
+import Breadcrumb from './Breadcrumb'
 
-export default Breadcrumbs
+export default Breadcrumb

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -1,0 +1,371 @@
+<!--
+ - @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<docs>
+
+### General description
+
+This component renders a breadcrumb bar. It adjusts to the available width
+by hiding breadcrumbs in a dropdown menu and emits an event when something
+is dropped on a creadcrumb.
+
+### Usage
+
+```vue
+<template>
+	<div>
+		<div class="container container__wide">
+			<Breadcrumbs :breadcrumbs="breadcrumbs" @dropped="dropped" />
+		</div>
+		<br />
+		<div class="container container__narrow">
+			<Breadcrumbs :breadcrumbs="breadcrumbs" @dropped="dropped" />
+		</div>
+		<br />
+		<div class="dragme" draggable="true">
+			<span>Drag me onto the breadcrumbs.</span>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	computed: {
+		breadcrumbs() {
+			const path = 'Folder 1/Folder 2/Folder 3/Folder 4'
+			const crumbs = (path === '') ? [] : path.split('/')
+			return [{ name: 'Home', path: '/' }].concat(crumbs.map((crumb, i) => {
+				return {
+					name: crumb,
+					path: '/' + crumbs.slice(0, i + 1).join('/'),
+				}
+			}))
+		},
+	},
+	methods: {
+		dropped(path) {
+			alert('Dropped something on ' + path)
+		},
+	}
+}
+</script>
+<style>
+.container {
+	display: inline-flex;
+}
+
+.container__wide {
+	width: 800px;
+}
+
+.container__narrow {
+	width: 250px;
+}
+
+.dragme {
+	display: block;
+	width: 100px;
+	height: 44px;
+	background-color: var(--color-background-dark);
+}
+</style>
+```
+</docs>
+
+<template>
+	<div ref="container" class="breadcrumb">
+		<div v-for="(crumb, index) in crumbs1"
+			:key="`f1${index}`"
+			:ref="`crumb_${index}`"
+			class="crumb svg folder"
+			:class="{'hidden': isHidden(index)}"
+			draggable="false"
+			@dragstart="dragstart"
+			@drop="dropped(index, $event)"
+			@dragover="dragOver($event)"
+			@dragenter="($event) => dragEnter(index, $event)"
+			@dragleave="dragLeave">
+			<a :href="'#' + crumb.path">
+				<span v-if="!index" :class="rootIcon" class="icon" />
+				<span v-else>{{ crumb.name }}</span>
+			</a>
+		</div>
+		<div v-if="hiddenCrumbs.length" class="crumb svg">
+			<Actions class="dropdown"
+				:force-menu="true"
+				:open.sync="actionsOpen"
+				draggable="false"
+				@dragstart.native="dragstart"
+				@dragover.native="dragOver($event)"
+				@drop.native="dropOnActions"
+				@dragenter.native="actionsOpen = true"
+				@dragleave.native="closeActions">
+				<ActionRouter
+					v-for="(crumb, index) in hiddenCrumbs"
+					:key="`dropdown${index}`"
+					:to="crumb.path"
+					icon="icon-folder"
+					class="crumb"
+					draggable="false"
+					@dragstart.native="dragstart"
+					@drop.native="dropped(hiddenIndices[index], $event)"
+					@dragover.native="dragOver($event)"
+					@dragenter.native="($event) => dragEnter(hiddenIndices[index], $event)"
+					@dragleave.native="dragLeave">
+					{{ crumb.name }}
+				</ActionRouter>
+			</Actions>
+		</div>
+		<div v-for="(crumb, index) in crumbs2"
+			:key="`f2${index}`"
+			:ref="`crumb_${index + crumbs1.length}`"
+			class="crumb svg folder"
+			:class="{'hidden': isHidden(index + crumbs1.length)}"
+			draggable="false"
+			@dragstart="dragstart"
+			@drop="dropped(index + crumbs1.length, $event)"
+			@dragover="dragOver($event)"
+			@dragenter="($event) => dragEnter(index + crumbs1.length, $event)"
+			@dragleave="dragLeave">
+			<a :href="'#' + crumb.path">
+				<span>{{ crumb.name }}</span>
+			</a>
+		</div>
+	</div>
+</template>
+
+<script>
+import debounce from 'debounce'
+import { Actions } from 'Components/Actions'
+import { ActionRouter } from 'Components/ActionRouter'
+
+export default {
+	components: {
+		Actions,
+		ActionRouter
+	},
+	props: {
+		breadcrumbs: {
+			type: Array,
+			required: true,
+			default: () => []
+		},
+		rootIcon: {
+			type: String,
+			required: false,
+			default: 'icon-home'
+		}
+	},
+	data: function() {
+		return {
+			hiddenIndices: [],
+			actionsOpen: false
+		}
+	},
+	computed: {
+		crumbs1() {
+			if (this.hiddenIndices.length) {
+				return this.breadcrumbs.slice(0, Math.round(this.breadcrumbs.length / 2))
+			}
+			return this.breadcrumbs
+		},
+
+		crumbs2() {
+			if (this.hiddenIndices.length) {
+				return this.breadcrumbs.slice(Math.round(this.breadcrumbs.length / 2))
+			}
+			return []
+		},
+
+		hiddenCrumbs() {
+			const crumbs = []
+			for (let jj = 0; jj < this.hiddenIndices.length; jj++) {
+				crumbs.push(this.breadcrumbs[this.hiddenIndices[jj]])
+			}
+			return crumbs
+		}
+	},
+	watch: {
+		breadcrumbs: function(val) {
+			this.actionsOpen = false
+			this.$nextTick(() => this.handleWindowResize())
+		}
+	},
+	created() {
+		window.addEventListener('resize', debounce(() => {
+			this.handleWindowResize()
+		}, 100))
+	},
+	mounted() {
+		this.handleWindowResize()
+	},
+	beforeDestroy() {
+		window.removeEventListener('resize', this.handleWindowResize)
+	},
+	methods: {
+		closeActions(e) {
+			// Get the correct element, the events are bound to the <a>
+			if (e.target.closest) {
+				const target = e.target.closest('.crumb .dropdown')
+				// Don't do anything if we leave towards a child element.
+				if (target.contains(e.relatedTarget)) {
+					return
+				}
+				this.actionsOpen = false
+			}
+		},
+
+		isHidden(index) {
+			return this.hiddenIndices.includes(index)
+		},
+
+		handleWindowResize() {
+			if (this.$refs.container) {
+				const nrCrumbs = this.breadcrumbs.length
+				const hiddenIndices = []
+				const availableWidth = this.$refs.container.offsetWidth
+				const totalWidth = this.getTotalWidth()
+				let overflow = totalWidth - availableWidth
+				// If we overflow, we have to take the action-item width into account as well.
+				overflow += (overflow > 0) ? 51 : 0
+				let i = 0
+				const startIndex = Math.floor(nrCrumbs / 2)
+				while (overflow > 0 && i < nrCrumbs - 2) {
+					const currentIndex = startIndex + ((i % 2) ? i + 1 : i) / 2 * Math.pow(-1, i + (nrCrumbs % 2))
+					overflow -= this.getWidth(this.$refs[`crumb_${currentIndex}`][0])
+					hiddenIndices.push(currentIndex)
+					i++
+				}
+				this.hiddenIndices = hiddenIndices.sort()
+			}
+		},
+
+		getTotalWidth() {
+			return this.breadcrumbs.reduce((width, crumb, index) => width + this.getWidth(this.$refs[`crumb_${index}`][0]), 0)
+		},
+
+		getWidth(el) {
+			const hide = el.classList.contains('hidden')
+			el.classList.remove('hidden')
+			const w = el.offsetWidth
+			if (hide) {
+				el.classList.add('hidden')
+			}
+			return w
+		},
+		cancelEvent(e) {
+			e.stopPropagation()
+			e.preventDefault()
+			return false
+		},
+		dropOnActions(e) {
+			this.actionsOpen = false
+			return this.cancelEvent(e)
+		},
+		dragstart(e) {
+			return this.cancelEvent(e)
+		},
+		dropped(index, e) {
+			this.cancelEvent(e)
+			// If it is the last element in the path,
+			// don't do anything
+			if (index === (this.breadcrumbs.length - 1)) {
+				return
+			}
+			this.$emit('dropped', this.breadcrumbs[index].path)
+			this.actionsOpen = false
+			const crumbs = document.querySelectorAll('.crumb')
+			crumbs.forEach((f) => { f.classList.remove('over') })
+			return false
+		},
+		dragOver(e) {
+			if (e.preventDefault) {
+				e.preventDefault()
+			}
+			return false
+		},
+		dragEnter(index, e) {
+			// If it is the last element in the path,
+			// don't do anything
+			if (index === (this.breadcrumbs.length - 1)) {
+				return
+			}
+			// Get the correct element, in case we hover a child.
+			if (e.target.closest) {
+				const target = e.target.closest('.crumb')
+				if (target.classList && target.classList.contains('crumb')) {
+					const crumbs = document.querySelectorAll('.crumb')
+					crumbs.forEach((f) => { f.classList.remove('over') })
+					target.classList.add('over')
+				}
+			}
+		},
+		dragLeave(e) {
+			// Don't do anything if we leave towards a child element.
+			if (e.target.contains(e.relatedTarget)) {
+				return
+			}
+			// Get the correct element, in case we leave directly from a child.
+			if (e.target.closest) {
+				const target = e.target.closest('.crumb')
+				if (target.contains(e.relatedTarget)) {
+					return
+				}
+				if (target.classList && target.classList.contains('crumb')) {
+					target.classList.remove('over')
+				}
+			}
+		}
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+.breadcrumb {
+	width: calc(100% - 88px);
+	flex-grow: 1;
+
+	.crumb {
+		&.over {
+			background-color: var(--color-primary-light);
+		}
+		&.action-item {
+			ul {
+				overflow-y: auto;
+				-webkit-overflow-scrolling: touch;
+				min-height: calc(44px * 1.5);
+				max-height: calc(100vh - 50px * 2);
+			}
+		}
+		> a {
+			align-items: center;
+			display: inline-flex;
+
+			> span {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+		}
+	}
+}
+</style>

--- a/src/components/Breadcrumbs/index.js
+++ b/src/components/Breadcrumbs/index.js
@@ -1,0 +1,26 @@
+/**
+ * @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Breadcrumbs from './Breadcrumbs'
+
+export default Breadcrumbs
+export { Breadcrumbs }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -45,6 +45,7 @@ import AppNavigationSpacer from './AppNavigationSpacer'
 import AppSidebar from './AppSidebar'
 import AppSidebarTab from './AppSidebarTab'
 import Avatar from './Avatar'
+import Breadcrumbs from './Breadcrumbs'
 import ColorPicker from './ColorPicker'
 import Content from './Content'
 import DatetimePicker from './DatetimePicker'
@@ -81,6 +82,7 @@ export {
 	AppSidebar,
 	AppSidebarTab,
 	Avatar,
+	Breadcrumbs,
 	ColorPicker,
 	Content,
 	DatetimePicker,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -45,6 +45,7 @@ import AppNavigationSpacer from './AppNavigationSpacer'
 import AppSidebar from './AppSidebar'
 import AppSidebarTab from './AppSidebarTab'
 import Avatar from './Avatar'
+import Breadcrumb from './Breadcrumb'
 import Breadcrumbs from './Breadcrumbs'
 import ColorPicker from './ColorPicker'
 import Content from './Content'
@@ -82,6 +83,7 @@ export {
 	AppSidebar,
 	AppSidebarTab,
 	Avatar,
+	Breadcrumb,
 	Breadcrumbs,
 	ColorPicker,
 	Content,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -44,6 +44,7 @@ module.exports = {
 			ignore: [
 				'src/components/Action[sA-Z]*/*.vue',
 				'src/components/App*/*.vue',
+				'src/components/Breadcrumb*/*.vue',
 				'src/components/Multiselect/*.vue',
 				'src/components/Multiselect*/*.vue',
 				'src/components/PopoverMenu/!(PopoverMenu).vue'
@@ -61,6 +62,12 @@ module.exports = {
 					components: [
 						'src/components/App*/*.vue',
 						'src/components/Content/*.vue'
+					]
+				},
+				{
+					name: 'Breadcrumbs',
+					components: [
+						'src/components/Breadcrumb*/*.vue',
 					]
 				},
 				{

--- a/styleguide/assets/variables.css
+++ b/styleguide/assets/variables.css
@@ -9,6 +9,7 @@
     --color-primary-text-dark:#ededed;
     --color-primary-element:#0082c9;
     --color-primary-element-light:#17adff;
+    --color-primary-light:#e6f3fa;
     --color-error:#e9322d;
     --color-warning:#eca700;
     --color-success:#46ba61;


### PR DESCRIPTION
This PR adds a breadcrumb component as it is used in the files app, closes #800.
The component resizes with the viewport and hides folders in a dropdown if the width is to small. The first (root folder) and the last folder are always shown though. The component also emits an event when something is dropped on a folder. The dropdown with the hidden folders opens on hover, so one can drop on the hidden folders as well.

Some things don't work yet on netlify, but do work locally for me:
- [x] The initial resize on page load does not work. Resizing the browser window leads to a correct resizing
- [x] ~The `background-color` on hover is not working. Something seems to be off with this line https://github.com/nextcloud/nextcloud-vue/pull/913/files#diff-f1fe4599663441afb9babaefe49e0c7aR349~  
var(--color-primary-light) doesn't seem to be available on netlify, but since it is used for other components, I guess it is fine?
- [x] The breadcrumb arrow is not found

@skjnldsv Do you have an idea regarding the last two problems?

I didn't test the component in the Files app. Looking at https://github.com/nextcloud/server/blob/e4948f5d86a7df2a683e288e55f6f626d90d7cf0/apps/files/js/breadcrumb.js I guess there is more stuff to add on the component, but I would like to leave this to someone familiar with the Files app.
