### PR TITLE
Allow to show an empty sidebar

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -82,13 +82,37 @@
 		}
 	</script>
 	```
+	```
+
+	### Blank sidebar for e.g. empty content
+	```vue
+	<template>
+		<AppSidebar
+			:title="title"
+			blank="true">
+			<EmptyContent icon="icon-search">
+				Content not found.
+			</EmptyContent>
+		</AppSidebar>
+	</template>
+	<script>
+		export default {
+			data() {
+				return {
+					title: 'cat-picture.jpg'
+				}
+			}
+		}
+	</script>
+	```
 
 </docs>
 
 <template>
 	<transition name="slide-right">
 		<aside id="app-sidebar-vue" class="app-sidebar">
-			<header :class="{
+			<header v-if="!blank"
+				:class="{
 					'app-sidebar-header--with-figure': hasFigure,
 					'app-sidebar-header--compact': compact
 				}"
@@ -157,7 +181,7 @@
 			</header>
 
 			<!-- tabs navigation -->
-			<nav v-if="hasMultipleTabs"
+			<nav v-if="hasMultipleTabs && !blank"
 				class="app-sidebar-tabs__nav"
 				@keydown.left.exact.prevent="focusPreviousTab"
 				@keydown.right.exact.prevent="focusNextTab"
@@ -231,6 +255,10 @@ export default {
 		subtitle: {
 			type: String,
 			default: '',
+		},
+		blank: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -89,7 +89,7 @@
 	<template>
 		<AppSidebar
 			title="cat-picture.jpg"
-			blank="true">
+			:blank="true">
 			<EmptyContent icon="icon-search">
 				Content not found.
 			</EmptyContent>

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -88,22 +88,13 @@
 	```vue
 	<template>
 		<AppSidebar
-			:title="title"
+			title="cat-picture.jpg"
 			blank="true">
 			<EmptyContent icon="icon-search">
 				Content not found.
 			</EmptyContent>
 		</AppSidebar>
 	</template>
-	<script>
-		export default {
-			data() {
-				return {
-					title: 'cat-picture.jpg'
-				}
-			}
-		}
-	</script>
 	```
 
 </docs>


### PR DESCRIPTION
Allows to show a blank sidebar without header and tab navigation bar. Useful for showing a hint when loading data from the server (please ignore the unfinished sidebar implementation of the Tasks app in the GIF).

![appsidebar](https://user-images.githubusercontent.com/2496460/89576774-03159f80-d830-11ea-88f0-164b0533b2bc.gif)

Start of implementing #1090.
