### PR TITLE
Show icon instead of status if not in do not disturbe mode

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -54,7 +54,10 @@
 		<div v-if="hasMenu" class="icon-more" />
 
 		<!-- avatar status -->
-		<div v-if="canDisplayUserStatus"
+		<div v-if="userStatus.icon && userStatus.status !== 'dnd'" class="avatardiv__user-status avatardiv__user-status--icon">
+			{{ userStatus.icon }}
+		</div>
+		<div v-else-if="canDisplayUserStatus"
 			class="avatardiv__user-status"
 			:class="'avatardiv__user-status--' + userStatus.status" />
 		<div v-else-if="status"
@@ -608,6 +611,11 @@ export default {
 			@include iconfont('user-status-away');
 			color: #f4a331;
 		}
+		&--icon {
+			border: none;
+			background-color: transparent;
+		}
+		
 	}
 
 	.popovermenu-wrapper {

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -54,7 +54,7 @@
 		<div v-if="hasMenu" class="icon-more" />
 
 		<!-- avatar status -->
-		<div v-if="userStatus.icon && userStatus.status !== 'dnd'" class="avatardiv__user-status avatardiv__user-status--icon">
+		<div v-if="showUserStatusIconOnAvatar" class="avatardiv__user-status avatardiv__user-status--icon">
 			{{ userStatus.icon }}
 		</div>
 		<div v-else-if="canDisplayUserStatus"
@@ -138,6 +138,13 @@ export default {
 		 * Whether or not to display the user-status
 		 */
 		showUserStatus: {
+			type: Boolean,
+			default: true,
+		},
+		/**
+		 * Whether or not to the status-icon should be used instead of online/away
+		 */
+		showUserStatusCompact: {
 			type: Boolean,
 			default: true,
 		},
@@ -261,6 +268,12 @@ export default {
 			return this.showUserStatus
 				&& this.hasStatus
 				&& ['online', 'away', 'dnd'].includes(this.userStatus.status)
+		},
+		showUserStatusIconOnAvatar() {
+			return  this.showUserStatus
+				&& this.showUserStatusCompact
+				&& this.hasStatus
+				&& this.userStatus.status !== 'dnd'
 		},
 		getUserIdentifier() {
 			if (this.isDisplayNameDefined) {

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -270,7 +270,7 @@ export default {
 				&& ['online', 'away', 'dnd'].includes(this.userStatus.status)
 		},
 		showUserStatusIconOnAvatar() {
-			return  this.showUserStatus
+			return this.showUserStatus
 				&& this.showUserStatusCompact
 				&& this.hasStatus
 				&& this.userStatus.status !== 'dnd'
@@ -628,7 +628,6 @@ export default {
 			border: none;
 			background-color: transparent;
 		}
-		
 	}
 
 	.popovermenu-wrapper {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3404133/94700257-8b4d8800-033b-11eb-82b4-9d21858ba2d4.png)

How it looks in talk ([note that the duplicate icon needs a fixing there](https://github.com/nextcloud/spreed/pull/4253)):
![image](https://user-images.githubusercontent.com/3404133/94700867-4413c700-033c-11eb-951e-909b5b080fc9.png)


I played around a bit with a circled white background but this might look odd depending on the emoji. 

@jancborchardt Feel free to play around with the styles if needed 