### PR TITLE
Fix ActionInput label height

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -309,6 +309,7 @@ $input-margin: 4px;
 
 		width: #{$clickable-area - $input-margin * 2};
 		height: #{$clickable-area - $input-margin * 2};
+		box-sizing: border-box;
 		margin: 0 0 0 -8px;
 		padding: 7px 6px;
 


### PR DESCRIPTION
Noticed in Calendar. See https://nextcloud-vue-components.netlify.app/#/Components/Actions?id=actioninput

![image](https://user-images.githubusercontent.com/2197836/91580323-350cb400-e94d-11ea-8c04-2eb26a0f30aa.png)
