### PR TITLE
Replace v-html directive for Multiselect highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7111,7 +7111,8 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@nextcloud/router": "^1.0.0",
 		"core-js": "^3.4.4",
 		"debounce": "1.2.0",
-		"escape-html": "^1.0.3",
 		"hammerjs": "^2.0.8",
 		"md5": "^2.2.1",
 		"regenerator-runtime": "^0.13.3",

--- a/src/components/Highlight/Highlight.vue
+++ b/src/components/Highlight/Highlight.vue
@@ -1,0 +1,183 @@
+<!--
+  - @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+  -
+  - @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<docs>
+
+### General description
+
+Highlight a string with html &lt;strong&gt;. Accepts a substring to highlight or an array with ranges.
+
+### Usage
+
+```vue
+<template>
+	<div>
+		<Highlight text="Highlight me please!" search="me" />
+		<br />
+		<Highlight text="Highlight me please!" :highlight="[{ start: 4, end: 12 }]" />
+	</div>
+</template>
+```
+</docs>
+
+<script>
+import FindRanges from '../../utils/FindRanges'
+
+export default {
+	name: 'Highlight',
+	props: {
+		/**
+		 * The string to display
+		 */
+		text: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * The string to match and highlight
+		 */
+		search: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * The ranges to highlight, takes precedence over the search prop.
+		 */
+		highlight: {
+			type: Array,
+			default: () => [],
+		},
+	},
+	computed: {
+		/**
+		 * The indice ranges which should be highlighted.
+		 * If an array with ranges is provided, we use it. Otherwise
+		 * we calculate it based on the provided substring to highlight.
+		 *
+		 * @returns {Array} The array of ranges to highlight
+		 */
+		ranges() {
+			let ranges = []
+			// If the search term and the highlight array is empty, return early with empty array
+			if (!this.search && this.highlight.length === 0) {
+				return ranges
+			}
+
+			// If there are ranges to highlight provided, we use this array.
+			if (this.highlight.length > 0) {
+				ranges = this.highlight
+			// Otherwise we check the text to highlight for matches of the search term.
+			} else {
+				ranges = FindRanges(this.text, this.search)
+			}
+
+			/**
+			 * Validate the ranges array to be within the string length
+			 * and discard ranges which are completely out of bonds.
+			 */
+			return ranges.reduce((validRanges, range) => {
+				if (range.start < this.text.length && range.end > 0) {
+					validRanges.push({
+						start: (range.start < 0) ? 0 : range.start,
+						end: (range.end > this.text.length) ? this.text.length : range.end,
+					})
+				}
+				return validRanges
+			}, [])
+		},
+		/**
+		 * Calculate the different chunks to show based on the ranges to highlight.
+		 *
+		 * @returns {Array} The chunks
+		 */
+		chunks() {
+			// If the ranges array is empty, show only one chunk with all text
+			if (this.ranges.length === 0) {
+				return [{
+					start: 0,
+					end: this.text.length,
+					highlight: false,
+					text: this.text,
+				}]
+			}
+			// Calculate the chunks
+			const chunks = []
+			let currentIndex = 0
+			let currentRange = 0
+			// Iterate over all characters in the text
+			while (currentIndex < this.text.length) {
+				// Get the first range to highlight
+				const range = this.ranges[currentRange]
+				// If the range starts at the current index, construct a chunk to highlight,
+				// set the next range and continue with the next iteration.
+				if (range.start === currentIndex) {
+					chunks.push({
+						...range,
+						highlight: true,
+						text: this.text.substr(range.start, range.end - range.start),
+					})
+					currentRange++
+					currentIndex = range.end
+					// If this was the last range to highlight and we haven't reached the end of the text,
+					// add the rest of the text without highlighting.
+					if (currentRange >= this.ranges.length && currentIndex < this.text.length) {
+						chunks.push({
+							start: currentIndex,
+							end: this.text.length,
+							highlight: false,
+							text: this.text.substr(currentIndex, this.text.length - currentIndex),
+						})
+						// Set the current index so the while loop ends.
+						currentIndex = this.text.length
+					}
+					continue
+				}
+				// If the current range does start after the current index, construct a chunk without
+				// highlighting and set the current index to the start of the current range.
+				chunks.push({
+					start: currentIndex,
+					end: range.start,
+					highlight: false,
+					text: this.text.substr(currentIndex, range.start - currentIndex),
+				})
+				currentIndex = range.start
+			}
+			return chunks
+		},
+	},
+	/**
+	 * The render function to display the component
+	 *
+	 * @param {Function} createElement The function to create VNodes
+	 * @returns {VNodes} The created VNodes
+	 */
+	render: function(createElement) {
+		if (!this.ranges.length) {
+			return createElement('span', {}, this.text)
+		}
+
+		return createElement('span', {}, this.chunks.map(chunk => {
+			return chunk.highlight ? createElement('strong', {}, chunk.text) : chunk.text
+		}))
+	},
+}
+</script>

--- a/src/components/Highlight/index.js
+++ b/src/components/Highlight/index.js
@@ -1,7 +1,7 @@
 /**
- * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ * @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
  *
- * @author John Molakvoæ <skjnldsv@protonmail.com>
+ * @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -20,18 +20,6 @@
  *
  */
 
-export default {
-	methods: {
-		/**
-		 * Highlight a string with html <strong>
-		 *
-		 * @param {string} text the string to process
-		 * @param {string} match the string to match
-		 * @returns {string}
-		 */
-		highlightText(text, match) {
-			if (!match.length) return text
-			return text.replace(new RegExp(match, 'gi'), `<strong>${match}</strong>`)
-		},
-	},
-}
+import Highlight from './Highlight'
+
+export default Highlight

--- a/src/components/Multiselect/AvatarSelectOption.vue
+++ b/src/components/Multiselect/AvatarSelectOption.vue
@@ -70,27 +70,30 @@ export default {
 			:disable-tooltip="true"
 			class="option__avatar" />
 		<div class="option__desc">
-			<span class="option__desc--lineone"
-				v-html="highlightedDisplayName" />
-			<span v-if="desc !== ''"
+			<Highlight
+				class="option__desc--lineone"
+				:text="displayName"
+				:search="search" />
+			<Highlight
+				v-if="desc !== ''"
 				class="option__desc--linetwo"
-				v-html="highlightedDesc" />
+				:text="desc"
+				:search="search" />
 		</div>
 		<span v-if="icon !== ''" class="icon option__icon" :class="icon" />
 	</span>
 </template>
 
 <script>
-import escapeHtml from 'escape-html'
 import Avatar from '../Avatar'
-import highlightText from '../../mixins/highlightText'
+import Highlight from '../Highlight'
 
 export default {
 	name: 'AvatarSelectOption',
 	components: {
 		Avatar,
+		Highlight,
 	},
-	mixins: [highlightText],
 	props: {
 		/**
 		 * Secondary optional line
@@ -131,14 +134,6 @@ export default {
 		search: {
 			type: String,
 			default: '',
-		},
-	},
-	computed: {
-		highlightedDisplayName() {
-			return this.highlightText(escapeHtml(this.displayName), this.search)
-		},
-		highlightedDesc() {
-			return this.highlightText(escapeHtml(this.desc), this.search)
 		},
 	},
 }

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -37,7 +37,7 @@ You can use all the properties from https://vue-multiselect.js.org that are not 
 import Multiselect from '../index'
 export default {
 	data() {
-		return { value1: 2, value2: [2], options: [0, 1, 2, 3, 4] }
+		return { value1: '2', value2: ['2'], options: ['0', '1', '2', '3', '4'] }
 	}
 }
 </script>

--- a/src/utils/FindRanges.js
+++ b/src/utils/FindRanges.js
@@ -1,0 +1,47 @@
+/**
+ * @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Find the ranges of a substr in a given string
+ *
+ * @param {String} text The text to search in
+ * @param {String} search The text to search for
+ * @returns {Array} The array of ranges to highlight
+ */
+const FindRanges = (text, search) => {
+	const ranges = []
+	let currentIndex = 0
+	let index = text.toLowerCase().indexOf(search.toLowerCase(), currentIndex)
+	// Variable to track that we don't iterate more often than the length of the text.
+	// Shouldn't happen anyway, but just to be sure to not hang the browser for some reason.
+	let i = 0
+	while (index > -1 && i < text.length) {
+		currentIndex = index + search.length
+		ranges.push({ start: index, end: currentIndex })
+
+		index = text.toLowerCase().indexOf(search.toLowerCase(), index + 1)
+		i++
+	}
+	return ranges
+}
+
+export default FindRanges


### PR DESCRIPTION
This PR adds a `Highlight` directive, which highlights a substring with `<strong>`. It allows us to get rid of the currently used `v-html` directive and fixes some bugs in the current implementation.

Closes #1031.

Problems fixed compared to the current solution:
- The casing of the searched term is now correctly maintained. Before, if you searched for `opt`, `Option 1` would've become `option 1`

| master | PR | 
| ------------- |:-------------:|
| ![master_casing](https://user-images.githubusercontent.com/2496460/79697319-57e1da00-8282-11ea-902b-598ec87b1b4e.gif)     | ![pr_casing](https://user-images.githubusercontent.com/2496460/79697376-b9a24400-8282-11ea-85bc-95466acc81b4.gif) |

- In the ellipsised multiselect search terms are now correctly highlighted even if they span both parts

| master | PR | 
| ------------- |:-------------:|
| ![master_ellips](https://user-images.githubusercontent.com/2496460/79697560-c5423a80-8283-11ea-894b-7a5ce388d577.gif) | ![pr_ellips](https://user-images.githubusercontent.com/2496460/79697648-f9b5f680-8283-11ea-8975-e0282d39beaa.gif) |