### PR TITLE
Fix breadcrumbs drag example for Firefox ESR

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -48,7 +48,7 @@ is dropped on a creadcrumb.
 			</Breadcrumbs>
 		</div>
 		<br />
-		<div class="dragme" draggable="true">
+		<div class="dragme" draggable="true" @dragstart="dragStart">
 			<span>Drag me onto the breadcrumbs.</span>
 		</div>
 	</div>
@@ -62,6 +62,9 @@ export default {
 		},
 		droppedOnCrumb(e, path) {
 			alert('Drop on crumb ' + path)
+		},
+		dragStart(e) {
+			e.dataTransfer.setData('text/plain', 'dragging')
 		},
 	}
 }


### PR DESCRIPTION
On Firefox ESR 68.6.0 you have to set `event.dataTransfer.setData()` to enable dragging and element. In other browsers the example worked already.