### PR TITLE
vertically align active checkmark to center

### DIFF
--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -251,6 +251,7 @@ export default {
 		&-color-circle {
 			display: flex;
 			align-content: center;
+			align-items: center;
 			justify-content: center;
 			width: 34px;
 			height: 34px;

--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -250,7 +250,6 @@ export default {
 
 		&-color-circle {
 			display: flex;
-			align-content: center;
 			align-items: center;
 			justify-content: center;
 			width: 34px;


### PR DESCRIPTION
I spotted an issue downstream that I can replicate with firefox, which shows an active checkbox being at the top of the color picker, rather than the vertical center: https://github.com/nextcloud/deck/issues/2102

I'm not sure if `align-content` was a typo or not, so I left it there.

Using `align-items: center;` will vertically align children in a flex container to the middle of said container when combined with `justify-content: center;`