### PR TITLE
AppNavigationItem improved editing mode and AppNavigationNewItem component

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -94,7 +94,7 @@ the placeholder is the previous title of the element.
 Add the prop `:new-item=true`.
 
 ```
-<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="alert(value)" />
+<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="alert('new-item')" />
 ```
 ### Undo element
 Just set the `undo` and `title` props. When clicking the undo button, an `undo` event is emitted.

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -126,7 +126,7 @@ Just set the `pinned` prop.
 		class="app-navigation-entry"
 		@click="handleEdit">
 		<!-- Icon and title -->
-		<a v-if="!undo && !editing"
+		<a v-if="!undo && !newItem && !editing"
 			class="app-navigation-entry-link"
 			href="#"
 			@click="onClick">
@@ -148,6 +148,17 @@ Just set the `pinned` prop.
 			<div class="app-navigation-entry__deleted-description">
 				{{ title }}
 			</div>
+		</div>
+
+		<!-- New Item -->
+		<div v-if="newItem">
+			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
+				class="app-navigation-entry-icon">
+				<slot v-if="!loading" v-show="isIconShown" name="icon" />
+			</div>
+			<span class="app-navigation-entry__title" :title="title">
+				{{ title }}
+			</span>
 		</div>
 
 		<!-- Counter and Actions -->

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -116,7 +116,8 @@ Just set the `pinned` prop.
 			'app-navigation-entry--collapsible': collapsible,
 			'active': isActive
 		}"
-		class="app-navigation-entry">
+		class="app-navigation-entry"
+		@click="handleEdit">
 		<!-- Icon and title -->
 		<a v-if="!undo && !editing"
 			class="app-navigation-entry-link"
@@ -160,7 +161,7 @@ Just set the `pinned` prop.
 
 		<!-- edit entry -->
 		<div v-if="editing" class="app-navigation-entry__edit">
-			<form @submit.prevent="handleRename" @keydown.esc.exact.prevent="cancelEdit">
+			<form @submit.prevent="handleEditDone" @keydown.esc.exact.prevent="cancelEdit">
 				<input ref="inputTitle"
 					v-model="newTitle"
 					type="text"
@@ -168,7 +169,7 @@ Just set the `pinned` prop.
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
 				<button type="submit"
 					class="icon-confirm"
-					@click.stop.prevent="handleRename" />
+					@click.stop.prevent="handleEditDone" />
 				<button type="reset"
 					class="icon-close"
 					@click.stop.prevent="cancelEdit" />
@@ -409,18 +410,34 @@ export default {
 
 		// Edition methods
 		handleEdit() {
-			this.newTitle = this.title
-			this.editing = true
-			this.onMenuToggle(false)
-			this.$nextTick(() => {
-				this.$refs.inputTitle.focus()
-			})
+			if (this.editable) {
+				this.newTitle = this.title
+			}
+			if (this.editable || this.newItem) {
+				this.editing = true
+				this.onMenuToggle(false)
+				this.$nextTick(() => {
+					this.$refs.inputTitle.focus()
+				})
+			}
 		},
 		cancelEdit() {
 			this.editing = false
 		},
+		handleEditDone() {
+			if (this.editable) {
+				this.handleRename()
+			} else if (this.newItem) {
+				this.handleNewItem()
+			}
+		},
 		handleRename() {
 			this.$emit('update:title', this.newTitle)
+			this.newTitle = ''
+			this.editing = false
+		},
+		handleNewItem() {
+			this.$emit('newItem', this.newTitle)
 			this.newTitle = ''
 			this.editing = false
 		},

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -261,8 +261,8 @@ export default {
 		},
 		newItem: {
 			type: Boolean,
-			default: false,	
-		}
+			default: false,
+		},
 		/**
 		* Only for 'editable' items, sets label for the edit action button.
 		*/

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -123,8 +123,7 @@ Just set the `pinned` prop.
 			'app-navigation-entry--collapsible': collapsible,
 			'active': isActive
 		}"
-		class="app-navigation-entry"
-		@click="handleEdit">
+		class="app-navigation-entry">
 		<!-- Icon and title -->
 		<a v-if="!undo && !newItem && !editing"
 			class="app-navigation-entry-link"
@@ -151,7 +150,7 @@ Just set the `pinned` prop.
 		</div>
 
 		<!-- New Item -->
-		<div v-if="newItem">
+		<div v-if="newItem" @click="handleEdit" class="app-navigation-entry-div">
 			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
 				class="app-navigation-entry-icon">
 				<slot v-if="!loading" v-show="isIconShown" name="icon" />
@@ -508,7 +507,7 @@ export default {
 	}
 
 	// Main entry link
-	.app-navigation-entry-link {
+	.app-navigation-entry-link .app-navigation-entry-div {
 		z-index: 100; /* above the bullet to allow click*/
 		display: flex;
 		overflow: hidden;

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -82,12 +82,19 @@ prevent the user from collapsing the items.
 </AppNavigationItem>
 ```
 ### Editable element
-Add the prop `:editable=true` and an edit placeholder if you need it. By devault
+Add the prop `:editable=true` and an edit placeholder if you need it. By default
 the placeholder is the previous title of the element.
 
 ```
 <AppNavigationItem title="Editable Item" :editable="true"
 	editPlaceholder="your_placeholder_here" />
+```
+
+### New Item element
+Add the prop `:new-item=true`.
+
+```
+<AppNavigationItem title="New Item" :new-item="true" @new-item="alert(value)" />
 ```
 ### Undo element
 Just set the `undo` and `title` props. When clicking the undo button, an `undo` event is emitted.
@@ -437,7 +444,7 @@ export default {
 			this.editing = false
 		},
 		handleNewItem() {
-			this.$emit('newItem', this.inlineInputValue)
+			this.$emit('new-item', this.inlineInputValue)
 			this.inlineInputValue = ''
 			this.editing = false
 		},

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -150,14 +150,32 @@ Just set the `pinned` prop.
 		</div>
 
 		<!-- New Item -->
-		<div v-if="newItem && !editing" class="app-navigation-entry-div" @click="handleEdit">
+		<div v-if="newItem" class="app-navigation-entry-div" @click="handleEdit">
 			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
 				class="app-navigation-entry-icon">
 				<slot v-if="!loading" v-show="isIconShown" name="icon" />
 			</div>
-			<span class="app-navigation-entry__title" :title="title">
+
+			<span v-if="!editing" class="app-navigation-entry__title" :title="title">
 				{{ title }}
 			</span>
+
+			<!-- inline input -->
+			<div v-if="editing" class="app-navigation-entry__inline-input-container">
+				<form @submit.prevent="handleEditDone" @keydown.esc.exact.prevent="cancelEdit">
+					<input ref="inputTitle"
+						v-model="inlineInputValue"
+						type="text"
+						class="app-navigation-entry__inline-input"
+						:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
+					<button type="submit"
+						class="icon-confirm"
+						@click.stop.prevent="handleEditDone" />
+					<button type="reset"
+						class="icon-close"
+						@click.stop.prevent="cancelEdit" />
+				</form>
+			</div>
 		</div>
 
 		<!-- Counter and Actions -->
@@ -174,27 +192,6 @@ Just set the `pinned` prop.
 				<ActionButton v-if="undo" icon="app-navigation-entry__deleted-button icon-history" @click="handleUndo" />
 				<slot name="actions" />
 			</Actions>
-		</div>
-
-		<!-- inline input -->
-		<div v-if="editing" class="app-navigation-entry__inline-input-container">
-			<form @submit.prevent="handleEditDone" @keydown.esc.exact.prevent="cancelEdit">
-				<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
-					class="app-navigation-entry-icon">
-					<slot v-if="!loading" v-show="isIconShown" name="icon" />
-				</div>
-				<input ref="inputTitle"
-					v-model="inlineInputValue"
-					type="text"
-					class="app-navigation-entry__inline-input"
-					:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
-				<button type="submit"
-					class="icon-confirm"
-					@click.stop.prevent="handleEditDone" />
-				<button type="reset"
-					class="icon-close"
-					@click.stop.prevent="cancelEdit" />
-			</form>
 		</div>
 
 		<!-- Children elements -->
@@ -578,13 +575,13 @@ export default {
 
 .app-navigation-entry__inline-input-container {
 	flex: 1 0 100%;
+	width: calc(100% - #{$clickable-area});
 	/* Ugly hack for overriding the main entry link */
 	/* align the input correctly with the link text
 	44px-6px padding for the input */
-	padding-left: $clickable-area - $icon-margin - 6px !important;
+	/*padding-left: $clickable-area - $icon-margin - 6px !important;*/
 	form {
 		display: flex;
-		width: 100%;
 		.app-navigation-entry__inline-input {
 			flex: 1 1 100%;
 		}

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -259,7 +259,7 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		inline-button: {
+		newItem: {
 			type: Boolean,
 			default: false,	
 		}

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -160,12 +160,12 @@ Just set the `pinned` prop.
 		</div>
 
 		<!-- edit entry -->
-		<div v-if="editing" class="app-navigation-entry__edit">
+		<div v-if="editing" class="app-navigation-entry__inline-input-container">
 			<form @submit.prevent="handleEditDone" @keydown.esc.exact.prevent="cancelEdit">
 				<input ref="inputTitle"
-					v-model="newTitle"
+					v-model="inlineInputValue"
 					type="text"
-					class="app-navigation-entry__edit-input"
+					class="app-navigation-entry__inline-input"
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
 				<button type="submit"
 					class="icon-confirm"
@@ -326,7 +326,7 @@ export default {
 
 	data() {
 		return {
-			newTitle: '',
+			inlineInputValue: '',
 			opened: this.open,
 			editing: false,
 		}
@@ -411,7 +411,7 @@ export default {
 		// Edition methods
 		handleEdit() {
 			if (this.editable) {
-				this.newTitle = this.title
+				this.inlineInputValue = this.title
 			}
 			if (this.editable || this.newItem) {
 				this.editing = true
@@ -432,13 +432,13 @@ export default {
 			}
 		},
 		handleRename() {
-			this.$emit('update:title', this.newTitle)
-			this.newTitle = ''
+			this.$emit('update:title', this.inlineInputValue)
+			this.inlineInputValue = ''
 			this.editing = false
 		},
 		handleNewItem() {
-			this.$emit('newItem', this.newTitle)
-			this.newTitle = ''
+			this.$emit('newItem', this.inlineInputValue)
+			this.inlineInputValue = ''
 			this.editing = false
 		},
 
@@ -555,7 +555,7 @@ export default {
 	}
 }
 
-.app-navigation-entry__edit {
+.app-navigation-entry__inline-input-container {
 	flex: 1 0 100%;
 	/* Ugly hack for overriding the main entry link */
 	/* align the input correctly with the link text
@@ -564,7 +564,7 @@ export default {
 	form {
 		display: flex;
 		width: 100%;
-		.app-navigation-entry__edit-input {
+		.app-navigation-entry__inline-input {
 			flex: 1 1 100%;
 		}
 

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -150,7 +150,7 @@ Just set the `pinned` prop.
 		</div>
 
 		<!-- New Item -->
-		<div v-if="newItem" class="app-navigation-entry-div" @click="handleEdit">
+		<div v-if="newItem && !editing" class="app-navigation-entry-div" @click="handleEdit">
 			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
 				class="app-navigation-entry-icon">
 				<slot v-if="!loading" v-show="isIconShown" name="icon" />
@@ -507,7 +507,7 @@ export default {
 	}
 
 	// Main entry link
-	.app-navigation-entry-link .app-navigation-entry-div {
+	.app-navigation-entry-link, .app-navigation-entry-div {
 		z-index: 100; /* above the bullet to allow click*/
 		display: flex;
 		overflow: hidden;

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -259,6 +259,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		inline-button: {
+			type: Boolean,
+			default: false,	
+		}
 		/**
 		* Only for 'editable' items, sets label for the edit action button.
 		*/

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -94,7 +94,7 @@ the placeholder is the previous title of the element.
 Add the prop `:new-item=true`.
 
 ```
-<AppNavigationItem title="New Item" :new-item="true" @new-item="alert(value)" />
+<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="alert(value)" />
 ```
 ### Undo element
 Just set the `undo` and `title` props. When clicking the undo button, an `undo` event is emitted.

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -150,7 +150,7 @@ Just set the `pinned` prop.
 		</div>
 
 		<!-- New Item -->
-		<div v-if="newItem" @click="handleEdit" class="app-navigation-entry-div">
+		<div v-if="newItem" class="app-navigation-entry-div" @click="handleEdit">
 			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
 				class="app-navigation-entry-icon">
 				<slot v-if="!loading" v-show="isIconShown" name="icon" />

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -166,7 +166,7 @@ Just set the `pinned` prop.
 			</Actions>
 		</div>
 
-		<!-- edit entry -->
+		<!-- inline input -->
 		<div v-if="editing" class="app-navigation-entry__inline-input-container">
 			<form @submit.prevent="handleEditDone" @keydown.esc.exact.prevent="cancelEdit">
 				<input ref="inputTitle"

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -539,6 +539,7 @@ export default {
 			max-width: 100%;
 			white-space: nowrap;
 			text-overflow: ellipsis;
+			padding-left: 6px;
 		}
 	}
 
@@ -575,7 +576,8 @@ export default {
 
 .app-navigation-entry__inline-input-container {
 	flex: 1 0 100%;
-	width: calc(100% - #{$clickable-area});
+	max-width: calc(100% - #{$clickable-area});
+	margin: auto;
 	/* Ugly hack for overriding the main entry link */
 	/* align the input correctly with the link text
 	44px-6px padding for the input */
@@ -584,6 +586,7 @@ export default {
 		display: flex;
 		.app-navigation-entry__inline-input {
 			flex: 1 1 100%;
+			font-size: 14px;
 		}
 
 		// submit and cancel buttons

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -179,6 +179,10 @@ Just set the `pinned` prop.
 		<!-- inline input -->
 		<div v-if="editing" class="app-navigation-entry__inline-input-container">
 			<form @submit.prevent="handleEditDone" @keydown.esc.exact.prevent="cancelEdit">
+				<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
+					class="app-navigation-entry-icon">
+					<slot v-if="!loading" v-show="isIconShown" name="icon" />
+				</div>
 				<input ref="inputTitle"
 					v-model="inlineInputValue"
 					type="text"

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -135,7 +135,9 @@ Just set the `pinned` prop.
 				{{ title }}
 			</span>
 			<div v-if="editingActive" class="editingContainer">
-				<InputConfirmCancel v-model="editingValue"
+				<InputConfirmCancel
+					ref="editingInput"
+					v-model="editingValue"
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
 					@cancel="cancelEditing"
 					@confirm="handleEditingDone" />
@@ -401,9 +403,7 @@ export default {
 			this.editingValue = this.title
 			this.editingActive = true
 			this.onMenuToggle(false)
-			this.$nextTick(() => {
-				// this.$refs.editingInput.focus()
-			})
+			this.$refs.editingInput.focusInput()
 		},
 		cancelEditing() {
 			this.editingActive = false

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -474,11 +474,6 @@ export default {
 <style lang="scss" scoped>
 @import '../../fonts/scss/iconfont-vue';
 
-.editingContainer, .newItemContainer {
-	width: calc(100% - #{$clickable-area});
-	margin: auto;
-}
-
 .app-navigation-entry {
 	position: relative;
 	display: flex;
@@ -553,6 +548,11 @@ export default {
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			padding-left: 6px;
+		}
+
+		.editingContainer, .newItemContainer {
+			width: calc(100% - #{$clickable-area});
+			margin: auto;
 		}
 	}
 

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -32,7 +32,7 @@
 * With an icon:
 
 ```
-<AppNavigationItem title="My title" icon="icon-category-enabled">
+<AppNavigationItem title="My title" icon="icon-category-enabled" />
 
 ```
 * With a spinning loader instead of the icon:
@@ -403,7 +403,9 @@ export default {
 			this.editingValue = this.title
 			this.editingActive = true
 			this.onMenuToggle(false)
-			this.$refs.editingInput.focusInput()
+			this.$nextTick(() => {
+				this.$refs.editingInput.focusInput()
+			})
 		},
 		cancelEditing() {
 			this.editingActive = false

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -89,13 +89,6 @@ the placeholder is the previous title of the element.
 <AppNavigationItem title="Editable Item" :editable="true"
 	editPlaceholder="your_placeholder_here" icon="icon-folder" @update:title="function(value){alert(value)}" />
 ```
-
-### New Item element
-Add the prop `:new-item=true`.
-
-```
-<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="function(value){alert(value)}" />
-```
 ### Undo element
 Just set the `undo` and `title` props. When clicking the undo button, an `undo` event is emitted.
 
@@ -119,14 +112,13 @@ Just set the `pinned` prop.
 			'app-navigation-entry--opened': opened,
 			'app-navigation-entry--pinned': pinned,
 			'app-navigation-entry--editing' : editingActive,
-			'app-navigation-entry--newItemActive': newItemActive,
 			'app-navigation-entry--deleted': undo,
 			'app-navigation-entry--collapsible': collapsible,
 			'active': isActive
 		}"
 		class="app-navigation-entry">
 		<!-- Icon and title -->
-		<a v-if="!undo && !newItem"
+		<a v-if="!undo"
 			class="app-navigation-entry-link"
 			href="#"
 			@click="onClick">
@@ -153,26 +145,6 @@ Just set the `pinned` prop.
 		<div v-if="undo" class="app-navigation-entry__deleted">
 			<div class="app-navigation-entry__deleted-description">
 				{{ title }}
-			</div>
-		</div>
-
-		<!-- New Item -->
-		<div v-if="newItem" class="app-navigation-entry-div" @click="handleNewItem">
-			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
-				class="app-navigation-entry-icon">
-				<slot v-if="!loading" v-show="isIconShown" name="icon" />
-			</div>
-
-			<span v-if="!newItemActive" class="app-navigation-entry__title" :title="title">
-				{{ title }}
-			</span>
-
-			<!-- new Item input -->
-			<div v-if="newItemActive" class="newItemContainer">
-				<InputConfirmCancel v-model="newItemValue"
-					:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
-					@cancel="cancelNewItem"
-					@confirm="handleNewItemDone" />
 			</div>
 		</div>
 
@@ -279,14 +251,6 @@ export default {
 			default: false,
 		},
 		/**
-		* When clicked a inline text input with a confirm and cancel button appears insted of the title.
-		* When the user confirms the input the 'new-item' event gets emitted.
-		*/
-		newItem: {
-			type: Boolean,
-			default: false,
-		},
-		/**
 		* Only for 'editable' items, sets label for the edit action button.
 		*/
 		editLabel: {
@@ -294,7 +258,7 @@ export default {
 			default: '',
 		},
 		/**
-		* Only for items in 'editable' or 'newItem' mode, sets the placeholder text for the editing form.
+		* Only for items in 'editable' mode, sets the placeholder text for the editing form.
 		*/
 		editPlaceholder: {
 			type: String,
@@ -348,11 +312,9 @@ export default {
 
 	data() {
 		return {
-			newItemValue: '',
 			editingValue: '',
 			opened: this.open,
 			editingActive: false,
-			newItemActive: false,
 		}
 	},
 	computed: {
@@ -450,23 +412,6 @@ export default {
 			this.editingActive = false
 		},
 
-		// New Item methods
-		handleNewItem() {
-			this.newItemActive = true
-			this.onMenuToggle(false)
-			this.$nextTick(() => {
-				// this.$refs.newItemInput.focus()
-			})
-		},
-		cancelNewItem() {
-			this.newItemActive = false
-		},
-		handleNewItemDone() {
-			this.$emit('new-item', this.newItemValue)
-			this.newItemValue = ''
-			this.newItemActive = false
-		},
-
 		// Undo methods
 		handleUndo() {
 			this.$emit('undo')
@@ -475,7 +420,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import '../../fonts/scss/iconfont-vue';
 
 .app-navigation-entry {

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -119,6 +119,7 @@ Just set the `pinned` prop.
 			'app-navigation-entry--opened': opened,
 			'app-navigation-entry--pinned': pinned,
 			'app-navigation-entry--editing' : editingActive,
+			'app-navigation-entry--newItemActive': newItemActive,
 			'app-navigation-entry--deleted': undo,
 			'app-navigation-entry--collapsible': collapsible,
 			'active': isActive
@@ -139,20 +140,11 @@ Just set the `pinned` prop.
 			<span v-if="!editingActive" class="app-navigation-entry__title" :title="title">
 				{{ title }}
 			</span>
-			<div v-if="editingActive" class="app-navigation-entry__inline-input-container">
-				<form @submit.prevent="handleEditingDone" @keydown.esc.exact.prevent="cancelEditing">
-					<input ref="editingInput"
-						v-model="editingValue"
-						type="text"
-						class="app-navigation-entry__inline-input"
-						:placeholder="editPlaceholder !== '' ? editPlaceholder : title">
-					<button type="submit"
-						class="icon-confirm"
-						@click.stop.prevent="handleEditingDone" />
-					<button type="reset"
-						class="icon-close"
-						@click.stop.prevent="cancelEditing" />
-				</form>
+			<div v-if="editingActive" class="editingContainer">
+				<InputConfirmCancel v-model="editingValue"
+					:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
+					@cancel="cancelEditing"
+					@confirm="handleEditingDone" />
 			</div>
 		</a>
 
@@ -176,20 +168,11 @@ Just set the `pinned` prop.
 			</span>
 
 			<!-- new Item input -->
-			<div v-if="newItemActive" class="app-navigation-entry__inline-input-container">
-				<form @submit.prevent="handleNewItemDone" @keydown.esc.exact.prevent="cancelNewItem">
-					<input ref="newItemInput"
-						v-model="newItemValue"
-						type="text"
-						class="app-navigation-entry__inline-input"
-						:placeholder="title">
-					<button type="submit"
-						class="icon-confirm"
-						@click.stop.prevent="handleNewItemDone" />
-					<button type="reset"
-						class="icon-close"
-						@click.stop.prevent="cancelNewItem" />
-				</form>
+			<div v-if="newItemActive" class="newItemContainer">
+				<InputConfirmCancel v-model="newItemValue"
+					:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
+					@cancel="cancelNewItem"
+					@confirm="handleNewItemDone" />
 			</div>
 		</div>
 
@@ -222,6 +205,7 @@ import Actions from '../Actions/Actions'
 import ActionButton from '../ActionButton/ActionButton'
 import AppNavigationIconCollapsible from './AppNavigationIconCollapsible'
 import isMobile from '../../mixins/isMobile'
+import InputConfirmCancel from './InputConfirmCancel.vue'
 
 export default {
 	name: 'AppNavigationItem',
@@ -230,6 +214,7 @@ export default {
 		Actions,
 		ActionButton,
 		AppNavigationIconCollapsible,
+		InputConfirmCancel,
 	},
 	directives: {
 		ClickOutside,
@@ -449,7 +434,7 @@ export default {
 			this.editingActive = true
 			this.onMenuToggle(false)
 			this.$nextTick(() => {
-				this.$refs.editingInput.focus()
+				// this.$refs.editingInput.focus()
 			})
 		},
 		cancelEditing() {
@@ -466,7 +451,7 @@ export default {
 			this.newItemActive = true
 			this.onMenuToggle(false)
 			this.$nextTick(() => {
-				this.$refs.newItemInput.focus()
+				// this.$refs.newItemInput.focus()
 			})
 		},
 		cancelNewItem() {
@@ -488,6 +473,11 @@ export default {
 
 <style lang="scss" scoped>
 @import '../../fonts/scss/iconfont-vue';
+
+.editingContainer, .newItemContainer {
+	width: calc(100% - #{$clickable-area});
+	margin: auto;
+}
 
 .app-navigation-entry {
 	position: relative;
@@ -525,6 +515,12 @@ export default {
 		}
 	}
 
+	&:not(.app-navigation-entry--newItemActive):not(.app-navigation-entry--editing) {
+		.app-navigation-entry-link, .app-navigation-entry-div {
+			padding-right: $icon-margin;
+		}
+	}
+
 	// Main entry link
 	.app-navigation-entry-link, .app-navigation-entry-div {
 		z-index: 100; /* above the bullet to allow click*/
@@ -534,7 +530,6 @@ export default {
 		box-sizing: border-box;
 		min-height: $clickable-area;
 		padding: 0;
-		padding-right: $icon-margin;
 		white-space: nowrap;
 		color: var(--color-main-text);
 		background-repeat: no-repeat;
@@ -589,58 +584,6 @@ export default {
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		line-height: $clickable-area;
-	}
-}
-
-.app-navigation-entry__inline-input-container {
-	flex: 1 0 100%;
-	max-width: calc(100% - #{$clickable-area});
-	margin: auto;
-	/* Ugly hack for overriding the main entry link */
-	/* align the input correctly with the link text
-	44px-6px padding for the input */
-	/*padding-left: $clickable-area - $icon-margin - 6px !important;*/
-	form {
-		display: flex;
-		.app-navigation-entry__inline-input {
-			flex: 1 1 100%;
-			font-size: 14px;
-		}
-
-		// submit and cancel buttons
-		button {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			width: $clickable-area !important;
-			color: var(--color-main-text);
-			background: none;
-			font-size: 16px;
-
-			// icon hover/focus feedback
-			&::before {
-				opacity: $opacity_normal;
-			}
-			&:hover,
-			&:focus {
-				&::before {
-					opacity: $opacity_full;
-				}
-			}
-
-			&.icon-confirm {
-				@include iconfont('confirm');
-			}
-
-			&.icon-close {
-				@include iconfont('close');
-			}
-		}
-		.icon-close {
-			margin: 0;
-			border: none;
-			background-color: transparent;
-		}
 	}
 }
 

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -87,7 +87,7 @@ the placeholder is the previous title of the element.
 
 ```
 <AppNavigationItem title="Editable Item" :editable="true"
-	editPlaceholder="your_placeholder_here" />
+	editPlaceholder="your_placeholder_here" icon="icon-folder" />
 ```
 
 ### New Item element

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -459,7 +459,7 @@ export default {
 		}
 	}
 
-	&:not(.app-navigation-entry--newItemActive):not(.app-navigation-entry--editing) {
+	&:not(.app-navigation-entry--editing) {
 		.app-navigation-entry-link, .app-navigation-entry-div {
 			padding-right: $icon-margin;
 		}
@@ -499,7 +499,7 @@ export default {
 			padding-left: 6px;
 		}
 
-		.editingContainer, .newItemContainer {
+		.editingContainer {
 			width: calc(100% - #{$clickable-area});
 			margin: auto;
 		}

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -452,6 +452,16 @@ export default {
 				this.$refs.editingInput.focus()
 			})
 		},
+		cancelEditing() {
+			this.editingActive = false
+		},
+		handleEditingDone() {
+			this.$emit('update:title', this.editingValue)
+			this.editingValue = ''
+			this.editingActive = false
+		},
+
+		// New Item methods
 		handleNewItem() {
 			this.newItemActive = true
 			this.onMenuToggle(false)
@@ -459,16 +469,8 @@ export default {
 				this.$refs.newItemInput.focus()
 			})
 		},
-		cancelEditing() {
-			this.editingActive = false
-		},
 		cancelNewItem() {
 			this.newItemActive = false
-		},
-		handleEditingDone() {
-			this.$emit('update:title', this.editingValue)
-			this.editingValue = ''
-			this.editingActive = false
 		},
 		handleNewItemDone() {
 			this.$emit('new-item', this.newItemValue)

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -278,6 +278,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/**
+		* When clicked a inline text input with a confirm and cancel button appears insted of the title.
+		* When the user confirms the input the 'new-item' event gets emitted.
+		*/
 		newItem: {
 			type: Boolean,
 			default: false,
@@ -290,7 +294,7 @@ export default {
 			default: '',
 		},
 		/**
-		* Only for 'editable' items, sets placeholder text for the editing form.
+		* Only for items in 'editable' or 'newItem' mode, sets the placeholder text for the editing form.
 		*/
 		editPlaceholder: {
 			type: String,

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -1,26 +1,28 @@
 <!--
-  - @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
-  -
-  - @author John Molakvoæ <skjnldsv@protonmail.com>
-  - @author Marco Ambrosini <marcoambrosini@pm.me>
-  - @author Jonas Sulzer <jonas@violoncello.ch>
-  -
-  - @license GNU AGPL version 3 or any later version
-  -
-  - This program is free software: you can redistribute it and/or modify
-  - it under the terms of the GNU Affero General Public License as
-  - published by the Free Software Foundation, either version 3 of the
-  - License, or (at your option) any later version.
-  -
-  - This program is distributed in the hope that it will be useful,
-  - but WITHOUT ANY WARRANTY; without even the implied warranty of
-  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  - GNU Affero General Public License for more details.
-  -
-  - You should have received a copy of the GNU Affero General Public License
-  - along with this program. If not, see <http://www.gnu.org/licenses/>.
-  -
-  -->
+ - @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ -
+ - @author John Molakvoæ <skjnldsv@protonmail.com>
+ - @author Marco Ambrosini <marcoambrosini@pm.me>
+ - @author Jonas Sulzer <jonas@violoncello.ch>
+ - @author Jonathan Treffler <mail@jonathan-treffler.de>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
 <docs>
 
 # Usage

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -87,14 +87,14 @@ the placeholder is the previous title of the element.
 
 ```
 <AppNavigationItem title="Editable Item" :editable="true"
-	editPlaceholder="your_placeholder_here" icon="icon-folder" />
+	editPlaceholder="your_placeholder_here" icon="icon-folder" @update:title="function(value){alert(value)}" />
 ```
 
 ### New Item element
 Add the prop `:new-item=true`.
 
 ```
-<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="alert('new-item')" />
+<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="function(value){alert(value)}" />
 ```
 ### Undo element
 Just set the `undo` and `title` props. When clicking the undo button, an `undo` event is emitted.

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -1,3 +1,22 @@
+  <!--
+  - @copyright Copyright (c) 2020 Jonathan Treffler <mail@jonathan-treffler.de>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
 <docs>
 ### New Item element
 ```

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -52,7 +52,8 @@
 
 			<!-- new Item input -->
 			<div v-if="newItemActive" class="newItemContainer">
-				<InputConfirmCancel v-model="newItemValue"
+				<InputConfirmCancel ref="newItemInput"
+					v-model="newItemValue"
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
 					@cancel="cancelNewItem"
 					@confirm="handleNewItemDone" />
@@ -130,9 +131,7 @@ export default {
 			if (!this.loading) {
 				this.newItemActive = true
 				this.onMenuToggle(false)
-				// this.$nextTick(() => {
-				// this.$refs.newItemInput.focus()
-				// })
+				this.$refs.newItemInput.focusInput()
 			}
 		},
 		cancelNewItem() {

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -14,9 +14,9 @@ Add the prop `:new-item=true`.
 		class="app-navigation-entry">
 		<!-- New Item -->
 		<div class="app-navigation-entry-div" @click="handleNewItem">
-			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
+			<div :class="{ 'icon-loading-small': loading, [icon]: icon }"
 				class="app-navigation-entry-icon">
-				<slot v-if="!loading" v-show="isIconShown" name="icon" />
+				<slot v-if="!loading" name="icon" />
 			</div>
 
 			<span v-if="!newItemActive" class="app-navigation-entry__title" :title="title">

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -124,6 +124,7 @@ export default {
 	padding-left: 7px;
 	font-size: 14px;
 }
+
 .newItemContainer {
 	width: calc(100% - #{$clickable-area});
 	margin: auto;

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -1,0 +1,121 @@
+<docs>
+### New Item element
+Add the prop `:new-item=true`.
+
+```
+<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="function(value){alert(value)}" />
+```
+</docs>
+<template>
+	<!-- Navigation item, can be either an <li> or a <router-link> depending on the props -->
+	<nav-element v-bind="navElement"
+		:class="{
+			'app-navigation-entry--newItemActive': newItemActive,
+		}"
+		class="app-navigation-entry">
+		<!-- New Item -->
+		<div class="app-navigation-entry-div" @click="handleNewItem">
+			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
+				class="app-navigation-entry-icon">
+				<slot v-if="!loading" v-show="isIconShown" name="icon" />
+			</div>
+
+			<span v-if="!newItemActive" class="app-navigation-entry__title" :title="title">
+				{{ title }}
+			</span>
+
+			<!-- new Item input -->
+			<div v-if="newItemActive" class="newItemContainer">
+				<InputConfirmCancel v-model="newItemValue"
+					:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
+					@cancel="cancelNewItem"
+					@confirm="handleNewItemDone" />
+			</div>
+		</div>
+	</nav-element>
+</template>
+
+<script>
+import { directive as ClickOutside } from 'v-click-outside'
+import isMobile from '../../mixins/isMobile'
+import InputConfirmCancel from './InputConfirmCancel.vue'
+
+export default {
+	name: 'AppNavigationNewItem',
+
+	components: {
+		InputConfirmCancel,
+	},
+	directives: {
+		ClickOutside,
+	},
+	mixins: [isMobile],
+	props: {
+		/**
+		 * The title of the element.
+		 */
+		title: {
+			type: String,
+			required: true,
+		},
+		/**
+		* Refers to the icon on the left, this prop accepts a class
+		* like 'icon-category-enabled'.
+		*/
+		icon: {
+			type: String,
+			default: '',
+		},
+
+		/**
+		* Displays a loading animated icon on the left of the element
+		* instead of the icon.
+		*/
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		* Only for 'editable' items, sets label for the edit action button.
+		*/
+		editLabel: {
+			type: String,
+			default: '',
+		},
+		/**
+		* Sets the placeholder text for the editing form.
+		*/
+		editPlaceholder: {
+			type: String,
+			default: '',
+		},
+	},
+
+	data() {
+		return {
+			newItemValue: '',
+			newItemActive: false,
+		}
+	},
+	computed: {
+	},
+	methods: {
+		// New Item methods
+		handleNewItem() {
+			this.newItemActive = true
+			this.onMenuToggle(false)
+			this.$nextTick(() => {
+				// this.$refs.newItemInput.focus()
+			})
+		},
+		cancelNewItem() {
+			this.newItemActive = false
+		},
+		handleNewItemDone() {
+			this.$emit('new-item', this.newItemValue)
+			this.newItemValue = ''
+			this.newItemActive = false
+		},
+	},
+}
+</script>

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -1,22 +1,25 @@
-  <!--
-  - @copyright Copyright (c) 2020 Jonathan Treffler <mail@jonathan-treffler.de>
-  -
-  - @license GNU AGPL version 3 or any later version
-  -
-  - This program is free software: you can redistribute it and/or modify
-  - it under the terms of the GNU Affero General Public License as
-  - published by the Free Software Foundation, either version 3 of the
-  - License, or (at your option) any later version.
-  -
-  - This program is distributed in the hope that it will be useful,
-  - but WITHOUT ANY WARRANTY; without even the implied warranty of
-  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  - GNU Affero General Public License for more details.
-  -
-  - You should have received a copy of the GNU Affero General Public License
-  - along with this program. If not, see <http://www.gnu.org/licenses/>.
-  -
-  -->
+<!--
+ - @copyright Copyright (c) 2020 Jonathan Treffler <mail@jonathan-treffler.de>
+ -
+ - @author Jonathan Treffler <mail@jonathan-treffler.de>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
 <docs>
 # Usage
 

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -98,6 +98,11 @@ export default {
 		}
 	},
 	computed: {
+        navElement() {
+			return {
+				is: 'li',
+			}
+		},
 	},
 	methods: {
 		// New Item methods

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -18,6 +18,8 @@
   -
   -->
 <docs>
+# Usage
+
 ### New Item element
 ```
 <AppNavigationNewItem title="New Item" icon="icon-add" @new-item="function(value){alert(value)}" />

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -22,6 +22,11 @@
 ```
 <AppNavigationNewItem title="New Item" icon="icon-add" @new-item="function(value){alert(value)}" />
 ```
+
+### New Item element with a loading animation instead of the icon
+```
+<AppNavigationNewItem title="New Item" icon="icon-add" :loading="true" />
+```
 </docs>
 <template>
 	<li

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -36,7 +36,7 @@
 		class="app-navigation-entry">
 		<!-- New Item -->
 		<div class="app-navigation-entry-div" @click="handleNewItem">
-			<div :class="{ 'icon-loading-small': loading, [icon]: icon }"
+			<div :class="{ 'icon-loading-small': loading, [icon]: !loading }"
 				class="app-navigation-entry-icon">
 				<slot v-if="!loading" name="icon" />
 			</div>

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -19,7 +19,7 @@ Add the prop `:new-item=true`.
 				<slot v-if="!loading" name="icon" />
 			</div>
 
-			<span v-if="!newItemActive" class="app-navigation-entry__title" :title="title">
+			<span v-if="!newItemActive" class="app-navigation-entry__title app-navigation-new-item__title" :title="title">
 				{{ title }}
 			</span>
 
@@ -117,3 +117,9 @@ export default {
 	},
 }
 </script>
+<style lang="scss">
+.app-navigation-new-item__title {
+	padding-left: 7px;
+	font-size: 14px;
+}
+</style>

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -122,11 +122,13 @@ export default {
 	},
 	methods: {
 		handleNewItem() {
-			this.newItemActive = true
-			this.onMenuToggle(false)
-			this.$nextTick(() => {
-				// this.$refs.newItemInput.focus()
-			})
+			if(!this.loading) {
+				this.newItemActive = true
+				this.onMenuToggle(false)
+				//this.$nextTick(() => {
+					// this.$refs.newItemInput.focus()
+				//})
+			}
 		},
 		cancelNewItem() {
 			this.newItemActive = false

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -8,7 +8,7 @@ Add the prop `:new-item=true`.
 </docs>
 <template>
 	<!-- Navigation item, can be either an <li> or a <router-link> depending on the props -->
-	<nav-element v-bind="navElement"
+	<li
 		:class="{
 			'app-navigation-entry--newItemActive': newItemActive,
 		}"
@@ -32,7 +32,7 @@ Add the prop `:new-item=true`.
 					@confirm="handleNewItemDone" />
 			</div>
 		</div>
-	</nav-element>
+	</li>
 </template>
 
 <script>
@@ -98,11 +98,6 @@ export default {
 		}
 	},
 	computed: {
-        navElement() {
-			return {
-				is: 'li',
-			}
-		},
 	},
 	methods: {
 		// New Item methods

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -122,12 +122,12 @@ export default {
 	},
 	methods: {
 		handleNewItem() {
-			if(!this.loading) {
+			if (!this.loading) {
 				this.newItemActive = true
 				this.onMenuToggle(false)
-				//this.$nextTick(() => {
-					// this.$refs.newItemInput.focus()
-				//})
+				// this.$nextTick(() => {
+				// this.$refs.newItemInput.focus()
+				// })
 			}
 		},
 		cancelNewItem() {

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -130,7 +130,6 @@ export default {
 		handleNewItem() {
 			if (!this.loading) {
 				this.newItemActive = true
-				this.onMenuToggle(false)
 				this.$refs.newItemInput.focusInput()
 			}
 		},

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -3,11 +3,10 @@
 Add the prop `:new-item=true`.
 
 ```
-<AppNavigationItem title="New Item" icon="icon-add" :new-item="true" @new-item="function(value){alert(value)}" />
+<AppNavigationNewItem title="New Item" icon="icon-add" @new-item="function(value){alert(value)}" />
 ```
 </docs>
 <template>
-	<!-- Navigation item, can be either an <li> or a <router-link> depending on the props -->
 	<li
 		:class="{
 			'app-navigation-entry--newItemActive': newItemActive,
@@ -100,7 +99,6 @@ export default {
 	computed: {
 	},
 	methods: {
-		// New Item methods
 		handleNewItem() {
 			this.newItemActive = true
 			this.onMenuToggle(false)

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -124,4 +124,8 @@ export default {
 	padding-left: 7px;
 	font-size: 14px;
 }
+.newItemContainer {
+	width: calc(100% - #{$clickable-area});
+	margin: auto;
+}
 </style>

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -1,7 +1,5 @@
 <docs>
 ### New Item element
-Add the prop `:new-item=true`.
-
 ```
 <AppNavigationNewItem title="New Item" icon="icon-add" @new-item="function(value){alert(value)}" />
 ```

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -17,7 +17,7 @@
 				<slot v-if="!loading" name="icon" />
 			</div>
 
-			<span v-if="!newItemActive" class="app-navigation-entry__title app-navigation-new-item__title" :title="title">
+			<span v-if="!newItemActive" class="app-navigation-new-item__title" :title="title">
 				{{ title }}
 			</span>
 
@@ -117,6 +117,10 @@ export default {
 </script>
 <style lang="scss">
 .app-navigation-new-item__title {
+	overflow: hidden;
+	max-width: 100%;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 	padding-left: 7px;
 	font-size: 14px;
 }

--- a/src/components/AppNavigationItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationNewItem.vue
@@ -130,7 +130,9 @@ export default {
 		handleNewItem() {
 			if (!this.loading) {
 				this.newItemActive = true
-				this.$refs.newItemInput.focusInput()
+				this.$nextTick(() => {
+					this.$refs.newItemInput.focusInput()
+				})
 			}
 		},
 		cancelNewItem() {

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="app-navigation-entry__inline-input-container">
-		<form @submit.prevent="confirm" @keydown.esc.exact.prevent="cancel">
+		<form @submit.prevent="confirm" @keydown.esc.exact.prevent="cancel" @click.stop.prevent>
 			<input ref="editingInput"
 				v-model="valueModel"
 				type="text"

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -1,3 +1,25 @@
+<!--
+ - @copyright Copyright (c) 2020 Jonathan Treffler <mail@jonathan-treffler.de>
+ -
+ - @author Jonathan Treffler <mail@jonathan-treffler.de>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+ 
 <docs>
 # Usage
 

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -74,9 +74,7 @@ export default {
 			this.$emit('cancel')
 		},
 		focusInput() {
-			//this.$nextTick(() => {
 			this.$refs.input.focus()
-			//})
 		},
 	},
 }

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -1,3 +1,10 @@
+<docs>
+# Usage
+
+```
+<InputConfirmCancel @confirm="alert('confirm')" @cancel="alert('cancel')" />
+```
+</docs>
 <template>
 	<div class="app-navigation-entry__inline-input-container">
 		<form @submit.prevent="confirm" @keydown.esc.exact.prevent="cancel" @click.stop.prevent>

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -19,7 +19,7 @@
  - along with this program. If not, see <http://www.gnu.org/licenses/>.
  -
  -->
- 
+
 <docs>
 # Usage
 

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -30,7 +30,7 @@
 <template>
 	<div class="app-navigation-entry__inline-input-container">
 		<form @submit.prevent="confirm" @keydown.esc.exact.prevent="cancel" @click.stop.prevent>
-			<input ref="editingInput"
+			<input ref="input"
 				v-model="valueModel"
 				type="text"
 				class="app-navigation-entry__inline-input"
@@ -72,6 +72,11 @@ export default {
 		},
 		cancel() {
 			this.$emit('cancel')
+		},
+		focusInput() {
+			this.$nextTick(() => {
+				this.$refs.input.focus()
+			})
 		},
 	},
 }

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -74,9 +74,9 @@ export default {
 			this.$emit('cancel')
 		},
 		focusInput() {
-			this.$nextTick(() => {
-				this.$refs.input.focus()
-			})
+			//this.$nextTick(() => {
+			this.$refs.input.focus()
+			//})
 		},
 	},
 }

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -1,0 +1,104 @@
+<template>
+	<div class="app-navigation-entry__inline-input-container">
+		<form @submit.prevent="confirm" @keydown.esc.exact.prevent="cancel">
+			<input ref="editingInput"
+				v-model="valueModel"
+				type="text"
+				class="app-navigation-entry__inline-input"
+				:placeholder="placeholder">
+			<button type="submit"
+				class="icon-confirm"
+				@click.stop.prevent="confirm" />
+			<button type="reset"
+				class="icon-close"
+				@click.stop.prevent="cancel" />
+		</form>
+	</div>
+</template>
+<script>
+export default {
+	props: {
+		placeholder: {
+			default: '',
+			type: String,
+		},
+	},
+	data() {
+		return {
+			value: '',
+		}
+	},
+	computed: {
+		valueModel: {
+			get() { return this.value },
+			set(newValue) {
+				this.$emit('input', newValue)
+				this.value = newValue
+			},
+		},
+	},
+	methods: {
+		confirm() {
+			this.$emit('confirm')
+		},
+		cancel() {
+			this.$emit('cancel')
+		},
+	},
+}
+</script>
+
+<style lang="scss">
+@import '../../fonts/scss/iconfont-vue';
+
+.app-navigation-entry__inline-input-container {
+	flex: 1 0 100%;
+	width: 100%;
+	form {
+		display: flex;
+		.app-navigation-entry__inline-input {
+			flex: 1 1 100%;
+			font-size: 14px;
+		}
+
+		// submit and cancel buttons
+		button {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: $clickable-area !important;
+			color: var(--color-main-text);
+			background: none;
+			font-size: 16px;
+
+			// icon hover/focus feedback
+			&::before {
+				opacity: $opacity_normal;
+			}
+			&:hover,
+			&:focus {
+				&::before {
+					opacity: $opacity_full;
+				}
+			}
+
+			&.icon-confirm {
+				@include iconfont('confirm');
+				border-left: none;
+			}
+			&.icon-confirm:hover {
+				border-radius: 0px var(--border-radius) var(--border-radius) 0px !important;
+			}
+
+			&.icon-close {
+				@include iconfont('close');
+			}
+		}
+		.icon-close {
+			margin: 0;
+			border: none;
+			background-color: transparent;
+		}
+	}
+}
+</style>


### PR DESCRIPTION
@jancborchardt and I decided to create a new mode for the AppNavigationItem, to add something similar to the editable mode, but without the editing part, just a inline input box that apperas when the logo is clicked and a event when the new input gets acccepted.
We will need this for the News App Vue Rewrite.
I think @jancborchardt can explain this much better than me.

- [x] implement behaviour
- [x] make variable names more useful
- [x] update docs
- [x] code cleanup
- [x] move into dedicated component (Work in progress)
- [x] variable name cleanup
- [x] Copyright header
- [x] re-implement automatic focus of the input
- [x] final testing
- [x] Screenshot

## Screenshots
![image](https://user-images.githubusercontent.com/28999431/97313593-1cdee580-1867-11eb-969a-b865be2f1d39.png)

when clicked:
![image](https://user-images.githubusercontent.com/28999431/97313560-10f32380-1867-11eb-87e8-d17ce3eac7c5.png)