### PR TITLE
reduce indentation of the sub-levels

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -514,7 +514,7 @@ export default {
 		.app-navigation-entry {
 			display: inline-flex;
 			flex-wrap: wrap;
-			padding-left: $clickable-area;
+			padding-left: $clickable-area - $icon-margin;
 		}
 	}
 }
@@ -523,7 +523,7 @@ export default {
 .app-navigation-entry__deleted {
 	display: inline-flex;
 	flex: 1 1 0;
-	padding-left: $clickable-area !important;
+	padding-left: $clickable-area - $icon-margin !important;
 	.app-navigation-entry__deleted-description {
 		position: relative;
 		overflow: hidden;
@@ -539,7 +539,7 @@ export default {
 	/* Ugly hack for overriding the main entry link */
 	/* align the input correctly with the link text
 	44px-6px padding for the input */
-	padding-left: $clickable-area - 6px !important;
+	padding-left: $clickable-area - $icon-margin - 6px !important;
 	form {
 		display: flex;
 		width: 100%;
@@ -603,7 +603,7 @@ export default {
 		}
 		// prevent the icon of children elements from being hidden
 		// by the previous rule
-		.app-navigation-entry__children li a :first-child {
+		.app-navigation-entry__children li:not(.app-navigation-entry--collapsible) a :first-child {
 			visibility: visible;
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Holger Dehnhardt <holger@dehnhardt.org>

Fixes: https://github.com/nextcloud/nextcloud-vue/issues/1140

The indention of a sublevel now starts with the right edge of the parent.

From the second level on, :hover previously displayed the arrow icon and the navigation icon on top of each other.
![image](https://user-images.githubusercontent.com/5556832/86132714-90562d80-bae7-11ea-89d0-904e8de3ed80.png)

The navigation icon is now also hidden for lower levels. 
![Nav2](https://user-images.githubusercontent.com/5556832/86132742-9ea44980-bae7-11ea-810a-f06867d18a7b.png)

Unfortunately, :hover fades out all the navigation icons of the same branch. But I don't know what to do about that;-)
![Nav1](https://user-images.githubusercontent.com/5556832/86132749-a106a380-bae7-11ea-851f-1a359979ba42.png)

