### PR TITLE
Cleanup code and properly toggle Breadcrumb menu

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -10,7 +10,7 @@ msgstr ""
 msgid "{tag} (restricted)"
 msgstr ""
 
-#: src/components/Actions/Actions.vue:196
+#: src/components/Actions/Actions.vue:197
 msgid "Actions"
 msgstr ""
 

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -52,6 +52,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 	<ActionLink icon="icon-external" title="Link" href="https://nextcloud.com" />
 </Actions>
 ```
+
 </docs>
 <template>
 	<!-- if only one action, check if we need to bind to click or not -->
@@ -332,29 +333,39 @@ export default {
 
 	methods: {
 		// MENU STATE MANAGEMENT
-		toggleMenu(e) {
-			this.opened = !this.opened
+		toggleMenu(state) {
+			if (typeof state === 'boolean') {
+				this.opened = state
+			} else {
+				this.opened = !this.opened
+			}
+
 			// focus first on menu open after opening the menu
 			if (this.opened) {
 				this.$nextTick(() => {
 					this.onOpen()
 					this.focusFirstAction()
 				})
+
 				/**
 				 * Event emitted when the popover menu is opened
-				 * @type {null}
 				 */
-				this.$emit('open', e)
+				this.$emit('open')
 			} else {
 				this.offsetX = 0
 				this.offsetY = 0
 				this.offsetYArrow = 0
 				this.rotateArrow = false
+
+				/**
+				 * Event emitted when the popover menu is closed
+				 */
+				this.$emit('close')
 			}
 
 			/**
 			 * Event emitted when the popover menu open state is changed
-			 * @type {bool}
+			 * @type {boolean}
 			 */
 			this.$emit('update:open', this.opened)
 		},
@@ -367,23 +378,22 @@ export default {
 			if (this.opened) {
 				/**
 				 * Event emitted when the popover menu open state is changed
-				 * @type {bool}
+				 * @type {boolean}
 				 */
 				this.$emit('update:open', false)
+
 				/**
 				 * Event emitted when the popover menu is closed
-				 * @type {null}
 				 */
-				this.$emit('close', e)
+				this.$emit('close')
 
+				// close everything
+				this.opened = false
+				this.offsetX = 0
+				this.offsetY = 0
+				this.offsetYArrow = 0
+				this.rotateArrow = false
 			}
-
-			// close everything
-			this.opened = false
-			this.offsetX = 0
-			this.offsetY = 0
-			this.offsetYArrow = 0
-			this.rotateArrow = false
 		},
 
 		/**

--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -87,6 +87,7 @@ export default {
 	min-height: 100%;
 	// Overriding server styles TODO: cleanup!
 	margin: 0 !important;
+	min-width: 0;
 }
 
 </style>

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -123,6 +123,20 @@ export default {
 			 * Comparing two crumbs somehow does not work, so we use the indices.
 			 */
 			hiddenIndices: [],
+
+			/**
+			 * This is the props of the middle Action menu
+			 * that show the ellipsised breadcrumbs
+			 */
+			menuBreadcrumbProps: {
+				// Don't show a title for this breadcrumb, only the Actions menu
+				title: '',
+				forceMenu: true,
+				// Don't allow dropping directly on the actions breadcrumb
+				disableDrop: true,
+				// Is the menu open or not
+				open: false,
+			},
 		}
 	},
 	beforeMount() {
@@ -168,7 +182,7 @@ export default {
 			if (this.$refs.actionsBreadcrumb.$el.contains(e.relatedTarget)) {
 				return
 			}
-			this.$refs.actionsBreadcrumb.$refs.actions.opened = false
+			this.menuBreadcrumbProps.open = false
 		},
 		/**
 		 * Call the resize function after a delay
@@ -302,7 +316,8 @@ export default {
 				this.$emit('dropped', e, path)
 			}
 			// Close the actions menu after the drop
-			this.$refs.actionsBreadcrumb.$refs.actions.opened = false
+			this.menuBreadcrumbProps.open = false
+
 			// Remove all hovering classes
 			const crumbs = document.querySelectorAll('.crumb')
 			crumbs.forEach((f) => { f.classList.remove('crumb--hovered') })
@@ -424,23 +439,24 @@ export default {
 			// Use a breadcrumb component for the hidden breadcrumbs
 			crumbs.push(createElement('Breadcrumb', {
 				class: 'dropdown',
-				// We want the Actions to always show as a dropdown menu
-				props: {
-					// Don't show a title for this breadcrumb, only the Actions menu
-					title: '',
-					forceMenu: true,
-					// Don't allow dropping directly on the actions breadcrumb
-					disableDrop: true,
-					hideable: false,
-				},
+
+				props: this.menuBreadcrumbProps,
+
 				// Add a ref to the Actions menu
 				ref: 'actionsBreadcrumb',
 				key: 'actions-breadcrumb-1',
 				// Add handlers so the Actions menu opens on hover
 				nativeOn: {
 					dragstart: this.dragStart,
-					dragenter: () => { this.$refs.actionsBreadcrumb.$refs.actions.opened = true },
+					dragenter: () => { this.menuBreadcrumbProps.open = true },
 					dragleave: this.closeActions,
+				},
+				on: {
+					// Make sure we keep the same open state
+					// as the Actions component
+					'update:open': (open) => {
+						this.menuBreadcrumbProps.open = open
+					},
 				},
 			// Add all hidden breadcrumbs as ActionRouter or ActionLink
 			}, this.hiddenCrumbs.map(crumb => {


### PR DESCRIPTION
```vue
<Actions ref="actions" @open="log" @close="log">
	<ActionButton>Test</ActionButton>
	<ActionButton>Test</ActionButton>
	<ActionButton>Test</ActionButton>
</Actions>
```

~~Allows us to do `this.$refs.actions.toggleMenu(true)`~~

Cleaner than having to always pass an open property or do `this.$refs.actions.opened = true` 
What do you think @nextcloud/vuejs ?

~~We cannot use close/open methods name as `this.open` is already used by the prop~~

Fixed differently by properly passing the open prop through the children

___
This also fixes a missing close event when clicking the menu icon to close