### PR TITLE
Fix sidebar title height with subtitle

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -619,13 +619,8 @@ $top-buttons-spacing: 6px;
 			}
 			&--with-subtitle {
 				justify-content: space-between;
-				height: $desc-height;
-			}
-			&--editable {
-				height: $desc-height * .75;
 			}
 			&--with-subtitle--editable {
-				height: $desc-height * 1.5;
 
 				.app-sidebar-header__subtitle {
 					margin-left: $desc-input-padding;


### PR DESCRIPTION
open the sidebar of a deck card:

Before | After
---|---
![Bildschirmfoto von 2020-06-10 09-44-24](https://user-images.githubusercontent.com/213943/84243513-9a959500-ab02-11ea-881d-22ab0863e785.png) | ![Bildschirmfoto von 2020-06-10 09-44-27](https://user-images.githubusercontent.com/213943/84243519-9b2e2b80-ab02-11ea-9b19-f4cff8261181.png)

not sure why the height was there in first place. But the padding from 
https://github.com/nextcloud/nextcloud-vue/blob/545b8ecb645d13cfafe1e25a2ad5f2c57fd4afe2/src/components/AppSidebar/AppSidebar.vue#L569

Seems to cause the problems with a fixed height.
So either we add more magic, or we don't use a fixed height anymore
