### PR TITLE
Do not fetch user status if current user is a guest

### DIFF
--- a/src/mixins/userStatus.js
+++ b/src/mixins/userStatus.js
@@ -22,6 +22,7 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { getCapabilities } from '@nextcloud/capabilities'
+import { getCurrentUser } from '@nextcloud/auth'
 
 export default {
 	data() {
@@ -44,6 +45,11 @@ export default {
 		async fetchUserStatus(userId) {
 			const capabilities = getCapabilities()
 			if (!Object.prototype.hasOwnProperty.call(capabilities, 'user_status') || !capabilities.user_status.enabled) {
+				return
+			}
+
+			// User status endpoint is not available for guests.
+			if (!getCurrentUser()) {
 				return
 			}
 


### PR DESCRIPTION
The user status endpoint is not available for guests, [only for logged in users](https://github.com/nextcloud/server/blob/0fad921840eb801492522af6ef795231163cff20/apps/user_status/lib/Controller/StatusesController.php#L71). As the request will always fail if the current user is a guest there should be no need to perform it.

Note, however, that this will prevent user statuses to be shown on the avatars in public share pages, even if the current user is actually logged in. [Public share pages are opened in incognito mode](https://github.com/nextcloud/server/blob/217a69ebf9cd766c23b6f69037cbbe07cb00b7ce/apps/files_sharing/lib/Controller/ShareController.php#L310), so `getCurrentUser` returns null. However, if the current user is logged in requests to the API would work without problems, so technically it would be possible to fetch the user statuses.

Due to the problem described in last paragraph I am not sure if this should be merged or not. In fact the more I think about it the less I like this pull request :-P Opinions?
