### PR TITLE
Force normal font weight for avatar letter placeholder, even for unread mails

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -464,6 +464,7 @@ export default {
 		display: block;
 		width: 100%;
 		text-align: center;
+		font-weight: normal;
 		color: var(--color-main-background);
 	}
 


### PR DESCRIPTION
Avatars of people in unread mails had the letter of the avatar placeholder bolded too. This didn’t look very good, so now it’s forced to normal font weight always:
![Avatar fontweight before](https://user-images.githubusercontent.com/925062/80023396-c1a9f000-84dd-11ea-80c3-c9931ad6f1f3.png) ![Avatar fontweight after](https://user-images.githubusercontent.com/925062/80023399-c2428680-84dd-11ea-96ce-a4b91671e87e.png)

cc @nextcloud/mail for review