### PR TITLE
Export EmptyContent

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -50,6 +50,7 @@ import Breadcrumbs from './Breadcrumbs'
 import ColorPicker from './ColorPicker'
 import Content from './Content'
 import DatetimePicker from './DatetimePicker'
+import EmptyContent from './EmptyContent'
 import Modal from './Modal'
 import Multiselect from './Multiselect'
 import MultiselectTags from './MultiselectTags'
@@ -88,6 +89,7 @@ export {
 	ColorPicker,
 	Content,
 	DatetimePicker,
+	EmptyContent,
 	Modal,
 	Multiselect,
 	MultiselectTags,


### PR DESCRIPTION
Export of EmptyContent is missing 
* import { EmptyContent} from 'nextcloud/vue' 
* import { EmptyContent } from '@nextcloud/vue/dist/Components/EmptyContent'

didn't work
* import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'

worked
