### PR TITLE
Fix avatar caching for non-user rendering

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -112,7 +112,9 @@ function getUserHasAvatar(userId) {
 }
 
 function setUserHasAvatar(userId, flag) {
-	browserStorage.setItem('user-has-avatar.' + userId, flag)
+	if (userId) {
+		browserStorage.setItem('user-has-avatar.' + userId, flag)
+	}
 }
 
 export default {
@@ -516,7 +518,7 @@ export default {
 		updateImageIfValid(url, srcset = null) {
 			// skip loading
 			const userHasAvatar = getUserHasAvatar(this.user)
-			if (typeof userHasAvatar === 'boolean') {
+			if (this.isUserDefined && typeof userHasAvatar === 'boolean') {
 				this.isAvatarLoaded = true
 				this.avatarUrlLoaded = url
 				if (srcset) {
@@ -539,8 +541,13 @@ export default {
 				setUserHasAvatar(this.user, true)
 			}
 			img.onerror = () => {
+				console.debug('Invalid avatar url', url)
+				// Avatar is invalid, reset
+				this.avatarUrlLoaded = null
+				this.avatarSrcSetLoaded = null
+
 				this.userDoesNotExist = true
-				this.isAvatarLoaded = true
+				this.isAvatarLoaded = false
 				setUserHasAvatar(this.user, false)
 			}
 


### PR DESCRIPTION
- Do not cache if the user is not defined
- Added debug level
- Fallback to letters if the url is invalid


```vue
<Avatar
	:disable-menu="true"
	:disable-tooltip="true"
	display-name="Hello User"
	:is-no-user="true"
	:size="40"
	url="http://this.is.a.fakeUrl.jpg"
	class="app-content-list-item-icon" />

```