### PR TITLE
Fix npm run build by removing obsolete command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"dev": "webpack --config webpack.dev.js",
 		"watch": "webpack --progress --watch --config webpack.dev.js",
-		"build": "NODE_ENV=production webpack --progress --hide-modules --config webpack.prod.js",
+		"build": "NODE_ENV=production webpack --progress --config webpack.prod.js",
 		"l10n:extract": "node build/extract-l10n.js",
 		"lint": "eslint --ext .js,.vue src",
 		"lint:fix": "eslint --ext .js,.vue src --fix",


### PR DESCRIPTION
Remove hide-modules from webpack production command

Without this fix, `npm run build` fails with an error as this argument was removed in webpack 4 and https://github.com/nextcloud/nextcloud-vue/pull/1452 just upgraded to that version