### PR TITLE
We don't need an intermediate data & watcher for Actions open state

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -145,7 +145,7 @@ Just set the `pinned` prop.
 		<div v-if="hasUtils" class="app-navigation-entry__utils">
 			<slot name="counter" />
 			<Actions menu-align="right"
-				:open="menuOpened"
+				:open="menuOpen"
 				:force-menu="forceMenu"
 				:default-icon="menuIcon"
 				@update:open="onMenuToggle">
@@ -322,7 +322,6 @@ export default {
 		return {
 			newTitle: '',
 			opened: this.open,
-			menuOpened: this.menuOpen,
 			editing: false,
 		}
 	},
@@ -386,14 +385,10 @@ export default {
 		open(newVal) {
 			this.opened = newVal
 		},
-		menuOpen(newVal) {
-			this.menuOpened = newVal
-		},
 	},
 	methods: {
 		// sync opened menu state with prop
 		onMenuToggle(state) {
-			this.menuOpened = state
 			this.$emit('update:menuOpen', state)
 		},
 		// toggle the collapsible state


### PR DESCRIPTION
A bit cleaner!
Since we're only using the given prop and emitting a change we don't need this weird watch/sync mechanism.

The  Actions already contain its own separation & watcher so you can modify the state without triggering a `[Vue warn]: Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value. Prop being mutated: "open"`
