### PR TITLE
Allow an "extra" slot for the AppNavigationItem

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -180,6 +180,9 @@ Just set the `pinned` prop.
 		<ul v-if="canHaveChildren && hasChildren" class="app-navigation-entry__children">
 			<slot />
 		</ul>
+
+		<!-- Anything (virtual) that should be mounted in the component, like a related modal -->
+		<slot name="extra" />
 	</nav-element>
 </template>
 


### PR DESCRIPTION
If you want to mount a Modal for an item in the navigation it becomes
tricky to mount the (virtual or not in-place) modal component from the
navigation. To avoid more complexity itwold be convenient to just mount
the component inside the navigation with the intention that it shouldn't
really render anything in-place.

For https://github.com/nextcloud/mail/pull/3569