### PR TITLE
Fix customer avatar handling in userbubble

### DIFF
--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -82,8 +82,8 @@ This component has the following slot:
 			:class="primary ? 'user-bubble__content--primary' : ''"
 			@click="onClick">
 			<!-- Avatar -->
-			<Avatar :url="!isCustomAvatar && isAvatarUrl ? avatarImage : undefined"
-				:icon-class="!isCustomAvatar && !isAvatarUrl ? avatarImage : undefined"
+			<Avatar :url="isCustomAvatar && isAvatarUrl ? avatarImage : undefined"
+				:icon-class="isCustomAvatar && !isAvatarUrl ? avatarImage : undefined"
 				:user="user"
 				:display-name="displayName"
 				:size="size - (margin * 2)"


### PR DESCRIPTION
Regression from bd7bc35917e8a5150f1142565c47e3d169864444

It inverted the logic from `isUserAvatar` to `isCustomAvatar` but forgot to invert the bool operator on this 2 usages