### PR TITLE
Avoid Navigation to overflow NC-Header

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -138,7 +138,7 @@ export default {
 	top: $header-height;
 	left: 0;
 	// Above appcontent
-	z-index: 2000;
+	z-index: 1800;
 	height: calc(100vh - #{$header-height});
 	box-sizing: border-box;
 	background-color: var(--color-main-background);


### PR DESCRIPTION
Just saw, that the navigation overrides the Nextcloud-Header-Bar.

The header has a z-index of 2000, vue-body of 1000 and sidebar of 1500. Therefore i propose a z-index for navigation of 1800, to still override the sidebar in case, but appear below the NC-Header.



**Before:**
![grafik](https://user-images.githubusercontent.com/47433654/82700771-28523300-9c6f-11ea-9b20-b217e5276c73.png)

**After:**
![grafik](https://user-images.githubusercontent.com/47433654/82700821-3f912080-9c6f-11ea-8fa6-998ea051f460.png)
