### PR TITLE
Check actions out of bottom independent of left/right aligned

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -456,17 +456,19 @@ export default {
 			this.offsetY = 0
 			this.offsetYArrow = 0
 			this.rotateArrow = false
+
+			const isOut = IsOutOfViewport(this.$refs.menu)
+			if (isOut.bottom) {
+				this.offsetY = 0 - Math.round(this.$refs.menu.clientHeight) - 42
+				this.offsetYArrow = Math.round(this.$refs.menu.clientHeight) + 18
+				this.rotateArrow = true
+			}
+
 			if (this.menuAlign === 'center') {
-				const isOut = IsOutOfViewport(this.$refs.menu)
 				if (isOut.left || isOut.right) {
 					this.offsetX = isOut.offsetX > 0
 						? Math.round(isOut.offsetX) + 5
 						: Math.round(isOut.offsetX) - 5
-				}
-				if (isOut.bottom) {
-					this.offsetY = 0 - Math.round(this.$refs.menu.clientHeight) - 42
-					this.offsetYArrow = Math.round(this.$refs.menu.clientHeight) + 18
-					this.rotateArrow = true
 				}
 			}
 		},


### PR DESCRIPTION
Actions did only check the out-of-bottom, if the actionmenu was aligned as center, so e.g. on App-Navigation, it didn't check and ran out of view.
- The out of bottom (y-dir) should be checked independent of right/left align (x-dir).

**Before:**
![grafik](https://user-images.githubusercontent.com/47433654/83322235-419e4500-a256-11ea-8bfe-97ac3866be21.png)


**After:**
![grafik](https://user-images.githubusercontent.com/47433654/83322248-5e3a7d00-a256-11ea-9661-66d67e6a528d.png)
