### PR TITLE
Fix broken netlify docs

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -79,7 +79,6 @@
 		}
 	</script>
 	```
-	```
 
 	### Empty sidebar for e.g. empty content component.
 	```vue


### PR DESCRIPTION
I overlooked a "```" in the docs, sorry for the hassle.

Closes #1284.