### PR TITLE
Fix Avatar URL check in UserBubble

### DIFF
--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -202,11 +202,14 @@ export default {
 		 * @returns {boolean}
 		 */
 		isAvatarUrl() {
+			if (!this.avatarImage) {
+				return false
+			}
+
 			try {
 				const url = new URL(this.avatarImage)
 				return !!url
 			} catch (error) {
-				console.error(error)
 				return false
 			}
 		},


### PR DESCRIPTION
If `avatarImage` was not set, it was throwing all over the place