### PR TITLE
Use factory function to return default value

### DIFF
--- a/src/mixins/excludeClickOutsideClasses.js
+++ b/src/mixins/excludeClickOutsideClasses.js
@@ -29,7 +29,7 @@ export default {
 		 */
 		excludeClickOutsideClasses: {
 			type: String | Array,
-			default: [],
+			default: () => [],
 		},
 	},
 	methods: {


### PR DESCRIPTION
This fixes the warning:

```
[Vue warn]: Invalid default value for prop "excludeClickOutsideClasses": Props with type Object/Array must use a factory function to return the default value.

found in

---> <AppNavigationSettings> at src/components/AppNavigationSettings/AppNavigationSettings.vue
       <AppNavigation> at src/components/AppNavigation/AppNavigation.vue
         <AppNavigation> at src/components/AppNavigation/AppNavigation.vue
           <Content> at src/components/Content/Content.vue
             <App> at src/App.vue
               <Root> vue.runtime.esm.js:619
```