### PR TITLE
Move away from containers server styling

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -23,7 +23,7 @@
  -->
 
 <template>
-	<main id="app-content" class="no-snapper">
+	<main id="app-content-vue" class="app-content no-snapper">
 		<!-- @slot Provide content to the app content -->
 		<slot />
 	</main>
@@ -79,14 +79,15 @@ export default {
 </script>
 <style lang="scss" scoped>
 
-#app-content {
-	z-index: 1000;
-	background-color: var(--color-main-background);
+.app-content {
 	position: relative;
+	z-index: 1000;
 	flex-basis: 100vw;
+	min-width: 0;
 	min-height: 100%;
 	// Overriding server styles TODO: cleanup!
 	margin: 0 !important;
+	background-color: var(--color-main-background);
 }
 
 </style>

--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -55,6 +55,7 @@ emit('toggle-navigation', {
 
 <template>
 	<div
+		id="app-navigation-vue"
 		class="app-navigation"
 		:class="{'app-navigation--close':!open }">
 		<AppNavigationToggle :open="open" @update:open="toggleNavigation" />

--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -25,7 +25,7 @@
 	<a class="app-navigation-toggle"
 		href="#"
 		:aria-expanded="open"
-		aria-controls="app-navigation"
+		aria-controls="app-navigation-vue"
 		@click.prevent="toggleNavigation"
 		@keydown.space.exact.prevent="toggleNavigation" />
 </template>

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -87,7 +87,7 @@
 
 <template>
 	<transition name="slide-right">
-		<aside id="app-sidebar">
+		<aside id="app-sidebar-vue" class="app-sidebar">
 			<header :class="{
 					'app-sidebar-header--with-figure': hasFigure,
 					'app-sidebar-header--compact': compact
@@ -510,9 +510,9 @@ $top-buttons-spacing: 6px;
 
 /*
 	Sidebar: to be used within #content
-	#app-content will be shrinked properly
+	app-content will be shrinked properly
 */
-#app-sidebar {
+.app-sidebar {
 	position: -webkit-sticky; // Safari support
 	position: sticky;
 	z-index: 1500;

--- a/src/components/Content/Content.vue
+++ b/src/components/Content/Content.vue
@@ -45,7 +45,9 @@
 </docs>
 
 <template>
-	<div id="content" :class="`app-${appName}`">
+	<div id="content-vue"
+		:class="`app-${appName.toLowerCase()}`"
+		class="content">
 		<slot />
 	</div>
 </template>
@@ -60,3 +62,16 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.content {
+	box-sizing: border-box;
+	position: relative;
+	display: flex;
+	padding-top: 50px;
+	min-height: 100%;
+	::v-deep * {
+		box-sizing: border-box;
+	}
+}
+</style>


### PR DESCRIPTION
- [x] Move away from server styling
- [x] Set app-content default to shrink with `min-width`
   :warning: breaking! If you added some css to make sure the content was not overflowing to the right, please remove it, the content will now be shrink properly alongside the app-nav & app-sidebar with flex (like it should have been since the beginning!)
- [x] Fixed app-navigation-toggle aria controls