### PR TITLE
Fix audit and lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,43 +20,13 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"chokidar": {
-					"version": "2.1.8",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-					"optional": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
-				},
 				"commander": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
 					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
 				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
 				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"version": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"slash": {
@@ -116,20 +86,6 @@
 						"@babel/highlight": "^7.8.3"
 					}
 				},
-				"@babel/helper-module-transforms": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-					"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-					"requires": {
-						"@babel/helper-module-imports": "^7.8.3",
-						"@babel/helper-replace-supers": "^7.8.6",
-						"@babel/helper-simple-access": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/template": "^7.8.6",
-						"@babel/types": "^7.9.0",
-						"lodash": "^4.17.13"
-					}
-				},
 				"@babel/highlight": {
 					"version": "7.9.0",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
@@ -139,11 +95,6 @@
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
 					}
-				},
-				"@babel/parser": {
-					"version": "7.9.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 				},
 				"@babel/types": {
 					"version": "7.9.0",
@@ -196,17 +147,12 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -222,17 +168,12 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -272,6 +213,12 @@
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-regex": "^7.8.3",
 				"regexpu-core": "^4.7.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
 			}
 		},
 		"@babel/helper-define-map": {
@@ -284,17 +231,12 @@
 				"lodash": "^4.17.13"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -310,17 +252,12 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -377,17 +314,12 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -448,17 +380,12 @@
 				"lodash": "^4.17.13"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -510,17 +437,12 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -539,48 +461,10 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"version": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 					"requires": {
 						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.8.7",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"requires": {
-						"@babel/types": "^7.8.7",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"requires": {
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"requires": {
-						"@babel/types": "^7.8.3"
 					}
 				},
 				"@babel/highlight": {
@@ -591,37 +475,6 @@
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.8.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
-				},
-				"@babel/template": {
-					"version": "7.8.6",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/parser": "^7.8.6",
-						"@babel/types": "^7.8.6"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.8.6",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.6",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.6",
-						"@babel/types": "^7.8.6",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
@@ -635,8 +488,7 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
@@ -654,8 +506,7 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"version": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 					"requires": {
 						"@babel/highlight": "^7.8.3"
@@ -669,21 +520,6 @@
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.8.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
-				},
-				"@babel/template": {
-					"version": "7.8.6",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/parser": "^7.8.6",
-						"@babel/types": "^7.8.6"
 					}
 				},
 				"@babel/types": {
@@ -734,17 +570,12 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -787,8 +618,7 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-			"dev": true
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -837,13 +667,12 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
-			"integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
+			"integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-				"@babel/plugin-transform-parameters": "^7.9.5"
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
@@ -998,45 +827,18 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
-			"integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz",
+			"integrity": "sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-define-map": "^7.8.3",
-				"@babel/helper-function-name": "^7.9.5",
+				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-split-export-declaration": "^7.8.3",
 				"globals": "^11.1.0"
-			},
-			"dependencies": {
-				"@babel/helper-function-name": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-					"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.9.5"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
-				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -1048,9 +850,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
-			"integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
+			"integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -1181,9 +983,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
-			"integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
+			"version": "7.9.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz",
+			"integrity": "sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==",
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1275,9 +1077,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
-			"integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
+			"integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
 			"requires": {
 				"@babel/compat-data": "^7.9.0",
 				"@babel/helper-compilation-targets": "^7.8.7",
@@ -1288,7 +1090,7 @@
 				"@babel/plugin-proposal-json-strings": "^7.8.3",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
 				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.9.0",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
@@ -1305,9 +1107,9 @@
 				"@babel/plugin-transform-async-to-generator": "^7.8.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
 				"@babel/plugin-transform-block-scoping": "^7.8.3",
-				"@babel/plugin-transform-classes": "^7.9.5",
+				"@babel/plugin-transform-classes": "^7.9.0",
 				"@babel/plugin-transform-computed-properties": "^7.8.3",
-				"@babel/plugin-transform-destructuring": "^7.9.5",
+				"@babel/plugin-transform-destructuring": "^7.8.3",
 				"@babel/plugin-transform-dotall-regex": "^7.8.3",
 				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
 				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
@@ -1322,7 +1124,7 @@
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
 				"@babel/plugin-transform-new-target": "^7.8.3",
 				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.9.5",
+				"@babel/plugin-transform-parameters": "^7.8.7",
 				"@babel/plugin-transform-property-literals": "^7.8.3",
 				"@babel/plugin-transform-regenerator": "^7.8.7",
 				"@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -1333,7 +1135,7 @@
 				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
 				"@babel/plugin-transform-unicode-regex": "^7.8.3",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.9.5",
+				"@babel/types": "^7.9.0",
 				"browserslist": "^4.9.1",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
@@ -1341,17 +1143,12 @@
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1370,17 +1167,12 @@
 				"esutils": "^2.0.2"
 			},
 			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"@babel/helper-validator-identifier": "^7.9.0",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1432,11 +1224,6 @@
 						"js-tokens": "^4.0.0"
 					}
 				},
-				"@babel/parser": {
-					"version": "7.9.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
-				},
 				"@babel/types": {
 					"version": "7.9.0",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
@@ -1482,11 +1269,6 @@
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
 					}
-				},
-				"@babel/parser": {
-					"version": "7.9.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 				},
 				"@babel/types": {
 					"version": "7.9.0",
@@ -1813,10 +1595,8 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -1866,11 +1646,8 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -1881,34 +1658,13 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.6",
-						"jest-util": "^25.2.6",
-						"jest-worker": "^25.2.6",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
 				},
 				"jest-message-util": {
 					"version": "25.2.6",
@@ -1925,18 +1681,6 @@
 						"stack-utils": "^1.0.1"
 					}
 				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
-				"jest-serializer": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
-					"dev": true
-				},
 				"jest-util": {
 					"version": "25.2.6",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
@@ -1950,10 +1694,8 @@
 					}
 				},
 				"jest-worker": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
-					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -2018,7 +1760,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -2033,10 +1774,8 @@
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -2431,10 +2170,8 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -2484,11 +2221,8 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -2506,38 +2240,6 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.6",
-						"jest-util": "^25.2.6",
-						"jest-worker": "^25.2.6",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
-				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
-				"jest-serializer": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
 					"dev": true
 				},
 				"jest-util": {
@@ -2618,10 +2320,8 @@
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -2800,10 +2500,8 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -2813,7 +2511,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
 					"requires": {
 						"fill-range": "^7.0.1"
 					}
@@ -2847,17 +2544,13 @@
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -2868,40 +2561,12 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.6",
-						"jest-util": "^25.2.6",
-						"jest-worker": "^25.2.6",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
-				},
-				"jest-serializer": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
-					"dev": true
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 				},
 				"jest-util": {
 					"version": "25.2.6",
@@ -2916,10 +2581,8 @@
 					}
 				},
 				"jest-worker": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
-					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -2935,10 +2598,8 @@
 					}
 				},
 				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"version": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
@@ -2966,7 +2627,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -2975,16 +2635,13 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -3038,10 +2695,8 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -3091,11 +2746,8 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -3115,48 +2767,6 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
-				"jest-haste-map": {
-					"version": "25.2.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.0.tgz",
-					"integrity": "sha512-VeoodAL671sKKXDvaT2r1Z/0GSDWJi/fAcDGuRAHrRCqkrPnPsV0Uq35YTNO0RrMF8LdRRogu6Mie1Eli2CVLA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.0",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.0",
-						"jest-util": "^25.2.0",
-						"jest-worker": "^25.2.0",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
-				},
-				"jest-regex-util": {
-					"version": "25.2.0",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.0.tgz",
-					"integrity": "sha512-D85pUKyzdi4zFAnub4EDp48eB08oua2aaN8wPrcaL98SnmJmJCSC+8iMZvonyy8qTtXgElK8JcsdPl4Y8+WhGg==",
-					"dev": true
-				},
-				"jest-serializer": {
-					"version": "25.2.0",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.0.tgz",
-					"integrity": "sha512-wCaA4dM1F4klHEpjRzAnv/8K4eqvB/0x4f6AA4W8ie8DP2XarCt6yAsdRCE+zw+htZSwcNOWvYvpOVov8y8pJA==",
-					"dev": true
-				},
-				"jest-worker": {
-					"version": "25.2.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.0.tgz",
-					"integrity": "sha512-oGzUBnVnRdb51Aru3XFNa0zOafAIEerqZoQow+Vy8LDDiy12dvSrOeVeO8oNrxCMkGG4JtXqX9IPC93JJiAk+g==",
-					"dev": true,
-					"requires": {
-						"merge-stream": "^2.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
 				"micromatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -3166,12 +2776,6 @@
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
 					}
-				},
-				"realpath-native": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
-					"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
-					"dev": true
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -3204,10 +2808,8 @@
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -3350,9 +2952,9 @@
 			}
 		},
 		"@nextcloud/l10n": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.2.2.tgz",
-			"integrity": "sha512-p4YrycRqLY2yBaK9E/G5pbISxwmsgs4cd2KbI1zIiMWHiPrZWqU0myQFgfuoL9zW3ySyKI7ozqyJu4I8RZEOAA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.2.0.tgz",
+			"integrity": "sha512-aPsVAewCYMNe2h0yse3Fj7LofvnvFPimojw24K47ip1+I1gawMIsQL+BYAnN8wzlcbsDTEc7I1FxtOh+8dHHIA==",
 			"requires": {
 				"core-js": "^3.6.4",
 				"node-gettext": "^3.0.0"
@@ -3889,8 +3491,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -4061,8 +3662,7 @@
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -4094,14 +3694,12 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -4457,112 +4055,13 @@
 				"resolve": "^1.12.0"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.9.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
-					"integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.9.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3"
-					}
-				},
 				"@babel/highlight": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+					"version": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
 					"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.9.0",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.9.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.8.6",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/parser": "^7.8.6",
-						"@babel/types": "^7.8.6"
-					},
-					"dependencies": {
-						"@babel/code-frame": {
-							"version": "7.8.3",
-							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-							"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-							"dev": true,
-							"requires": {
-								"@babel/highlight": "^7.8.3"
-							}
-						}
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-					"integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.9.0",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.9.0",
-						"@babel/types": "^7.9.0",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					},
-					"dependencies": {
-						"@babel/code-frame": {
-							"version": "7.8.3",
-							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-							"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-							"dev": true,
-							"requires": {
-								"@babel/highlight": "^7.8.3"
-							}
-						}
 					}
 				},
 				"@babel/types": {
@@ -4577,10 +4076,8 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -4658,33 +4155,11 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
-					}
-				},
-				"babel-plugin-jest-hoist": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
-					"integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
-					"dev": true,
-					"requires": {
-						"@types/babel__traverse": "^7.0.6"
-					}
-				},
-				"babel-preset-jest": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.2.6.tgz",
-					"integrity": "sha512-Xh2eEAwaLY9+SyMt/xmGZDnXTW/7pSaBPG0EMo7EuhvosFKVWYB6CqwYD31DaEQuoTL090oDZ0FEqygffGRaSQ==",
-					"dev": true,
-					"requires": {
-						"@babel/plugin-syntax-bigint": "^7.0.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-						"babel-plugin-jest-hoist": "^25.2.6"
 					}
 				},
 				"braces": {
@@ -4731,11 +4206,8 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -4746,45 +4218,12 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.6",
-						"jest-util": "^25.2.6",
-						"jest-worker": "^25.2.6",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
-				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
-				"jest-serializer": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
 					"dev": true
 				},
 				"jest-util": {
@@ -4800,10 +4239,8 @@
 					}
 				},
 				"jest-worker": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
-					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -4850,7 +4287,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -4865,10 +4301,8 @@
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -4938,15 +4372,6 @@
 						"json5": "^1.0.1"
 					}
 				},
-				"mkdirp": {
-					"version": "0.5.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-					"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4995,6 +4420,15 @@
 				"test-exclude": "^6.0.0"
 			}
 		},
+		"babel-plugin-jest-hoist": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
+			"integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
+			"dev": true,
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
@@ -5015,6 +4449,17 @@
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.2.6.tgz",
+			"integrity": "sha512-Xh2eEAwaLY9+SyMt/xmGZDnXTW/7pSaBPG0EMo7EuhvosFKVWYB6CqwYD31DaEQuoTL090oDZ0FEqygffGRaSQ==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-bigint": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^25.2.6"
 			}
 		},
 		"babel-runtime": {
@@ -5212,6 +4657,15 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"block-stream": {
 			"version": "0.0.9",
@@ -5432,25 +4886,33 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
-			"integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
+			"integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001038",
-				"electron-to-chromium": "^1.3.390",
-				"node-releases": "^1.1.53",
-				"pkg-up": "^2.0.0"
+				"caniuse-lite": "^1.0.30001035",
+				"electron-to-chromium": "^1.3.380",
+				"node-releases": "^1.1.52",
+				"pkg-up": "^3.1.0"
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30001039",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
-					"integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
+					"version": "1.0.30001038",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+					"integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.398",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
-					"integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w=="
+					"version": "1.3.390",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
+					"integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
+				},
+				"pkg-up": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+					"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+					"requires": {
+						"find-up": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -5557,26 +5019,6 @@
 				"y18n": "^4.0.0"
 			},
 			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-					"dev": true
-				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5736,10 +5178,9 @@
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"chokidar": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
-			"dev": true,
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
@@ -5758,8 +5199,7 @@
 		"chownr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-			"dev": true
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -6036,8 +5476,7 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
 			"version": "5.52.2",
@@ -6263,8 +5702,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"consolidate": {
 			"version": "0.15.1",
@@ -6534,9 +5972,9 @@
 			"dev": true
 		},
 		"css-loader": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.1.tgz",
-			"integrity": "sha512-0G4CbcZzQ9D1Q6ndOfjFuMDo8uLYMu5vc9Abs5ztyHcKvmil6GJrMiNjzzi3tQvUF+mVRuDg7bE6Oc0Prolgig==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.0.tgz",
+			"integrity": "sha512-zed7D7JNZEq7htpu3H9oBUVWVgI6s8FgigejbVq+dc5zHV3SUPsyYBozXLIC9Eb73ahAYmnVdnn/SAB4WA75AQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.3.1",
@@ -6751,7 +6189,6 @@
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -6796,6 +6233,12 @@
 				"object-keys": "^1.1.1",
 				"regexp.prototype.flags": "^1.2.0"
 			}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"optional": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -6933,8 +6376,7 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -6963,6 +6405,12 @@
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
+		},
+		"detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+			"optional": true
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -7307,15 +6755,6 @@
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 					"dev": true
-				},
-				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
 				}
 			}
 		},
@@ -7945,12 +7384,6 @@
 				"eslint-visitor-keys": "^1.1.0"
 			},
 			"dependencies": {
-				"acorn-jsx": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-					"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-					"dev": true
-				},
 				"eslint-visitor-keys": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
@@ -8283,12 +7716,6 @@
 						"slash": "^3.0.0",
 						"stack-utils": "^1.0.1"
 					}
-				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
 				},
 				"micromatch": {
 					"version": "4.0.2",
@@ -8634,15 +8061,6 @@
 					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 					"dev": true
 				},
-				"json5": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"loader-utils": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -8665,6 +8083,12 @@
 					}
 				}
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -8764,7 +8188,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -8878,6 +8301,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.1"
+			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -8993,418 +8425,64 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+			"version": "1.2.12",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+			"integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
 			"optional": true,
 			"requires": {
+				"bindings": "^1.5.0",
 				"nan": "^2.12.1",
-				"node-pre-gyp": "^0.12.0"
+				"node-pre-gyp": "*"
 			},
 			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-					"optional": true
-				},
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"optional": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"optional": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"optional": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"optional": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"optional": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-					"optional": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"fs-minipass": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-					"optional": true,
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.6.0"
 					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"optional": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"optional": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"optional": true
-				},
 				"minipass": {
-					"version": "2.3.5",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-					"optional": true,
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
-				"minizlib": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-					"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"optional": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"optional": true
-				},
-				"needle": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-					"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
-					"optional": true,
-					"requires": {
-						"debug": "^4.1.0",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				},
 				"nopt": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-					"optional": true,
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 					"requires": {
 						"abbrev": "1",
 						"osenv": "^0.1.4"
 					}
 				},
-				"npm-bundled": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-					"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-					"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-							"optional": true
-						}
-					}
-				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"optional": true,
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -9416,66 +8494,22 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"optional": true,
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"requires": {
 						"glob": "^7.1.3"
 					}
 				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"optional": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-					"optional": true
-				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -9484,58 +8518,28 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"optional": true
-				},
 				"tar": {
-					"version": "4.4.8",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-					"optional": true,
+					"version": "4.4.13",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 					"requires": {
 						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
 						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"yallist": "^3.0.3"
 					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"optional": true
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 				}
 			}
 		},
@@ -9572,7 +8576,6 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -9587,14 +8590,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9603,7 +8604,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -9614,7 +8614,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9917,20 +8916,12 @@
 			}
 		},
 		"gonzales-pe": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
-			"integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+			"integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "1.1.x"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
-					"dev": true
-				}
+				"minimist": "^1.2.5"
 			}
 		},
 		"good-listener": {
@@ -10031,8 +9022,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -10289,7 +9279,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -10326,6 +9315,15 @@
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 			"dev": true
+		},
+		"ignore-walk": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+			"optional": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
 		},
 		"immer": {
 			"version": "1.10.0",
@@ -10403,8 +9401,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "7.1.0",
@@ -10548,24 +9545,6 @@
 					"requires": {
 						"onetime": "^5.1.0",
 						"signal-exit": "^3.0.2"
-					}
-				},
-				"run-async": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-					"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-					"dev": true,
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
-				},
-				"rxjs": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-					"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.9.0"
 					}
 				},
 				"string-width": {
@@ -10841,8 +9820,7 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -11067,8 +10045,7 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -11103,105 +10080,25 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"version": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-					"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3"
 					}
 				},
 				"@babel/highlight": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
 					}
 				},
-				"@babel/parser": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-					"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-					"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/types": "^7.8.3"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-					"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.4",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.4",
-						"@babel/types": "^7.8.3",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
 				"@babel/types": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+					"version": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -11209,10 +10106,8 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -11966,12 +10861,6 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
 				"jest-util": {
 					"version": "25.2.6",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
@@ -12409,12 +11298,6 @@
 				"jsdom": "^16.2.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-					"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-					"dev": true
-				},
 				"acorn-globals": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -12429,12 +11312,6 @@
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
 					"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
-					"dev": true
-				},
-				"browser-process-hrtime": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-					"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 					"dev": true
 				},
 				"data-urls": {
@@ -12593,15 +11470,6 @@
 					"dev": true,
 					"requires": {
 						"punycode": "^2.1.1"
-					}
-				},
-				"w3c-hr-time": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-					"integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-					"dev": true,
-					"requires": {
-						"browser-process-hrtime": "^1.0.0"
 					}
 				},
 				"w3c-xmlserializer": {
@@ -12834,6 +11702,202 @@
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
 			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
 			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+			"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.2.6",
+				"anymatch": "^3.0.3",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^2.1.2",
+				"graceful-fs": "^4.2.3",
+				"jest-serializer": "^25.2.6",
+				"jest-util": "^25.2.6",
+				"jest-worker": "^25.2.6",
+				"micromatch": "^4.0.2",
+				"sane": "^4.0.3",
+				"walker": "^1.0.7",
+				"which": "^2.0.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
+					"integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^3.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"fsevents": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
+				},
+				"graceful-fs": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jest-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
+					"integrity": "sha512-gpXy0H5ymuQ0x2qgl1zzHg7LYHZYUmDEq6F7lhHA8M0eIwDB2WteOcCnQsohl9c/vBKZ3JF2r4EseipCZz3s4Q==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"chalk": "^3.0.0",
+						"is-ci": "^2.0.0",
+						"make-dir": "^3.0.0"
+					}
+				},
+				"jest-worker": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+					"dev": true,
+					"requires": {
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
 		},
 		"jest-jasmine2": {
 			"version": "25.2.7",
@@ -13280,6 +12344,12 @@
 			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
 			"dev": true
 		},
+		"jest-regex-util": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+			"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+			"dev": true
+		},
 		"jest-resolve": {
 			"version": "25.2.6",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.2.6.tgz",
@@ -13431,12 +12501,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -13533,10 +12597,8 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -13586,11 +12648,8 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -13610,26 +12669,6 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
-				"jest-haste-map": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.6",
-						"jest-util": "^25.2.6",
-						"jest-worker": "^25.2.6",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
-				},
 				"jest-message-util": {
 					"version": "25.2.6",
 					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.2.6.tgz",
@@ -13644,12 +12683,6 @@
 						"slash": "^3.0.0",
 						"stack-utils": "^1.0.1"
 					}
-				},
-				"jest-serializer": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
-					"dev": true
 				},
 				"jest-util": {
 					"version": "25.2.6",
@@ -13729,10 +12762,8 @@
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -13860,10 +12891,8 @@
 					}
 				},
 				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -13946,11 +12975,8 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
+					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
 				},
 				"get-caller-file": {
 					"version": "2.0.5",
@@ -13967,8 +12993,7 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
@@ -13981,26 +13006,6 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"anymatch": "^3.0.3",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^2.1.2",
-						"graceful-fs": "^4.2.3",
-						"jest-serializer": "^25.2.6",
-						"jest-util": "^25.2.6",
-						"jest-worker": "^25.2.6",
-						"micromatch": "^4.0.2",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7",
-						"which": "^2.0.2"
-					}
 				},
 				"jest-message-util": {
 					"version": "25.2.6",
@@ -14026,18 +13031,6 @@
 						"@jest/types": "^25.2.6"
 					}
 				},
-				"jest-regex-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-					"dev": true
-				},
-				"jest-serializer": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
-					"dev": true
-				},
 				"jest-util": {
 					"version": "25.2.6",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
@@ -14051,10 +13044,8 @@
 					}
 				},
 				"jest-worker": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
-					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -14166,7 +13157,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -14181,10 +13171,8 @@
 					}
 				},
 				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -14242,6 +13230,12 @@
 					}
 				}
 			}
+		},
+		"jest-serializer": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+			"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
+			"dev": true
 		},
 		"jest-serializer-vue": {
 			"version": "2.0.2",
@@ -14805,22 +13799,28 @@
 			"dev": true
 		},
 		"js-beautify": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.3.tgz",
-			"integrity": "sha512-wfk/IAWobz1TfApSdivH5PJ0miIHgDoYb1ugSqHcODPmaYu46rYe5FVuIEkhjg8IQiv6rDNPyhsqbsohI/C2vQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.11.0.tgz",
+			"integrity": "sha512-a26B+Cx7USQGSWnz9YxgJNMmML/QG2nqIaL7VVYPCXbqiKz8PN0waSNvroMtvAK6tY7g/wPdNWGEP+JTNIBr6A==",
 			"dev": true,
 			"requires": {
 				"config-chain": "^1.1.12",
 				"editorconfig": "^0.15.3",
 				"glob": "^7.1.3",
-				"mkdirp": "~0.5.1",
-				"nopt": "~4.0.1"
+				"mkdirp": "~1.0.3",
+				"nopt": "^4.0.3"
 			},
 			"dependencies": {
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
 				"nopt": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 					"dev": true,
 					"requires": {
 						"abbrev": "1",
@@ -15267,7 +14267,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -15377,7 +14376,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-			"dev": true,
 			"requires": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
@@ -15386,8 +14384,7 @@
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				}
 			}
 		},
@@ -15657,8 +14654,7 @@
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
 		},
 		"merge2": {
 			"version": "1.3.0",
@@ -15835,6 +14831,30 @@
 				"minipass": "^3.0.0"
 			}
 		},
+		"minizlib": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+			"requires": {
+				"minipass": "^2.9.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+				}
+			}
+		},
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -15873,20 +14893,11 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"requires": {
-				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				}
+				"minimist": "^1.2.5"
 			}
 		},
 		"move-concurrently": {
@@ -15972,6 +14983,17 @@
 			"dev": true,
 			"requires": {
 				"varstream": "^0.3.2"
+			}
+		},
+		"needle": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
+			"integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
+			"optional": true,
+			"requires": {
+				"debug": "^3.2.6",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
 			}
 		},
 		"negotiator": {
@@ -16178,6 +15200,76 @@
 				}
 			}
 		},
+		"node-pre-gyp": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+			"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+			"optional": true,
+			"requires": {
+				"detect-libc": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"needle": "^2.2.1",
+				"nopt": "^4.0.1",
+				"npm-packlist": "^1.1.6",
+				"npmlog": "^4.0.2",
+				"rc": "^1.2.7",
+				"rimraf": "^2.6.1",
+				"semver": "^5.3.0",
+				"tar": "^4.4.2"
+			},
+			"dependencies": {
+				"fs-minipass": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+					"optional": true,
+					"requires": {
+						"minipass": "^2.6.0"
+					}
+				},
+				"minipass": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+					"optional": true,
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+					"optional": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"tar": {
+					"version": "4.4.13",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+					"optional": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"optional": true
+				}
+			}
+		},
 		"node-releases": {
 			"version": "1.1.53",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
@@ -16304,6 +15396,32 @@
 			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
 			"dev": true
 		},
+		"npm-bundled": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+			"optional": true,
+			"requires": {
+				"npm-normalize-package-bin": "^1.0.1"
+			}
+		},
+		"npm-normalize-package-bin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+			"optional": true
+		},
+		"npm-packlist": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+			"optional": true,
+			"requires": {
+				"ignore-walk": "^3.0.1",
+				"npm-bundled": "^1.0.1",
+				"npm-normalize-package-bin": "^1.0.1"
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -16317,7 +15435,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -16334,8 +15451,7 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -16352,8 +15468,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -16439,17 +15554,6 @@
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				}
 			}
 		},
 		"object.pick": {
@@ -16744,8 +15848,7 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -16759,14 +15862,12 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -16800,7 +15901,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
 			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -16809,7 +15909,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -16832,8 +15931,7 @@
 		"p-try": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-			"dev": true
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
 		"pako": {
 			"version": "1.0.11",
@@ -17033,8 +16131,7 @@
 		"picomatch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
-			"dev": true
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
 		},
 		"pify": {
 			"version": "3.0.0",
@@ -17079,6 +16176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			},
@@ -17087,6 +16185,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -17095,6 +16194,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -17104,6 +16204,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -17112,6 +16213,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -17119,7 +16221,8 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				}
 			}
 		},
@@ -18084,6 +17187,18 @@
 						"ajv-keywords": "^3.4.1"
 					}
 				}
+			}
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"optional": true,
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			}
 		},
 		"react": {
@@ -19343,15 +18458,6 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"convert-source-map": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
 				"postcss": {
 					"version": "7.0.21",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
@@ -19444,7 +18550,6 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -19518,8 +18623,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -19587,12 +18691,6 @@
 					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 					"dev": true
 				},
-				"neo-async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-					"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-					"dev": true
-				},
 				"schema-utils": {
 					"version": "2.6.4",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
@@ -19614,8 +18712,7 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"saxes": {
 			"version": "3.1.11",
@@ -19806,8 +18903,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -19904,8 +19000,7 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -20408,7 +19503,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -20479,7 +19573,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0"
 			}
@@ -20520,8 +19613,7 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"style-loader": {
 			"version": "1.1.3",
@@ -21510,22 +20602,6 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"glob": "^7.1.4",
 				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"text-table": {
@@ -22176,15 +21252,6 @@
 					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 					"dev": true
 				},
-				"json5": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"loader-utils": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -22498,18 +21565,6 @@
 				"lodash": "^4.17.15"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-					"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-					"dev": true
-				},
-				"acorn-jsx": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-					"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-					"dev": true
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -22534,17 +21589,6 @@
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
 					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 					"dev": true
-				},
-				"espree": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-					"dev": true,
-					"requires": {
-						"acorn": "^7.1.1",
-						"acorn-jsx": "^5.2.0",
-						"eslint-visitor-keys": "^1.1.0"
-					}
 				},
 				"lodash": {
 					"version": "4.17.15",
@@ -22847,12 +21891,12 @@
 			"dev": true
 		},
 		"watchpack": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
+			"integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.2",
+				"chokidar": "^2.1.8",
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0"
 			}
@@ -22942,41 +21986,9 @@
 					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 					"dev": true
 				},
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-					"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
+					"version": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -23245,26 +22257,6 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
-				},
-				"chokidar": {
-					"version": "2.1.8",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
 				},
 				"cliui": {
 					"version": "4.1.0",
@@ -23538,7 +22530,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,18 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
 					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
 				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
 				"pify": {
-					"version": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"slash": {
@@ -86,6 +96,20 @@
 						"@babel/highlight": "^7.8.3"
 					}
 				},
+				"@babel/helper-module-transforms": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+					"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.8.3",
+						"@babel/helper-replace-supers": "^7.8.6",
+						"@babel/helper-simple-access": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/template": "^7.8.6",
+						"@babel/types": "^7.9.0",
+						"lodash": "^4.17.13"
+					}
+				},
 				"@babel/highlight": {
 					"version": "7.9.0",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
@@ -95,6 +119,11 @@
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
 					}
+				},
+				"@babel/parser": {
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 				},
 				"@babel/types": {
 					"version": "7.9.0",
@@ -147,12 +176,17 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -168,12 +202,17 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -213,12 +252,6 @@
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-regex": "^7.8.3",
 				"regexpu-core": "^4.7.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-				}
 			}
 		},
 		"@babel/helper-define-map": {
@@ -231,12 +264,17 @@
 				"lodash": "^4.17.13"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -252,12 +290,17 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -314,12 +357,17 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -380,12 +428,17 @@
 				"lodash": "^4.17.13"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -437,12 +490,17 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -461,10 +519,48 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"version": "7.8.3",
+					"resolved": false,
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 					"requires": {
 						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.7",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
+					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+					"requires": {
+						"@babel/types": "^7.8.7",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"requires": {
+						"@babel/types": "^7.8.3"
 					}
 				},
 				"@babel/highlight": {
@@ -475,6 +571,37 @@
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
@@ -488,7 +615,8 @@
 					}
 				},
 				"debug": {
-					"version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
@@ -506,7 +634,8 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"version": "7.8.3",
+					"resolved": false,
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 					"requires": {
 						"@babel/highlight": "^7.8.3"
@@ -520,6 +649,21 @@
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
 					}
 				},
 				"@babel/types": {
@@ -570,12 +714,17 @@
 				"@babel/types": "^7.8.3"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -618,7 +767,8 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -667,12 +817,13 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
-			"integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+			"integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-transform-parameters": "^7.9.5"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
@@ -827,18 +978,45 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz",
-			"integrity": "sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==",
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
+			"integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-define-map": "^7.8.3",
-				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-function-name": "^7.9.5",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-split-export-declaration": "^7.8.3",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/helper-function-name": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+					"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.9.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
+				"@babel/types": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.5",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -850,9 +1028,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
-			"integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
+			"integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -983,9 +1161,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.9.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz",
-			"integrity": "sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==",
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+			"integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1077,9 +1255,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
-			"integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
+			"integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
 			"requires": {
 				"@babel/compat-data": "^7.9.0",
 				"@babel/helper-compilation-targets": "^7.8.7",
@@ -1090,7 +1268,7 @@
 				"@babel/plugin-proposal-json-strings": "^7.8.3",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
 				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.9.5",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
@@ -1107,9 +1285,9 @@
 				"@babel/plugin-transform-async-to-generator": "^7.8.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
 				"@babel/plugin-transform-block-scoping": "^7.8.3",
-				"@babel/plugin-transform-classes": "^7.9.0",
+				"@babel/plugin-transform-classes": "^7.9.5",
 				"@babel/plugin-transform-computed-properties": "^7.8.3",
-				"@babel/plugin-transform-destructuring": "^7.8.3",
+				"@babel/plugin-transform-destructuring": "^7.9.5",
 				"@babel/plugin-transform-dotall-regex": "^7.8.3",
 				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
 				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
@@ -1124,7 +1302,7 @@
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
 				"@babel/plugin-transform-new-target": "^7.8.3",
 				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.8.7",
+				"@babel/plugin-transform-parameters": "^7.9.5",
 				"@babel/plugin-transform-property-literals": "^7.8.3",
 				"@babel/plugin-transform-regenerator": "^7.8.7",
 				"@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -1135,7 +1313,7 @@
 				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
 				"@babel/plugin-transform-unicode-regex": "^7.8.3",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.9.0",
+				"@babel/types": "^7.9.5",
 				"browserslist": "^4.9.1",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
@@ -1143,12 +1321,17 @@
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1167,12 +1350,17 @@
 				"esutils": "^2.0.2"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+					"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+				},
 				"@babel/types": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1224,6 +1412,11 @@
 						"js-tokens": "^4.0.0"
 					}
 				},
+				"@babel/parser": {
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+				},
 				"@babel/types": {
 					"version": "7.9.0",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
@@ -1269,6 +1462,11 @@
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
 					}
+				},
+				"@babel/parser": {
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 				},
 				"@babel/types": {
 					"version": "7.9.0",
@@ -1595,8 +1793,10 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -1646,8 +1846,11 @@
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -1658,13 +1861,34 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.6",
+						"jest-util": "^25.2.6",
+						"jest-worker": "^25.2.6",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
 				},
 				"jest-message-util": {
 					"version": "25.2.6",
@@ -1681,6 +1905,18 @@
 						"stack-utils": "^1.0.1"
 					}
 				},
+				"jest-regex-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+					"dev": true
+				},
+				"jest-serializer": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
+					"dev": true
+				},
 				"jest-util": {
 					"version": "25.2.6",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
@@ -1694,8 +1930,10 @@
 					}
 				},
 				"jest-worker": {
-					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -1760,6 +1998,7 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -1774,8 +2013,10 @@
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -2170,8 +2411,10 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -2221,8 +2464,11 @@
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -2240,6 +2486,38 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.6",
+						"jest-util": "^25.2.6",
+						"jest-worker": "^25.2.6",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
+				},
+				"jest-regex-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+					"dev": true
+				},
+				"jest-serializer": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
 					"dev": true
 				},
 				"jest-util": {
@@ -2320,8 +2598,10 @@
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -2500,8 +2780,10 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -2511,6 +2793,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
 					"requires": {
 						"fill-range": "^7.0.1"
 					}
@@ -2544,13 +2827,17 @@
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -2561,12 +2848,40 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.6",
+						"jest-util": "^25.2.6",
+						"jest-worker": "^25.2.6",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
+				},
+				"jest-serializer": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
+					"dev": true
 				},
 				"jest-util": {
 					"version": "25.2.6",
@@ -2581,8 +2896,10 @@
 					}
 				},
 				"jest-worker": {
-					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -2598,8 +2915,10 @@
 					}
 				},
 				"micromatch": {
-					"version": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
@@ -2627,6 +2946,7 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -2635,13 +2955,16 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -2695,8 +3018,10 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -2746,8 +3071,11 @@
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -2767,6 +3095,48 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
+				"jest-haste-map": {
+					"version": "25.2.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.0.tgz",
+					"integrity": "sha512-VeoodAL671sKKXDvaT2r1Z/0GSDWJi/fAcDGuRAHrRCqkrPnPsV0Uq35YTNO0RrMF8LdRRogu6Mie1Eli2CVLA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.0",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.0",
+						"jest-util": "^25.2.0",
+						"jest-worker": "^25.2.0",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
+				},
+				"jest-regex-util": {
+					"version": "25.2.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.0.tgz",
+					"integrity": "sha512-D85pUKyzdi4zFAnub4EDp48eB08oua2aaN8wPrcaL98SnmJmJCSC+8iMZvonyy8qTtXgElK8JcsdPl4Y8+WhGg==",
+					"dev": true
+				},
+				"jest-serializer": {
+					"version": "25.2.0",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.0.tgz",
+					"integrity": "sha512-wCaA4dM1F4klHEpjRzAnv/8K4eqvB/0x4f6AA4W8ie8DP2XarCt6yAsdRCE+zw+htZSwcNOWvYvpOVov8y8pJA==",
+					"dev": true
+				},
+				"jest-worker": {
+					"version": "25.2.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.0.tgz",
+					"integrity": "sha512-oGzUBnVnRdb51Aru3XFNa0zOafAIEerqZoQow+Vy8LDDiy12dvSrOeVeO8oNrxCMkGG4JtXqX9IPC93JJiAk+g==",
+					"dev": true,
+					"requires": {
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
 				"micromatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -2776,6 +3146,12 @@
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
 					}
+				},
+				"realpath-native": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+					"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+					"dev": true
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -2808,8 +3184,10 @@
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -2952,9 +3330,9 @@
 			}
 		},
 		"@nextcloud/l10n": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.2.0.tgz",
-			"integrity": "sha512-aPsVAewCYMNe2h0yse3Fj7LofvnvFPimojw24K47ip1+I1gawMIsQL+BYAnN8wzlcbsDTEc7I1FxtOh+8dHHIA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.2.2.tgz",
+			"integrity": "sha512-p4YrycRqLY2yBaK9E/G5pbISxwmsgs4cd2KbI1zIiMWHiPrZWqU0myQFgfuoL9zW3ySyKI7ozqyJu4I8RZEOAA==",
 			"requires": {
 				"core-js": "^3.6.4",
 				"node-gettext": "^3.0.0"
@@ -4055,13 +4433,112 @@
 				"resolve": "^1.12.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+					"integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.9.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
 				"@babel/highlight": {
-					"version": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+					"version": "7.9.0",
+					"resolved": false,
 					"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.9.0",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.8.3",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+							"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.8.3"
+							}
+						}
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+					"integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.9.0",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.9.0",
+						"@babel/types": "^7.9.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.8.3",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+							"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.8.3"
+							}
+						}
 					}
 				},
 				"@babel/types": {
@@ -4076,8 +4553,10 @@
 					}
 				},
 				"debug": {
-					"version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -4155,11 +4634,33 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
+					"integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
+					"dev": true,
+					"requires": {
+						"@types/babel__traverse": "^7.0.6"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.2.6.tgz",
+					"integrity": "sha512-Xh2eEAwaLY9+SyMt/xmGZDnXTW/7pSaBPG0EMo7EuhvosFKVWYB6CqwYD31DaEQuoTL090oDZ0FEqygffGRaSQ==",
+					"dev": true,
+					"requires": {
+						"@babel/plugin-syntax-bigint": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+						"babel-plugin-jest-hoist": "^25.2.6"
 					}
 				},
 				"braces": {
@@ -4206,8 +4707,11 @@
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -4218,12 +4722,45 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.6",
+						"jest-util": "^25.2.6",
+						"jest-worker": "^25.2.6",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
+				},
+				"jest-regex-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+					"dev": true
+				},
+				"jest-serializer": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+					"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
 					"dev": true
 				},
 				"jest-util": {
@@ -4239,8 +4776,10 @@
 					}
 				},
 				"jest-worker": {
-					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -4287,6 +4826,7 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -4301,8 +4841,10 @@
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -4372,6 +4914,15 @@
 						"json5": "^1.0.1"
 					}
 				},
+				"mkdirp": {
+					"version": "0.5.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+					"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4420,15 +4971,6 @@
 				"test-exclude": "^6.0.0"
 			}
 		},
-		"babel-plugin-jest-hoist": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
-			"integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
-			"dev": true,
-			"requires": {
-				"@types/babel__traverse": "^7.0.6"
-			}
-		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
@@ -4449,17 +4991,6 @@
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-preset-jest": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.2.6.tgz",
-			"integrity": "sha512-Xh2eEAwaLY9+SyMt/xmGZDnXTW/7pSaBPG0EMo7EuhvosFKVWYB6CqwYD31DaEQuoTL090oDZ0FEqygffGRaSQ==",
-			"dev": true,
-			"requires": {
-				"@babel/plugin-syntax-bigint": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^25.2.6"
 			}
 		},
 		"babel-runtime": {
@@ -4886,33 +5417,25 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-			"integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+			"integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001035",
-				"electron-to-chromium": "^1.3.380",
-				"node-releases": "^1.1.52",
-				"pkg-up": "^3.1.0"
+				"caniuse-lite": "^1.0.30001038",
+				"electron-to-chromium": "^1.3.390",
+				"node-releases": "^1.1.53",
+				"pkg-up": "^2.0.0"
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30001038",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
-					"integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
+					"version": "1.0.30001039",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
+					"integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.390",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-					"integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
-				},
-				"pkg-up": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-					"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-					"requires": {
-						"find-up": "^3.0.0"
-					}
+					"version": "1.3.398",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
+					"integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w=="
 				}
 			}
 		},
@@ -5019,6 +5542,26 @@
 				"y18n": "^4.0.0"
 			},
 			"dependencies": {
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5972,9 +6515,9 @@
 			"dev": true
 		},
 		"css-loader": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.0.tgz",
-			"integrity": "sha512-zed7D7JNZEq7htpu3H9oBUVWVgI6s8FgigejbVq+dc5zHV3SUPsyYBozXLIC9Eb73ahAYmnVdnn/SAB4WA75AQ==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.1.tgz",
+			"integrity": "sha512-0G4CbcZzQ9D1Q6ndOfjFuMDo8uLYMu5vc9Abs5ztyHcKvmil6GJrMiNjzzi3tQvUF+mVRuDg7bE6Oc0Prolgig==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.3.1",
@@ -6755,6 +7298,15 @@
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
 				}
 			}
 		},
@@ -7384,6 +7936,12 @@
 				"eslint-visitor-keys": "^1.1.0"
 			},
 			"dependencies": {
+				"acorn-jsx": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+					"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+					"dev": true
+				},
 				"eslint-visitor-keys": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
@@ -7716,6 +8274,12 @@
 						"slash": "^3.0.0",
 						"stack-utils": "^1.0.1"
 					}
+				},
+				"jest-regex-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+					"dev": true
 				},
 				"micromatch": {
 					"version": "4.0.2",
@@ -8061,6 +8625,15 @@
 					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 					"dev": true
 				},
+				"json5": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"loader-utils": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -8188,6 +8761,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -10045,7 +10619,8 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -11703,202 +12278,6 @@
 			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
 			"dev": true
 		},
-		"jest-haste-map": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
-			"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.2.6",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-serializer": "^25.2.6",
-				"jest-util": "^25.2.6",
-				"jest-worker": "^25.2.6",
-				"micromatch": "^4.0.2",
-				"sane": "^4.0.3",
-				"walker": "^1.0.7",
-				"which": "^2.0.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
-					"integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"dev": true,
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-					"dev": true,
-					"optional": true
-				},
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"jest-util": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
-					"integrity": "sha512-gpXy0H5ymuQ0x2qgl1zzHg7LYHZYUmDEq6F7lhHA8M0eIwDB2WteOcCnQsohl9c/vBKZ3JF2r4EseipCZz3s4Q==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.2.6",
-						"chalk": "^3.0.0",
-						"is-ci": "^2.0.0",
-						"make-dir": "^3.0.0"
-					}
-				},
-				"jest-worker": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
-					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
-					"dev": true,
-					"requires": {
-						"merge-stream": "^2.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
-		},
 		"jest-jasmine2": {
 			"version": "25.2.7",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.2.7.tgz",
@@ -12597,8 +12976,10 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -12648,8 +13029,11 @@
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"graceful-fs": {
 					"version": "4.2.3",
@@ -12668,6 +13052,26 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.6",
+						"jest-util": "^25.2.6",
+						"jest-worker": "^25.2.6",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
 				},
 				"jest-message-util": {
 					"version": "25.2.6",
@@ -12762,8 +13166,10 @@
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -12891,8 +13297,10 @@
 					}
 				},
 				"anymatch": {
-					"version": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
@@ -12975,8 +13383,11 @@
 					}
 				},
 				"fsevents": {
-					"version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
 				},
 				"get-caller-file": {
 					"version": "2.0.5",
@@ -12993,7 +13404,8 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
@@ -13006,6 +13418,26 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.6.tgz",
+					"integrity": "sha512-nom0+fnY8jwzelSDQnrqaKAcDZczYQvMEwcBjeL3PQ4MlcsqeB7dmrsAniUw/9eLkngT5DE6FhnenypilQFsgA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.2.6",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.3",
+						"jest-serializer": "^25.2.6",
+						"jest-util": "^25.2.6",
+						"jest-worker": "^25.2.6",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
 				},
 				"jest-message-util": {
 					"version": "25.2.6",
@@ -13044,8 +13476,10 @@
 					}
 				},
 				"jest-worker": {
-					"version": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
 					"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+					"dev": true,
 					"requires": {
 						"merge-stream": "^2.0.0",
 						"supports-color": "^7.0.0"
@@ -13157,6 +13591,7 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -13171,8 +13606,10 @@
 					}
 				},
 				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -14267,6 +14704,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -14376,6 +14814,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"dev": true,
 			"requires": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
@@ -14384,7 +14823,8 @@
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
 				}
 			}
 		},
@@ -14654,7 +15094,8 @@
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"merge2": {
 			"version": "1.3.0",
@@ -14986,9 +15427,9 @@
 			}
 		},
 		"needle": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
-			"integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.1.tgz",
+			"integrity": "sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==",
 			"optional": true,
 			"requires": {
 				"debug": "^3.2.6",
@@ -15901,6 +16342,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
 			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -15909,6 +16351,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -15931,7 +16374,8 @@
 		"p-try": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+			"dev": true
 		},
 		"pako": {
 			"version": "1.0.11",
@@ -16131,7 +16575,8 @@
 		"picomatch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+			"dev": true
 		},
 		"pify": {
 			"version": "3.0.0",
@@ -16176,7 +16621,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			},
@@ -16185,7 +16629,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -16194,7 +16637,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -16204,7 +16646,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -16213,7 +16654,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -16221,8 +16661,7 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				}
 			}
 		},


### PR DESCRIPTION
Regarding the messages:

```js
// Requires jest 26 https://github.com/facebook/jest/issues/5815
npm WARN acorn-dynamic-import@4.0.0 requires a peer of acorn@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN jsdom@16.2.1 requires a peer of canvas@^2.5.0 but none is installed. You must install peer dependencies yourself.
npm WARN jsdom@15.2.1 requires a peer of canvas@^2.5.0 but none is installed. You must install peer dependencies yourself.

// Requires jsdom@16, crossing the jest issue above
npm WARN ws@7.2.3 requires a peer of bufferutil@^4.0.1 but none is installed. You must install peer dependencies yourself.
npm WARN ws@7.2.3 requires a peer of utf-8-validate@^5.0.2 but none is installed. You must install peer dependencies yourself.
npm WARN ws@7.2.3 requires a peer of bufferutil@^4.0.1 but none is installed. You must install peer dependencies yourself.
npm WARN ws@7.2.3 requires a peer of utf-8-validate@^5.0.2 but none is installed. You must install peer dependencies yourself.

// Requires node-sass 5 (everyone is waiti, they're super late and missing lots of new features of sass) https://github.com/sass/node-sass/issues/2111
npm WARN sass-loader@8.0.2 requires a peer of sass@^1.3.0 but none is installed. You must install peer dependencies yourself.
npm WARN sass-loader@8.0.2 requires a peer of fibers@>= 3.1.0 but none is installed. You must install peer dependencies yourself.
```