### PR TITLE
Provide Navigation list as slot

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -60,6 +60,11 @@ emit('toggle-navigation', {
 		:class="{'app-navigation--close':!open }">
 		<AppNavigationToggle :open="open" @update:open="toggleNavigation" />
 		<slot />
+
+		<!-- List for Navigation li-items -->
+		<ul class="app-navigation__list">
+			<slot name="list" />
+		</ul>
 	</div>
 </template>
 
@@ -158,7 +163,8 @@ export default {
 	}
 
 	//list of navigation items
-	ul {
+	ul,
+	&__list {
 		position: relative;
 		height: 100%;
 		width: inherit;


### PR DESCRIPTION
There are quite many li-items on app-navigation, that need a ul-container to be properly shown on sidebar (esp. if many items need a scrollbar). The container was already thought to be used, but as far as i understand from vue-coding it's better code-style to provide the slot as proposed here, instead of letting users manually add the ul-tag within the app-navigation.

Makes the Code of the list-items a bit more meaningful connected to the AppNavigation (here on forms app).

![grafik](https://user-images.githubusercontent.com/47433654/82714634-d8379880-9c8f-11ea-905f-1d8fcd6e38c2.png)

![grafik](https://user-images.githubusercontent.com/47433654/82714610-b3432580-9c8f-11ea-84f2-72128742616e.png)
