### PR TITLE
Only show mouseover-title on text in navigationItem

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -107,7 +107,6 @@ Just set the `pinned` prop.
 <template>
 	<!-- Navigation item, can be either an <li> or a <router-link> depending on the props -->
 	<nav-element v-bind="navElement"
-		:title="title"
 		:class="{
 			'app-navigation-entry--no-icon': !isIconShown,
 			'app-navigation-entry--opened': opened,
@@ -130,7 +129,9 @@ Just set the `pinned` prop.
 				class="app-navigation-entry-icon">
 				<slot v-if="!loading" v-show="isIconShown" name="icon" />
 			</div>
-			<span class="app-navigation-entry__title">{{ title }}</span>
+			<span class="app-navigation-entry__title" :title="title">
+				{{ title }}
+			</span>
 		</a>
 
 		<AppNavigationIconCollapsible v-if="collapsible" :open="opened" @click.prevent.stop="toggleCollapse" />


### PR DESCRIPTION
On forms, @jancborchardt recognized, that the actions-menu of navigationItems shows the form-title on mouseover.
This PR now shifts the title-attribute, into the Title-span, so it is only visible there. Actions-Menu as well as counter do not show the title anymore.

**Before** (imagine a cursor above the small label):
![grafik](https://user-images.githubusercontent.com/47433654/82692636-6005ae80-9c60-11ea-9060-866c0448610b.png)
![grafik](https://user-images.githubusercontent.com/47433654/82692816-a9ee9480-9c60-11ea-8078-96ff2eff085f.png)


**After**:
![grafik](https://user-images.githubusercontent.com/47433654/82692636-6005ae80-9c60-11ea-9060-866c0448610b.png)

![grafik](https://user-images.githubusercontent.com/47433654/82692594-4a908480-9c60-11ea-978d-0284620806cb.png)
