### PR TITLE
New prop for AppNavigationItem to set actions/menu placement

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -146,6 +146,7 @@ Just set the `pinned` prop.
 		<div v-if="hasUtils" class="app-navigation-entry__utils">
 			<slot name="counter" />
 			<Actions menu-align="right"
+				:placement="menuPlacement"
 				:open="menuOpen"
 				:force-menu="forceMenu"
 				:default-icon="menuIcon"
@@ -316,6 +317,13 @@ export default {
 		menuIcon: {
 			type: String,
 			default: undefined,
+		},
+		/**
+		 * The action's menu direction
+		 */
+		menuPlacement: {
+			type: String,
+			default: 'bottom',
 		},
 	},
 


### PR DESCRIPTION
Just forwarding the "menu-placement" prop to the underlying Actions component. Default is the same as Actions's placement.

It can be useful, for example, to avoid hiding what's below the AppNavigationItem when showing the menu.