### PR TITLE
White background for avatars with transparency, also in dark theme

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -421,6 +421,12 @@ export default {
 		background-color: var(--color-text-maxcontrast);
 	}
 
+	&:not(&--unknown) {
+		// White background for avatars with transparency, also in dark theme
+		background-color: #fff !important;
+		box-shadow: 0 0 5px rgba(0, 0, 0, 0.05) inset;
+	}
+
 	&--with-menu {
 		cursor: pointer;
 		.icon-more {


### PR DESCRIPTION
### Before
Avatars with transparency have the generated color from the letter placeholder shine through. This of course should not happen and looks all kinds of weird with logos:
![Mail app avatars before](https://user-images.githubusercontent.com/925062/80022639-a7234700-84dc-11ea-843c-0f9f86dc7fdb.png) ![Mail app avatars dark theme before](https://user-images.githubusercontent.com/925062/80022641-a7bbdd80-84dc-11ea-98d2-5d42fdd5b3f6.png)

### After
Now there is always white background. Also in the dark theme, as images with transparency usually expect white as background.
![Maill app avatars after](https://user-images.githubusercontent.com/925062/80022644-a8547400-84dc-11ea-8ddb-505b9c9b5876.png) ![Mail avatars dark theme after](https://user-images.githubusercontent.com/925062/80022643-a8547400-84dc-11ea-8604-d554b6a408f1.png)

Please review @nextcloud/vuejs and cc @ChristophWurst @GretaD because this is very visible in Mail.