### PR TITLE
Fix No OC found test warnings

### DIFF
--- a/tests/OC.js
+++ b/tests/OC.js
@@ -1,0 +1,11 @@
+export class OC {
+
+	getLanguage() {
+		return 'en-GB'
+	}
+
+	getLocale() {
+		return 'en_GB'
+	}
+
+}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -20,5 +20,9 @@
  *
  */
 
+import { OC } from './OC.js'
+
+global.OC = new OC()
+
 global.TRANSLATIONS = []
 global.SCOPE_VERSION = 1


### PR DESCRIPTION
This fixes the `No OC found` warnings from l10n: https://github.com/nextcloud/nextcloud-vue/pull/1081/checks?check_run_id=661403687#step:5:11