### PR TITLE
Make appSidebar scrollable inside

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -444,14 +444,17 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-$header-height: 50px;
 $sidebar-min-width: 300px;
 $sidebar-max-width: 500px;
+
 $desc-vertical-padding: 18px;
 $desc-input-padding: 7px;
-$desc-title-height: 30px;
+
 // title and subtitle
-$desc-height: $desc-title-height + 22px;
+$desc-title-height: 30px;
+$desc-subtitle-height: 22px;
+$desc-height: $desc-title-height + $desc-subtitle-height;
+
 $top-buttons-spacing: 6px;
 
 /*
@@ -462,7 +465,7 @@ $top-buttons-spacing: 6px;
 	position: -webkit-sticky; // Safari support
 	position: sticky;
 	z-index: 1500;
-	top: $header-height;
+	top: var(--header-height);
 	right: 0;
 	display: flex;
 	overflow-x: hidden;
@@ -472,7 +475,7 @@ $top-buttons-spacing: 6px;
 	width: 27vw;
 	min-width: $sidebar-min-width;
 	max-width: $sidebar-max-width;
-	height: calc(100vh - #{$header-height});
+	height: calc(100vh - var(--header-height));
 	border-left: 1px solid var(--color-border);
 	background: var(--color-main-background);
 	.app-sidebar-header {

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -266,9 +266,10 @@ export default {
 </script>
 <style lang="scss" scoped>
 .app-sidebar-tabs {
-	flex: 1 1 auto;
 	display: flex;
 	flex-direction: column;
+	min-height: 0;
+	flex: 1 1 100%;
 
 	&__nav {
 		margin-top: 10px;
@@ -340,7 +341,8 @@ export default {
 	&__content {
 		position: relative;
 		// take full available height
-		flex: 1 1 100%;
+		min-height: 0;
+		height: 100%;
 		// force the use of the tab component if more than one tab
 		// you can just put raw content if you don't use tabs
 		&--multiple > :not(section) {

--- a/src/components/AppSidebarTab/AppSidebarTab.vue
+++ b/src/components/AppSidebarTab/AppSidebarTab.vue
@@ -31,7 +31,8 @@
 		:aria-labelledby="name"
 		class="app-sidebar__tab"
 		tabindex="0"
-		role="tabpanel">
+		role="tabpanel"
+		@scroll="onScroll">
 		<slot />
 	</section>
 </template>
@@ -65,6 +66,19 @@ export default {
 			return this.$parent.activeTab === this.id
 		},
 	},
+
+	methods: {
+		onScroll(event) {
+			// Are we scrolled to the very bottom ?
+			if (this.$el.scrollHeight - this.$el.scrollTop === this.$el.clientHeight) {
+				/**
+				 * Bottom scroll is reached
+				 */
+				this.$emit('bottomReached', event)
+			}
+			this.$emit('scroll', event)
+		},
+	},
 }
 </script>
 
@@ -73,6 +87,8 @@ export default {
 	display: none;
 	padding: 10px;
 	min-height: 100%; // fill available height
+	max-height: 100%; // scroll inside
+	overflow: auto;
 
 	&:focus {
 		border-color: var(--color-primary);


### PR DESCRIPTION
Joas told me recently they had to rely on hacks to make the sidebar inner scrollable.
The AppSidebar needs to be as simple as possible, so I made the inner tabs scrollable by default and integrated two new events:
- `scroll`, the tab is being scrolled
- `bottomReached`, the tab is scrolled to the bottom

I also fixed some variables on the css