### PR TITLE
Allow to specify a custom action instead of the star

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -163,14 +163,17 @@
 					}"
 					class="app-sidebar-header__desc">
 					<!-- favourite icon -->
-					<div v-if="canStar" class="app-sidebar-header__star-action">
-						<a :class="{
-								'icon-starred': isStarred && !starLoading,
-								'icon-star': !isStarred && !starLoading,
-								'icon-loading-small': starLoading
-							}"
-							class="app-sidebar-header__star"
-							@click.prevent="toggleStarred" />
+					<div v-if="canStar || $slots['tertiary-actions']" class="app-sidebar-header__tertiary-actions">
+						<slot name="tertiary-actions">
+							<a v-if="canStar"
+								:class="{
+									'icon-starred': isStarred && !starLoading,
+									'icon-star': !isStarred && !starLoading,
+									'icon-loading-small': starLoading
+								}"
+								class="app-sidebar-header__star"
+								@click.prevent="toggleStarred" />
+						</slot>
 					</div>
 
 					<!-- main title -->
@@ -480,7 +483,7 @@ $top-buttons-spacing: 6px;
 			box-sizing: content-box;
 			padding: #{$desc-vertical-padding} 0 #{$desc-vertical-padding} #{$desc-vertical-padding / 2};
 
-			.app-sidebar-header__star-action {
+			.app-sidebar-header__tertiary-actions {
 				display: flex;
 				height: $clickable-area;
 				width: $clickable-area;

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -80,7 +80,7 @@
 	</script>
 	```
 
-	### Editable title after click
+	### Editable title after click with custom tertiary action
 	```vue
 	<template>
 		<AppSidebar
@@ -89,7 +89,11 @@
 			:title-placeholder="titlePlaceholder"
 			:subtitle="subtitle"
 			@update:title="titleUpdate">
-			<!-- Insert your slots and tabs here -->
+			<template slot="tertiary-actions">
+				<form>
+					<input type="checkbox" @click="toggledCheckbox"/>
+				</form>
+			</template>
 		</AppSidebar>
 	</template>
 	<script>
@@ -105,6 +109,9 @@
 			methods: {
 				titleUpdate(e) {
 					this.title = e
+				},
+				toggledCheckbox() {
+					alert('toggle')
 				}
 			}
 		}


### PR DESCRIPTION
This PR allows to specify a custom action instead of the star icon in the sidebar. Useful e.g. for the Tasks app to toggle the completed state of a task.

Since #1288 introduced quite some changes to the structure, I implemented it on top of #1288. The important commit is f1ea31adc8fa131a96d4bdd9609bc9848c70edfe. I will rebase this PR here once #1288 is in.

![custom-action](https://user-images.githubusercontent.com/2496460/90564528-cf2e6880-e1a5-11ea-9856-10ad843eafbe.gif)
