### PR TITLE
Cache hasAvatar info in sessionStorage to avoid flicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5461,6 +5461,21 @@
 				"core-js": "^3.6.4"
 			}
 		},
+		"@nextcloud/browser-storage": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.1.1.tgz",
+			"integrity": "sha512-bWzs/A44rEK8b3CMOFw0ZhsenagrWdsB902LOEwmlMCcFysiFgWiOPbF4/0/ODlOYjvPrO02wf6RigWtb8P+gA==",
+			"requires": {
+				"core-js": "3.6.1"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
+					"integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ=="
+				}
+			}
+		},
 		"@nextcloud/browserslist-config": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	"dependencies": {
 		"@nextcloud/auth": "^1.2.3",
 		"@nextcloud/axios": "^1.3.2",
+		"@nextcloud/browser-storage": "^0.1.1",
 		"@nextcloud/capabilities": "^1.0.2",
 		"@nextcloud/dialogs": "^3.0.0",
 		"@nextcloud/event-bus": "^1.1.4",

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -90,6 +90,7 @@
 </template>
 
 <script>
+import { getBuilder } from '@nextcloud/browser-storage'
 import { directive as ClickOutside } from 'v-click-outside'
 import PopoverMenu from '../PopoverMenu'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -100,8 +101,10 @@ import Tooltip from '../../directives/Tooltip'
 import usernameToColor from '../../functions/usernameToColor'
 import { userStatus } from '../../mixins'
 
+const browserStorage = getBuilder('nextcloud').persist().build()
+
 function getUserHasAvatar(userId) {
-	const flag = window.sessionStorage.getItem('userHasAvatar-' + userId)
+	const flag = browserStorage.getItem('user-has-avatar.' + userId)
 	if (typeof flag === 'string') {
 		return Boolean(flag)
 	}
@@ -109,7 +112,7 @@ function getUserHasAvatar(userId) {
 }
 
 function setUserHasAvatar(userId, flag) {
-	window.sessionStorage.setItem('userHasAvatar-' + userId, flag)
+	browserStorage.setItem('user-has-avatar.' + userId, flag)
 }
 
 export default {


### PR DESCRIPTION
This is a crude POC that shows that when we save the "does this user has an avatar call", performance improves.

Possible solution for https://github.com/nextcloud/spreed/issues/4284

Maybe this should be stored in a store or something, but as I understand, Vue components in the library don't really have a store available.

Another approach would be to supply an optional property "hasAvatar" and the caching could be done from the outside in situations where the caller thinks it makes sense.