### PR TITLE
Allow to toggle sidebar and always show the toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -520,7 +520,7 @@
 			"dependencies": {
 				"@babel/code-frame": {
 					"version": "7.8.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 					"requires": {
 						"@babel/highlight": "^7.8.3"
@@ -635,7 +635,7 @@
 			"dependencies": {
 				"@babel/code-frame": {
 					"version": "7.8.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 					"requires": {
 						"@babel/highlight": "^7.8.3"
@@ -3313,9 +3313,9 @@
 			}
 		},
 		"@nextcloud/event-bus": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.1.3.tgz",
-			"integrity": "sha512-/f3OMh9Tu3bn17sCc1Sb5AaC/fjegP9bjFmlsPDFNcCAHrKKM5B2X+2eUDF2osLirYaBjVqypBmD87zyiE0WjQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.1.4.tgz",
+			"integrity": "sha512-It27KzmUaSQ7w22nHFwOn8XgeVG0HYYOSNG9gs4UkP5VqcZ16m4ydt3GkMpWcyFec4OUjJc+yf7omRc3pNxsSw==",
 			"requires": {
 				"@types/semver": "^6.2.1",
 				"core-js": "^3.6.2",
@@ -4476,7 +4476,7 @@
 				},
 				"@babel/highlight": {
 					"version": "7.9.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
 					"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
 					"dev": true,
 					"requires": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	],
 	"dependencies": {
 		"@nextcloud/axios": "^1.1.0",
+		"@nextcloud/event-bus": "^1.1.4",
 		"@nextcloud/l10n": "^1.1.0",
 		"@nextcloud/router": "^1.0.0",
 		"core-js": "^3.4.4",

--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -2,6 +2,8 @@
  - @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  -
  - @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ - @author John Molakvoæ <skjnldsv@protonmail.com>
+ - @author Marco Ambrosini <marcoambrosini@pm.me>
  -
  - @license GNU AGPL version 3 or any later version
  -
@@ -20,19 +22,31 @@
  -
  -->
 <template>
-	<a id="app-navigation-toggle"
+	<a class="app-navigation-toggle"
 		tabindex="0"
 		href="#"
-		@click.prevent="emitClick"
-		@keydown.space.exact.prevent="emitClick" />
+		:aria-expanded="open"
+		aria-controls="app-navigation"
+		@click.prevent="toggleNavigation"
+		@keydown.space.exact.prevent="toggleNavigation" />
 </template>
 
 <script>
+
 export default {
+
 	name: 'AppNavigationToggle',
+
+	props: {
+		open: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	methods: {
-		emitClick() {
-			this.$emit('click')
+		toggleNavigation() {
+			this.$emit('update:open', !this.open)
 		},
 	},
 }
@@ -41,11 +55,11 @@ export default {
 <style scoped lang="scss">
 @import '../../fonts/scss/iconfont-vue';
 
-#app-navigation-toggle {
-	display: none;
-	position: fixed;
-	z-index: 1050; // above app-content
-	left: 0;
+.app-navigation-toggle {
+	position: absolute;
+	top: 0;
+	right: 0;
+	margin-right: - $clickable-area;
 	width: $clickable-area;
 	height: $clickable-area;
 	padding: $icon-margin;
@@ -62,10 +76,5 @@ export default {
 		opacity: $opacity_full;
 	}
 }
-// mobile only
-@media only screen and (max-width: 768px) {
-	#app-navigation-toggle {
-		display: inline-block !important;
-	}
-}
+
 </style>


### PR DESCRIPTION
- [x] Move the `AppNavigationToggle` in the `AppNavigation`
- [x] Move from #app-navigation IDs to have independent styling from server
- [x] Move `AppNavigation` open state IN the `AppNavigation`
- [x] Create a global `toggle-navigation` to emit with th event bus for any app to open the navigation (was originally the start of this pair programming, we ended up fixing far too much ^^')
- [x] Allow to toggle the navigation even when in desktop mode
- [x] Changed the animation/css from translate and shifting the `AppContent` to the left to using proper flex layout and not weird absolute positioning anymore :tada:
- [x] In mobile, opening the navigation does NOT shift the content, it just hovers it now. It avoid changing the whole layout and improve the rendering performances
- [x] Document the new global event (cc @ChristophWurst)
- [x] Emit event at first load


### QA
- [x] Swiping
- [x] Toggling navigation
- [x] Scrolling navigation
- [x] Not being able to scroll left and see the hidden navigation
- [x] Settings


fix https://github.com/nextcloud/server/issues/15831
___
@ma12-co, @skjnldsv & @ChristophWurst on a nice beer programming session on a sweet Friday afternoon :beers: 