### PR TITLE
Force single multiselect value to be shown when the input is not active

### DIFF
--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -10,6 +10,12 @@
 	position: relative;
 	background-color: var(--color-main-background);
 
+	/* Force single multiselect value to be shown when not active */
+	&:not(.multiselect--active) .multiselect__single {
+		position: absolute;
+		width: 100%;
+	}
+
 	// active state, force the input to be shown, we don't want
 	// the placeholder or the currently selected options
 	&.multiselect--active {


### PR DESCRIPTION
Fixes showing the multiselect value in the user management when the Multiselect is single value but taggable and searchable. The main issue is that the input always has a `position: absolute;` set, so even though the value label has a `z-index: 1;` it will never be shown on top.

Before:
![image](https://user-images.githubusercontent.com/3404133/77197105-dfea8d80-6ae4-11ea-9747-9656493402df.png)

After:
![image](https://user-images.githubusercontent.com/3404133/77197024-b893c080-6ae4-11ea-9c58-fb1680f2ef28.png)

@skjnldsv Please have a closer look if that has any downsides, since the multiselect styling is quite complex :wink: I also cannot reproduce this in the nextcloud-vue docs so there might be some server styles interfering here, but I could not find the culprit. :see_no_evil: 

Found when testing https://github.com/nextcloud/server/pull/18818