### PR TITLE
Fix click event on actions

### DIFF
--- a/src/components/ActionRouter/ActionRouter.vue
+++ b/src/components/ActionRouter/ActionRouter.vue
@@ -27,7 +27,8 @@
 			:exact="exact"
 			class="action-router focusable"
 			:aria-label="ariaLabel"
-			rel="noreferrer noopener">
+			rel="noreferrer noopener"
+			@click.native="onClick">
 			<!-- icon -->
 			<span :class="[isIconUrl ? 'action-router__icon--url' : icon]"
 				:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"

--- a/src/components/ActionText/ActionText.vue
+++ b/src/components/ActionText/ActionText.vue
@@ -23,7 +23,8 @@
 
 <template>
 	<li>
-		<span class="action-text">
+		<span class="action-text"
+			@click="onClick">
 			<!-- icon -->
 			<span
 				v-if="icon !== ''"

--- a/src/components/ActionTextEditable/ActionTextEditable.vue
+++ b/src/components/ActionTextEditable/ActionTextEditable.vue
@@ -36,7 +36,8 @@ All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 
 <template>
 	<li :class="{ 'action--disabled': disabled }">
-		<span class="action-text-editable">
+		<span class="action-text-editable"
+			@click="onClick">
 			<!-- icon -->
 			<span :class="[isIconUrl ? 'action-text-editable__icon--url' : icon]"
 				:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"


### PR DESCRIPTION
While the ActionRouter should provide the `@click`-event according to docs, it didn't emit on click. So i looked through the actions, comparing docs to actual behavoiur resp. the click-event.

- This PR includes now to emit the Click-event on `ActionRouter`, `ActionText` and `ActionTextEditable` as given on Docs.
- The `ActionSeparator` also should emit the event according to docs. In this case i would rather remove the event on docs, as i don't see this as use-case of the separator. I just didn't find the place to edit the doc.
- Concerning the `ActionTextEditable` i'm not sure, which way would be more reasonable - emit the event as i did here, or better remove the event from docs?