### PR TITLE
Pass Date object for Action Input Value

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -129,7 +129,7 @@ export default {
 		 * value attribute of the input field
 		 */
 		value: {
-			type: String,
+			type: [String, Date, Number],
 			default: '',
 		},
 		/**


### PR DESCRIPTION
For addressing nextcloud/server#20520

`vue2-datepicker` expects a v-model with a `Date` but the value type checks for string only.
