### PR TITLE
Fix the validate slots function

### DIFF
--- a/src/utils/ValidateSlot.js
+++ b/src/utils/ValidateSlot.js
@@ -40,10 +40,13 @@ const ValidateSlot = (slots, allowed, vm) => {
 		const isVueComponent = !!node.componentOptions && typeof node.componentOptions.tag === 'string'
 		const isForbiddenComponent = isVueComponent && allowed.indexOf(node.componentOptions.tag) === -1
 
-		// if not a vue component or component not in allowed tags
-		if (isHtmlElement || isForbiddenComponent) {
-			// warn
-			Vue.util.warn(`${isHtmlElement ? node.tag : node.componentOptions.tag} is not allowed inside the ${vm.$options.name} component`, vm)
+		// if html element or not a vue component or vue component not in allowed tags
+		if (isHtmlElement || !isVueComponent || isForbiddenComponent) {
+			// only warn when html elment or forbidden component
+			// sometimes text nodes are present which are hardly removeable by the developer and spam the warnings
+			if (isHtmlElement || isForbiddenComponent) {
+				Vue.util.warn(`${isHtmlElement ? node.tag : node.componentOptions.tag} is not allowed inside the ${vm.$options.name} component`, vm)
+			}
 
 			// cleanup
 			slots.splice(index, 1)

--- a/src/utils/ValidateSlot.js
+++ b/src/utils/ValidateSlot.js
@@ -32,7 +32,9 @@ const ValidateSlot = (slots, allowed, vm) => {
 	if (slots === undefined) {
 		return
 	}
-	slots.forEach((node, index) => {
+
+	for (let index = slots.length - 1; index >= 0; index--) {
+		const node = slots[index]
 		// also check against allowed to avoid uninitiated vnodes with no componentOptions
 		const isHtmlElement = !node.componentOptions && node.tag && allowed.indexOf(node.tag) === -1
 		const isVueComponent = !!node.componentOptions && typeof node.componentOptions.tag === 'string'
@@ -46,7 +48,7 @@ const ValidateSlot = (slots, allowed, vm) => {
 			// cleanup
 			slots.splice(index, 1)
 		}
-	})
+	}
 }
 
 export default ValidateSlot


### PR DESCRIPTION
The `ValidateSlot` function had two issues:

- `forEach` in combination with `splice` does not work. `splice` mutates the original array, so the `forEach` loop skips the next element after a splice occurs. Hence, some elements are not checked.
- If an array entry was not a vue component, the check if it is a forbidden component will always lead to false, since `node.componentOptions.tag` fails with `undefined`. Hence, an element which is not a html element and not a vue component would not be filtered out. This happens to e.g. text nodes which the browser sometimes renders if there is a whitespace in the markup.

This PR is necessary for #913.