### PR TITLE
Enh/active hover focus highlight

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -72,12 +72,12 @@ Wrap the children in a template with the `slot` property and use the prop `allow
 prevent the user from collapsing the items.
 
 ```
-<AppNavigationItem title="Item with children" :allowCollapse="true">
+<AppNavigationItem title="Item with children" :allowCollapse="true" :open="true">
 	<template>
 		<AppNavigationItem title="AppNavigationItemChild1" />
-		<AppNavigationItem title="AppNavigationItemChild2" />
-		<AppNavigationItem title="AppNavigationItemChild3"  />
-		<AppNavigationItem title="AppNavigationItemChild4"  />
+		<AppNavigationItem class="active" title="AppNavigationItemChild2" />
+		<AppNavigationItem title="AppNavigationItemChild3" />
+		<AppNavigationItem title="AppNavigationItemChild4" />
 	</template>
 </AppNavigationItem>
 ```
@@ -441,11 +441,22 @@ export default {
 	box-sizing: border-box;
 	width: 100%;
 	min-height: $clickable-area;
+
 	// When .active class is applied, change color background of link and utils. The
 	// !important prevents the focus state to override the active state.
-	&.active > a,
-	&.active > a ~ .app-navigation-entry__utils {
+	&.active {
 		background-color: var(--color-primary-light) !important;
+	}
+	&:focus-within,
+	&:hover {
+		background-color: var(--color-background-hover);
+	}
+	&.active,
+	&:focus-within,
+	&:hover {
+		.app-navigation-entry__children {
+			background-color: var(--color-main-background);
+		}
 	}
 
 	/* hide deletion/collapse of subitems */
@@ -473,17 +484,6 @@ export default {
 		background-position: $icon-margin center;
 		background-size: $icon-size $icon-size;
 		line-height: $clickable-area;
-		&:hover,
-		&:hover ~ .app-navigation-entry__utils,
-		&:focus,
-		&:focus ~ .app-navigation-entry__utils {
-			background-color: var(--color-background-hover);
-		}
-		&.active,
-		&:active,
-		&:active ~ .app-navigation-entry__utils {
-			background-color: var(--color-primary-light);
-		}
 
 		.app-navigation-entry-icon {
 			display: flex;

--- a/styleguide/assets/variables.css
+++ b/styleguide/assets/variables.css
@@ -4,6 +4,7 @@
     --color-main-background-translucent:rgba(255, 255, 255, 0.97);
     --color-background-dark:#ededed;
     --color-background-darker:#dbdbdb;
+    --color-background-hover: #f5f5f5;
     --color-primary:#0082c9;
     --color-primary-text:#fff;
     --color-primary-text-dark:#ededed;


### PR DESCRIPTION
This aims to let the highlight on hover/focus/active state fill the whole line of the AppNavigationItem.

Before:
![image](https://user-images.githubusercontent.com/3404133/84066179-d2e38900-a9c5-11ea-8042-d9a0ecb9c2f6.png)

After:
![Peek 2020-06-14 15-37](https://user-images.githubusercontent.com/3404133/84594844-1a01cc00-ae55-11ea-83be-e41b4cbf8155.gif)


<details>
<summary>Solved</summary>
The only issue currently is that CSS hover state propagates to the parent nodes as well, so when hovering a nested child item, the whole parent will have a background set:

![image](https://user-images.githubusercontent.com/3404133/84066346-0e7e5300-a9c6-11ea-9d07-4b77ef47b4cb.png)

Any ideas how we could work around that with CSS?
</details>