### PR TITLE
Fix modal freeze

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -324,6 +324,8 @@ export default {
 	},
 	beforeDestroy() {
 		window.removeEventListener('keydown', this.handleKeydown)
+		this.mc.off('swipeleft swiperight')
+		this.mc.destroy()
 	},
 	mounted() {
 		this.showModal = true
@@ -339,9 +341,8 @@ export default {
 		// force mount the component to body
 		document.body.insertBefore(this.$el, document.body.lastChild)
 	},
-	unmounted() {
-		this.mc.off('swipeleft swiperight')
-		this.mc.destroy()
+	destroyed() {
+		this.$el.remove()
 	},
 
 	methods: {


### PR DESCRIPTION
The Modal component might freeze completely if it gets destroyed when its parent is destroyed. This is caused by the forced mount to body. To fix this I added a lifecycle hook that cleans up the injected html element after the component has been destroyed.

Additionally, I noticed that the modal code uses the lifecylce hook `unmounted` which is not existing in vue v2 ([see the documentation](https://vuejs.org/v2/api/#Options-Lifecycle-Hooks)). The dead code was moved to the corresponding hook `beforeDestroy`.

Found the bug while developing nextcloud/mail [#3591](https://github.com/nextcloud/mail/pull/3591).