### PR TITLE
Allow to set popover container

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -118,7 +118,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 			:open.sync="opened"
 			:placement="placement"
 			:boundaries-element="boundariesElement"
-			container="body"
+			:container="container"
 			@show="openMenu"
 			@apply-show="onOpen"
 			@hide="closeMenu">
@@ -268,6 +268,14 @@ export default {
 		boundariesElement: {
 			type: Element,
 			default: () => document.querySelector('body'),
+		},
+
+		/**
+		 * Selector for the actions' popover container
+		 */
+		container: {
+			type: String,
+			default: 'body',
 		},
 	},
 


### PR DESCRIPTION
This allows to select the popover container. The default is still `body` so nothing will break here 😉 Helps fixing #1384.

See https://github.com/nextcloud/nextcloud-vue/issues/1384#issuecomment-687573004 for details.