### PR TITLE
Fix actions navigation by keyboard

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -10,7 +10,7 @@ msgstr ""
 msgid "{tag} (restricted)"
 msgstr ""
 
-#: src/components/Actions/Actions.vue:247
+#: src/components/Actions/Actions.vue:249
 msgid "Actions"
 msgstr ""
 

--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -43,7 +43,7 @@ If you're using a long text you can specify a title
 </docs>
 
 <template>
-	<li :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }">
 		<button
 			class="action-button"
 			:aria-label="ariaLabel"

--- a/src/components/ActionCheckbox/ActionCheckbox.vue
+++ b/src/components/ActionCheckbox/ActionCheckbox.vue
@@ -35,7 +35,7 @@ This component is made to be used inside of the [Actions](#Actions) component sl
 </docs>
 
 <template>
-	<li :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span class="action-checkbox">
 			<input :id="id"
 				ref="checkbox"

--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -36,7 +36,7 @@ All undocumented attributes will be bound to the input or the datepicker. e.g. `
 </docs>
 
 <template>
-	<li :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span :class="{ 'action-input--picker': isDatePickerType , 'action-input-picker--disabled': disabled}"
 			class="action-input"
 			@mouseleave="onLeave">

--- a/src/components/ActionLink/ActionLink.vue
+++ b/src/components/ActionLink/ActionLink.vue
@@ -34,7 +34,7 @@ This component is made to be used inside of the [Actions](#Actions) component sl
 </docs>
 
 <template>
-	<li>
+	<li class="action">
 		<a
 			:download="download"
 			:href="href"

--- a/src/components/ActionRadio/ActionRadio.vue
+++ b/src/components/ActionRadio/ActionRadio.vue
@@ -37,7 +37,7 @@ So that only one of each name set can be selected at the same time.
 </docs>
 
 <template>
-	<li :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span class="action-radio">
 			<input :id="id"
 				ref="radio"

--- a/src/components/ActionRouter/ActionRouter.vue
+++ b/src/components/ActionRouter/ActionRouter.vue
@@ -22,7 +22,7 @@
   -->
 
 <template>
-	<li>
+	<li class="action">
 		<router-link :to="to"
 			:exact="exact"
 			class="action-router focusable"

--- a/src/components/ActionSeparator/ActionSeparator.vue
+++ b/src/components/ActionSeparator/ActionSeparator.vue
@@ -24,7 +24,7 @@
   -->
 
 <template>
-	<li class="action-separator action--disabled" />
+	<li class="action action-separator action--disabled" />
 </template>
 
 <script>

--- a/src/components/ActionText/ActionText.vue
+++ b/src/components/ActionText/ActionText.vue
@@ -22,7 +22,7 @@
   -->
 
 <template>
-	<li>
+	<li class="action">
 		<span class="action-text"
 			@click="onClick">
 			<!-- icon -->

--- a/src/components/ActionTextEditable/ActionTextEditable.vue
+++ b/src/components/ActionTextEditable/ActionTextEditable.vue
@@ -35,7 +35,7 @@ All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 </docs>
 
 <template>
-	<li :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span class="action-text-editable"
 			@click="onClick">
 			<!-- icon -->

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -505,10 +505,10 @@ export default {
 			// TODO: have a global disabled state for non input elements
 			const focusElement = this.$refs.fullmenu.querySelectorAll(focusableSelector)[this.focusIndex]
 			if (focusElement) {
-				const liMenuParent = focusElement.closest('li')
+				this.removeCurrentActive()
+				const liMenuParent = focusElement.closest('li.action')
 				focusElement.focus()
 				if (liMenuParent) {
-					this.removeCurrentActive()
 					liMenuParent.classList.add('active')
 				}
 			}

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -104,11 +104,12 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 		v-click-outside="closeMenu"
 		:class="{'action-item--open': opened}"
 		class="action-item"
-		@keydown.up.exact.prevent="focusPreviousAction"
-		@keydown.down.exact.prevent="focusNextAction"
-		@keydown.shift.tab.prevent="focusPreviousAction"
-		@keydown.page-up.exact.prevent="focusFirstAction"
-		@keydown.page-down.exact.prevent="focusLastAction"
+		@keydown.up.exact="focusPreviousAction"
+		@keydown.down.exact="focusNextAction"
+		@keydown.tab.exact="focusNextAction"
+		@keydown.shift.tab.exact="focusPreviousAction"
+		@keydown.page-up.exact="focusFirstAction"
+		@keydown.page-down.exact="focusLastAction"
 		@keydown.esc.exact.prevent="closeMenu">
 		<!-- If more than one action, create a popovermenu -->
 		<button class="icon action-item__menutoggle"
@@ -512,21 +513,33 @@ export default {
 				}
 			}
 		},
-		focusPreviousAction() {
-			this.focusIndex = Math.max(this.focusIndex - 1, 0)
-			this.focusAction()
+		focusPreviousAction(event) {
+			if (this.opened) {
+				event.preventDefault()
+				this.focusIndex = Math.max(this.focusIndex - 1, 0)
+				this.focusAction()
+			}
 		},
-		focusNextAction() {
-			this.focusIndex = Math.min(this.focusIndex + 1, this.$refs.menu.querySelectorAll(focusableSelector).length - 1)
-			this.focusAction()
+		focusNextAction(event) {
+			if (this.opened) {
+				event.preventDefault()
+				this.focusIndex = Math.min(this.focusIndex + 1, this.$refs.menu.querySelectorAll(focusableSelector).length - 1)
+				this.focusAction()
+			}
 		},
-		focusFirstAction() {
-			this.focusIndex = 0
-			this.focusAction()
+		focusFirstAction(event) {
+			if (this.opened) {
+				event.preventDefault()
+				this.focusIndex = 0
+				this.focusAction()
+			}
 		},
-		focusLastAction() {
-			this.focusIndex = this.$el.querySelectorAll(focusableSelector).length - 1
-			this.focusAction()
+		focusLastAction(event) {
+			if (this.opened) {
+				event.preventDefault()
+				this.focusIndex = this.$el.querySelectorAll(focusableSelector).length - 1
+				this.focusAction()
+			}
 		},
 
 		// ACTIONS MANAGEMENT


### PR DESCRIPTION
Related and partially fixes the issue by @jancborchardt at forms https://github.com/nextcloud/forms/issues/416

- First commit changes to only prevent default key-events, if the action-menu is opened. Like this, navigating through content does not get killed. If closed, navigation works as usual, if opened, navigation is caught into action-menu.
- Second commit allows to focus the three-dot actionmenu-button, to be able to close the menu again on space by keyboard. Further, the keyboard navigation overflows, so people can navigate through the actionmenu in a round.
- Special change in second commit, is not to focus the first element, when opening the menu. First looks a bit unfamiliar, as we know the menu until now with always the blue bar. The reason behind this change is that in order to open the menu on keyboard by pressing space-bar and directly close it again, people (or at least me) would typically just press the space-bar a second time. If focusing the first action after opening menu, on the second space-press this action is executed. This is especially bad, if the action contains destructive operation.
- Third commit then avoids to set active-class on a foreign parent-element as e.g. App-Navigation, when focusing the three-dot-menu. Therefore i included a class `action` to mark and then focus the parent-li only on actions.

@jancborchardt To me, navigation is logical like this. When actionmenu is open, i tab through it in circles and can close it again and then continue on body. Can you check (e.g. on forms) if this is common thing or just in my head? ;)