### PR TITLE
[WIP] In Action, stop propagation of click event coming from popover

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -110,7 +110,8 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 	<div v-else
 		v-show="hasMultipleActions || forceMenu"
 		:class="{'action-item--open': opened}"
-		class="action-item">
+		class="action-item"
+		@click.stop="">
 		<!-- If more than one action, create a popovermenu -->
 		<Popover
 			:delay="0"


### PR DESCRIPTION
This is one way to solve #1386. 

@skjnldsv @raimund-schluessler @ma12-co Does it feel right?

This only works when there are multiple actions. Any clue to do it when there is just once?

I can't find a way to directly do that in the Popover component. Do we even want to do that?