### PR TITLE
Check by index if hiding breadcrumbs is necessary

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -363,11 +363,12 @@ export default {
 		 *
 		 * @param {Array} crumbs The array of all crumbs
 		 * @param {Array} newCrumbs The array of the crumbs to hide and add
+		 * @param {Integer} offset The offset of the indices of the provided crumbs array
 		 */
-		addCrumbs(crumbs, newCrumbs) {
+		addCrumbs(crumbs, newCrumbs, offset = 0) {
 			newCrumbs.forEach((crumb, i) => {
 				if (crumb.elm && crumb.elm.classList) {
-					if (this.hiddenCrumbs.includes(crumb)) {
+					if (this.hiddenIndices.includes(i + offset)) {
 						crumb.elm.classList.add('crumb--hidden')
 					} else {
 						crumb.elm.classList.remove('crumb--hidden')
@@ -472,7 +473,7 @@ export default {
 		const crumbs2 = this.hiddenCrumbs.length
 			? breadcrumbs.slice(Math.round(breadcrumbs.length / 2))
 			: []
-		this.addCrumbs(crumbs, crumbs2)
+		this.addCrumbs(crumbs, crumbs2, crumbs1.length)
 
 		return createElement('div', { class: 'breadcrumb', ref: 'container' }, crumbs)
 	},


### PR DESCRIPTION
Due to vues inplace patching strategy comparing the crumbs was not reliable, so it could happen, that the hidden class was not applied to a crumb that should be hidden. Checking by the index is more reliable, as it only compares Integers.