### PR TITLE
Fix suggestion for RichContenteditable component

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -116,6 +116,6 @@ msgstr ""
 msgid "Unable to search the group"
 msgstr ""
 
-#: src/components/RichContenteditable/RichContenteditable.vue:112
+#: src/components/RichContenteditable/RichContenteditable.vue:114
 msgid "Write message, @ to mention someone …"
 msgstr ""

--- a/src/components/RichContenteditable/AutoCompleteResult.vue
+++ b/src/components/RichContenteditable/AutoCompleteResult.vue
@@ -23,7 +23,7 @@
 	<div class="autocomplete-result">
 		<!-- Avatar or icon -->
 		<div :class="[icon, `autocomplete-result__icon--${avatarUrl ? 'with-avatar' : ''}`]"
-			:style="{ backgroundImage: `url(${avatarUrl})` }"
+			:style="avatarUrl ? { backgroundImage: `url(${avatarUrl})` } : null "
 			class="autocomplete-result__icon">
 			<div v-if="haveStatus"
 				:class="[`autocomplete-result__status--${status && status.icon ? 'icon' : status.status}`]"

--- a/src/components/RichContenteditable/MentionBubble.vue
+++ b/src/components/RichContenteditable/MentionBubble.vue
@@ -27,7 +27,7 @@
 			<div class="mention-bubble__content">
 				<!-- Avatar or icon -->
 				<div :class="[icon, `mention-bubble__icon--${avatarUrl ? 'with-avatar' : ''}`]"
-					:style="{ backgroundImage: `url(${avatarUrl})` }"
+					:style="avatarUrl ? { backgroundImage: `url(${avatarUrl})` } : null"
 					class="mention-bubble__icon" />
 
 				<!-- Title -->

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -94,7 +94,7 @@ export default {
 		/**
 		 * Generate an autocompletion popup entry template
 		 *
-		 * @param {string} value the valeu to match against the userData
+		 * @param {string} value the value to match against the userData
 		 * @returns {string}
 		 */
 		genSelectTemplate(value) {


### PR DESCRIPTION
Bubble icon and autocomplete icons are always overridden by the background-image, even if there is no avatar URL (because it's not a user or there is no id).

This is an attempt to fix that :grin:.

refs #1433 