### PR TITLE
Finish toggle animation before emitting event

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -116,7 +116,8 @@ export default {
 				emit('navigation-toggled', {
 					open: this.open,
 				})
-			}, animationLength)
+			// We wait for 1.5 times the animation length to give the animation time to really finish.
+			}, 1.5 * animationLength)
 		},
 		toggleNavigationByEventBus({ open }) {
 			this.toggleNavigation(open)


### PR DESCRIPTION
The `navigation-toggled` event was emitted to soon, before the animation finished. Hence, the breadcrumb component would get the wrong width and hide breadcrumbs although not necessary. On hovering the actions menu, a resize would be triggered and the crumbs would be visible (correctly) now.

Giving a bit more time to finish the animation fixes the issue.

Follow-up to #975 @skjnldsv 

Before:
![master](https://user-images.githubusercontent.com/2496460/79433367-4d4aea80-7fcd-11ea-9467-02eee6ac349e.gif)

After:
![fix](https://user-images.githubusercontent.com/2496460/79433386-5471f880-7fcd-11ea-8e2c-a6865b116ea9.gif)
