### PR TITLE
Use main as appContent

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -21,13 +21,13 @@
  -->
 
 <template>
-	<div id="app-content" class="no-snapper" :style="opened ? 'transform: translateX(300px)' : ''">
+	<main id="app-content" class="no-snapper" :style="opened ? 'transform: translateX(300px)' : ''">
 		<AppNavigationToggle :aria-expanded="opened"
 			aria-controls="app-navigation"
 			@click="toggleNavigation" />
 		<!-- @slot Provide content to the app content -->
 		<slot />
-	</div>
+	</main>
 </template>
 
 <script>


### PR DESCRIPTION
Makes more sense for accessibility readers
![image](https://user-images.githubusercontent.com/14975046/77779125-4ece6600-7052-11ea-9e7d-a5c016bad0b0.png)
___

> The `<main>` tag specifies the main content of a document.
> 
> The content inside the `<main>` element should be unique to the document. It should not contain any content that is repeated across documents such as sidebars, navigation links, copyright information, site logos, and search forms.
> 
> Note: There must not be more than one `<main>` element in a document. The <main> element must NOT be a descendant of an `<article>`, `<aside>`, `<footer>`, `<header>`, or `<nav>` element.



___
@nextcloud/accessibility 