### PR TITLE
Forward update:active event in AppSidebar

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -218,7 +218,7 @@
 				</div>
 			</header>
 
-			<AppSidebarTabs ref="tabs" :active="active">
+			<AppSidebarTabs ref="tabs" :active="active" @update:active="onUpdateActive">
 				<slot />
 			</AppSidebarTabs>
 		</aside>
@@ -422,6 +422,9 @@ export default {
 			// Disable editing
 			this.$emit('update:titleEditable', false)
 			this.$emit('dismiss-editing')
+		},
+		onUpdateActive(activeTab) {
+			this.$emit('update:active', activeTab)
 		},
 	},
 }


### PR DESCRIPTION
Maybe I missed something and there is a new way to do that but it seems to be a bug. AppSidebar used to emit "update:active" event to let its parent know when active tab is changed.

"update:active" event is not emitted by AppSidebar anymore. It is emitted by AppSidebarTabs but not caught. So it just needs to be forwarded imho.