### PR TITLE
Fetch user status in avatar only if it is going to be shown

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -359,7 +359,7 @@ export default {
 	},
 	mounted() {
 		this.loadAvatarUrl()
-		if (this.user && !this.isNoUser) {
+		if (this.showUserStatus && this.user && !this.isNoUser) {
 			this.fetchUserStatus(this.user)
 		}
 	},


### PR DESCRIPTION
Before the user status was always fetched when the component was mounted,
even if "showUserStatus" was false. If the avatar was never meant to
show the user status that caused unneeded requests (for example, in the
chat view of Talk).