### PR TITLE
Fix actions single border radius

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -609,6 +609,7 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 		padding: $icon-margin;
 		cursor: pointer;
 		border: none;
+		border-radius: $clickable-area / 2;
 		background-color: transparent;
 	}
 
@@ -619,7 +620,6 @@ $arrow-margin: ($clickable-area - 2 * $arrow-width)  / 2;
 		align-items: center;
 		justify-content: center;
 		opacity: $opacity_normal;
-		border-radius: $clickable-area / 2;
 		font-weight: bold;
 		line-height: $icon-size;
 


### PR DESCRIPTION
| Before | After |
|:---------:|:------:|
|![Capture d’écran_2020-07-23_16-20-44](https://user-images.githubusercontent.com/14975046/88297723-931bfb00-cd00-11ea-8d6b-da93344f4c9f.png)|![Capture d’écran_2020-07-23_16-20-35](https://user-images.githubusercontent.com/14975046/88297720-92836480-cd00-11ea-8d14-b99a63d7d13a.png)|

Buttons have a border-radius from server, so it does it when you try with ActionLink for example

```vue
<Actions>
	<ActionLink icon="icon-external" href="https://nextcloud.com">
		Nextcloud website
	</ActionLink>
</Actions>
```
