### PR TITLE
Revert "Fix Provide Navigation List" & provide footer-slot

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -166,6 +166,7 @@ export default {
 	ul,
 	&__list {
 		position: relative;
+		height: 100%;
 		width: inherit;
 		overflow-x: hidden;
 		overflow-y: auto;

--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -65,6 +65,9 @@ emit('toggle-navigation', {
 		<ul class="app-navigation__list">
 			<slot name="list" />
 		</ul>
+
+		<!-- Footer for e.g. AppNavigationSettings -->
+		<slot name="footer" />
 	</div>
 </template>
 


### PR DESCRIPTION
It's a pity, and i'm really sorry for that back & forth. But the fix to avoid the breaking-change makes the actions-menu on navigation hiding within the small ul, instead of flipping or showing above.
Easiest way to solve this, is now to revert the mentioned commit, unfortunately then making the already announced breaking change really a change, that breaks the manual usage of ul, but forces to use the slot.

For reference: 
- The navigation-list PR, released as breaking change: #1107
- The PR, that wanted to avoid the navigation-PR to be breaking, also within current release: #1123
- This PR: Now becoming itself a breaking change, as the first one looked like not braking anything (see vue-public talk)? 😟 

**Before**
![grafik](https://user-images.githubusercontent.com/47433654/85060807-1e581d00-b1a6-11ea-942f-8ad12d8ff46a.png)
**After**
![grafik](https://user-images.githubusercontent.com/47433654/85060916-48a9da80-b1a6-11ea-9a77-3ea6996a929e.png)
