### PR TITLE
Fix Provide Navigation List

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -166,7 +166,6 @@ export default {
 	ul,
 	&__list {
 		position: relative;
-		height: 100%;
 		width: inherit;
 		overflow-x: hidden;
 		overflow-y: auto;


### PR DESCRIPTION
Sorry, seems like i need to fix my own PR #1107.
Just recognized, that to maintain compatibility to 'old' systems, that include the `ul` on their own, the 100% height needs to be removed. Otherwise, the two `ul` concur, resulting in two 50% `ul`-lists.
Tested now the cases of manual ul, the new template ul and list-items without ul. They should all work now.