### PR TITLE
Avatar: Add empty alt attribute for accessibility

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -47,7 +47,10 @@
 		@click="toggleMenu">
 		<!-- avatar -->
 		<div v-if="iconClass" :class="iconClass" class="avatar-class-icon" />
-		<img v-else-if="isAvatarLoaded && !userDoesNotExist" :src="avatarUrlLoaded" :srcset="avatarSrcSetLoaded">
+		<img v-else-if="isAvatarLoaded && !userDoesNotExist"
+			:src="avatarUrlLoaded"
+			:srcset="avatarSrcSetLoaded"
+			alt="">
 		<div v-if="hasMenu" class="icon-more" />
 
 		<!-- avatar status -->


### PR DESCRIPTION
When testing with Axe, Wave or Lighthouse there’s a bunch of errors before. Now fixed. :)

See https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html (since avatars are decorative and next to names)