### PR TITLE
Fix message source size

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -264,7 +264,7 @@ export default {
 		},
 		size: {
 			type: String,
-			default: 'normal',
+			default: 'large',
 			validator: size => {
 				return ['normal', 'large', 'full'].indexOf(size) !== -1
 			},


### PR DESCRIPTION
fixes https://github.com/nextcloud/mail/issues/2852#issuecomment-610449076

@skjnldsv you proposed for the default to be full. The large version looks better as a pop up, rather than covering the whole page. What do you think? We can also maybe raise a bit the size of the large version.