### PR TITLE
Improve testability + small code changes of AppSideBarTabs

### DIFF
--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -26,13 +26,15 @@
 <template>
 	<div class="app-sidebar-tabs">
 		<!-- tabs navigation -->
+		<!-- 33 and 34 code is for page up and page down
+			the working shortcode "pageup" and "pagedown" are not allowed on linter -->
 		<nav v-if="hasMultipleTabs"
 			class="app-sidebar-tabs__nav"
 			@keydown.left.exact.prevent="focusPreviousTab"
 			@keydown.right.exact.prevent="focusNextTab"
 			@keydown.tab.exact.prevent="focusActiveTabContent"
-			@keydown.page-up.exact.prevent="focusFirstTab"
-			@keydown.page-down.exact.prevent="focusLastTab">
+			@keydown.33.exact.prevent="focusFirstTab"
+			@keydown.34.exact.prevent="focusLastTab">
 			<ul>
 				<li v-for="tab in tabs" :key="tab.id" class="app-sidebar-tabs__tab">
 					<a :id="tab.id"

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+  - @copyright Copyright (c) 2020 Simon Belbeoch <simon.belbeoch@gmail.com>
   -
   - @author John Molakvoæ <skjnldsv@protonmail.com>
   -
@@ -22,7 +23,6 @@
 
 <!-- Follows the tab aria guidelines
 	https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html -->
-
 <template>
 	<div class="app-sidebar-tabs">
 		<!-- tabs navigation -->
@@ -69,7 +69,7 @@ const IsValidString = function(value) {
 }
 
 const IsValidStringWithoutSpaces = function(value) {
-	return value && typeof value === 'string' && value.trim() !== '' && value.indexOf(' ') === -1
+	return IsValidString(value) && value.indexOf(' ') === -1
 }
 
 export default {
@@ -148,8 +148,7 @@ export default {
 		 */
 		focusPreviousTab() {
 			if (this.currentTabIndex > 0) {
-				this.activeTab = this.tabs[this.currentTabIndex - 1].id
-				this.$emit('update:active', this.activeTab)
+				this.setActive(this.tabs[this.currentTabIndex - 1].id)
 			}
 			this.focusActiveTab() // focus nav item
 		},
@@ -160,8 +159,7 @@ export default {
 		 */
 		focusNextTab() {
 			if (this.currentTabIndex < this.tabs.length - 1) {
-				this.activeTab = this.tabs[this.currentTabIndex + 1].id
-				this.$emit('update:active', this.activeTab)
+				this.setActive(this.tabs[this.currentTabIndex + 1].id)
 			}
 			this.focusActiveTab() // focus nav item
 		},
@@ -171,8 +169,7 @@ export default {
 		 * and emit to the parent component
 		 */
 		focusFirstTab() {
-			this.activeTab = this.tabs[0].id
-			this.$emit('update:active', this.activeTab)
+			this.setActive(this.tabs[0].id)
 			this.focusActiveTab() // focus nav item
 		},
 
@@ -181,8 +178,7 @@ export default {
 		 * and emit to the parent component
 		 */
 		focusLastTab() {
-			this.activeTab = this.tabs[this.tabs.length - 1].id
-			this.$emit('update:active', this.activeTab)
+			this.setActive(this.tabs[this.tabs.length - 1].id)
 			this.focusActiveTab() // focus nav item
 		},
 

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -26,8 +26,7 @@
 <template>
 	<div class="app-sidebar-tabs">
 		<!-- tabs navigation -->
-		<!-- 33 and 34 code is for page up and page down
-			the working shortcode "pageup" and "pagedown" are not allowed on linter -->
+		<!-- 33 and 34 code is for page up and page down -->
 		<nav v-if="hasMultipleTabs"
 			class="app-sidebar-tabs__nav"
 			@keydown.left.exact.prevent="focusPreviousTab"

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -222,7 +222,7 @@ export default {
 				return
 			}
 
-			// Find all valid children (AppSidbarTab, other components, text nodes, etc.)
+			// Find all valid children (AppSidebarTab, other components, text nodes, etc.)
 			const children = this.$slots.default.filter(elem => elem.tag || elem.text.trim())
 
 			// Find all valid instances of AppSidebarTab

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -43,7 +43,7 @@
 						:href="`#tab-${tab.id}`"
 						:tabindex="activeTab === tab.id ? null : -1"
 						role="tab"
-						@click.prevent="setActive">
+						@click.prevent="setActive(tab.id)">
 						<span :class="tab.icon" class="app-sidebar-tabs__tab-icon" />
 						{{ tab.name }}
 					</a>
@@ -133,13 +133,11 @@ export default {
 
 		/**
 		 * Set the current active tab
+		 * @param {string} id the id of the tab
 		 */
-		setActive({ target }) {
-			// if click on icon, make sure we get the link
-			const id = target.closest('a').dataset.id
+		setActive(id) {
 			this.activeTab = id
 			this.$emit('update:active', this.activeTab)
-
 		},
 
 		/**

--- a/tests/unit/components/AppSidebar/AppSidebarTabs.spec.js
+++ b/tests/unit/components/AppSidebar/AppSidebarTabs.spec.js
@@ -105,11 +105,6 @@ describe('AppSidebarTabs.vue', () => {
 					],
 				},
 				stubs: {
-					/*
-					 * Register the component with PascalCase and kebab-case
-					 * to make sure both works.
-					 */
-					'app-sidebar-tab': AppSidebarTab,
 					AppSidebarTab,
 				},
 			})

--- a/tests/unit/components/AppSidebar/AppSidebarTabs.spec.js
+++ b/tests/unit/components/AppSidebar/AppSidebarTabs.spec.js
@@ -92,18 +92,19 @@ describe('AppSidebarTabs.vue', () => {
 			expect(wrapper.find('nav').exists()).toBe(false)
 		})
 	})
-	describe('when only children of type AppSidebarTab are used', () => {
-		describe('when they are more than 1 child of type AppSidebarTab are used', () => {
+	describe('when only children of type AppSidebarTab is used', () => {
+		describe('when 3 children of type AppSidebarTab are used', () => {
 			beforeEach(() => {
 				wrapper = mount(AppSidebarTabs, {
 					slots: {
 						default: [
-							'<app-sidebar-tab id="1" icon="icon-details" name="Tab1">Tab1</app-sidebar-tab>',
-							'<app-sidebar-tab id="2" icon="icon-details" name="Tab2">Tab2</app-sidebar-tab>',
+							'<app-sidebar-tab id="first" icon="icon-details" name="Tab1">Tab1</app-sidebar-tab>',
+							'<app-sidebar-tab id="second" icon="icon-details" name="Tab2">Tab2</app-sidebar-tab>',
+							'<app-sidebar-tab id="last" icon="icon-details" name="Tab2">Tab2</app-sidebar-tab>',
 						],
 					},
 					stubs: {
-						// used to register custom components
+					// used to register custom components
 						AppSidebarTab,
 					},
 				})
@@ -114,15 +115,56 @@ describe('AppSidebarTabs.vue', () => {
 			it('display the nav element', () => {
 				expect(wrapper.find('nav').exists()).toBe(true)
 			})
-			it('display all the elements in li', () => {
+			it('display all the 3 elements in li', () => {
 				const liList = wrapper.findAll('nav>ul>li')
-				expect(liList.length).toEqual(2)
+				expect(liList.length).toEqual(3)
 			})
-			it('emit "update:active" event with the tab id when clicking on a tab', () => {
-				const firstLink = wrapper.find('nav>ul>li>a')
-				const id = firstLink.attributes('id')
-				firstLink.trigger('click')
-				expect(wrapper.emitted('update:active')[0]).toEqual([id])
+			it('emit "update:active" event with the selected tab id when clicking on a tab', () => {
+				const lastLink = wrapper.find('nav>ul>li:last-of-type>a')
+				lastLink.trigger('click')
+				expect(wrapper.emitted('update:active')[0]).toEqual(['last'])
+			})
+			it('emit "update:active" event with the first tab id when keydown pageup is pressed', () => {
+				const lastLink = wrapper.find('nav>ul>li:last-of-type>a')
+				lastLink.trigger('keydown.pageup')
+				expect(wrapper.emitted('update:active')[0]).toEqual(['first'])
+			})
+			it('emit "update:active" event with the last tab id when keydown pagedown is pressed', () => {
+				const lastLink = wrapper.find('nav>ul>li:last-of-type>a')
+				lastLink.trigger('keydown.pagedown')
+				expect(wrapper.emitted('update:active')[0]).toEqual(['last'])
+			})
+			describe('when we select the first element', () => {
+				beforeEach(() => {
+					wrapper.setData({ activeTab: 'first' })
+				})
+				it('does not emit "update:active" event when keydown left is pressed', () => {
+					expect(wrapper.emitted('update:active')).toBeFalsy()
+					const firstLink = wrapper.find('nav>ul>li>a')
+					firstLink.trigger('keydown.left')
+					expect(wrapper.emitted('update:active')).toBeFalsy()
+				})
+				it('emit "update:active" event with the next tab id when keydown right is pressed', () => {
+					const firstLink = wrapper.find('nav>ul>li>a')
+					firstLink.trigger('keydown.right')
+					expect(wrapper.emitted('update:active')[0]).toEqual(['second'])
+				})
+			})
+			describe('when we select the last element', () => {
+				beforeEach(() => {
+					wrapper.setData({ activeTab: 'last' })
+				})
+				it('emit "update:active" event with the previous tab id when keydown left is pressed', () => {
+					const lastLink = wrapper.find('nav>ul>li:last-of-type>a')
+					lastLink.trigger('keydown.left')
+					expect(wrapper.emitted('update:active')[0]).toEqual(['second'])
+				})
+				it('does not emit "update:active" event when keydown right is pressed', () => {
+					expect(wrapper.emitted('update:active')).toBeFalsy()
+					const lastLink = wrapper.find('nav>ul>li:last-of-type>a')
+					lastLink.trigger('keydown.right')
+					expect(wrapper.emitted('update:active')).toBeFalsy()
+				})
 			})
 		})
 		describe('when they is only 1 child of type AppSidebarTab are used', () => {

--- a/tests/unit/components/AppSidebar/AppSidebarTabs.spec.js
+++ b/tests/unit/components/AppSidebar/AppSidebarTabs.spec.js
@@ -31,6 +31,8 @@ import ActionButton from '../../../../src/components/ActionButton/ActionButton.v
 let onWarning
 let consoleDebug
 
+let wrapper
+
 const initialConsole = { ...console }
 
 describe('AppSidebarTabs.vue', () => {
@@ -46,51 +48,103 @@ describe('AppSidebarTabs.vue', () => {
 		global.console = initialConsole
 	})
 	describe('when using the component without tabs', () => {
-		it('Issues no warning nor logs nothing to console.', () => {
-			mount(AppSidebarTabs, {
-				propsData: {
-					title: 'Sidebar title.',
-				},
-				slots: {
-					default: ['<div />'],
-				},
+		describe('with only one div', () => {
+			beforeEach(() => {
+				wrapper = mount(AppSidebarTabs, {
+					propsData: {
+						title: 'Sidebar title.',
+					},
+					slots: {
+						default: ['<div />'],
+					},
+				})
 			})
-			expect(onWarning).toHaveBeenCalledTimes(0)
-			expect(consoleDebug).toHaveBeenCalledTimes(0)
+			it('Issues no warning nor logs to console.', () => {
+				expect(onWarning).toHaveBeenCalledTimes(0)
+				expect(consoleDebug).toHaveBeenCalledTimes(0)
+			})
+			it('does not display the nav element', () => {
+				expect(wrapper.find('nav').exists()).toBe(false)
+			})
+		})
+		describe('with div and secondary action', () => {
+			beforeEach(() => {
+				wrapper = mount(AppSidebarTabs, {
+					propsData: {
+						title: 'Sidebar title.',
+					},
+					slots: {
+						default: '<div />',
+						'secondary-actions': ['<ActionButton icon="icon-delete">Test</ActionButton>'],
+					},
+					stubs: {
+						// used to register custom components
+						ActionButton,
+					},
+				})
+			})
+			it('Issues no warning.', () => {
+				expect(onWarning).toHaveBeenCalledTimes(0)
+			})
 		})
 
-		it('Issues no warning when using secondary actions.', () => {
-			mount(AppSidebarTabs, {
-				propsData: {
-					title: 'Sidebar title.',
-				},
-				slots: {
-					default: '<div />',
-					'secondary-actions': ['<ActionButton icon="icon-delete">Test</ActionButton>'],
-				},
-				stubs: {
-					// used to register custom components
-					ActionButton,
-				},
-			})
-			expect(onWarning).toHaveBeenCalledTimes(0)
+		it('does not display the nav element', () => {
+			expect(wrapper.find('nav').exists()).toBe(false)
 		})
 	})
 	describe('when only children of type AppSidebarTab are used', () => {
-		it('Issues no warning.', () => {
-			mount(AppSidebarTabs, {
-				slots: {
-					default: [
-						'<app-sidebar-tab id="1" icon="icon-details" name="Tab1">Tab1</app-sidebar-tab>',
-						'<app-sidebar-tab id="2" icon="icon-details" name="Tab2">Tab2</app-sidebar-tab>',
-					],
-				},
-				stubs: {
-					// used to register custom components
-					'app-sidebar-tab': AppSidebarTab,
-				},
+		describe('when they are more than 1 child of type AppSidebarTab are used', () => {
+			beforeEach(() => {
+				wrapper = mount(AppSidebarTabs, {
+					slots: {
+						default: [
+							'<app-sidebar-tab id="1" icon="icon-details" name="Tab1">Tab1</app-sidebar-tab>',
+							'<app-sidebar-tab id="2" icon="icon-details" name="Tab2">Tab2</app-sidebar-tab>',
+						],
+					},
+					stubs: {
+						// used to register custom components
+						AppSidebarTab,
+					},
+				})
 			})
-			expect(onWarning).toHaveBeenCalledTimes(0)
+			it('Issues no warning.', () => {
+				expect(onWarning).toHaveBeenCalledTimes(0)
+			})
+			it('display the nav element', () => {
+				expect(wrapper.find('nav').exists()).toBe(true)
+			})
+			it('display all the elements in li', () => {
+				const liList = wrapper.findAll('nav>ul>li')
+				expect(liList.length).toEqual(2)
+			})
+			it('emit "update:active" event with the tab id when clicking on a tab', () => {
+				const firstLink = wrapper.find('nav>ul>li>a')
+				const id = firstLink.attributes('id')
+				firstLink.trigger('click')
+				expect(wrapper.emitted('update:active')[0]).toEqual([id])
+			})
+		})
+		describe('when they is only 1 child of type AppSidebarTab are used', () => {
+			beforeEach(() => {
+				wrapper = mount(AppSidebarTabs, {
+					slots: {
+						default: [
+							'<app-sidebar-tab id="1" icon="icon-details" name="Tab1">Tab1</app-sidebar-tab>',
+						],
+					},
+					stubs: {
+						// used to register custom components
+						AppSidebarTab,
+					},
+				})
+			})
+			it('Issues no warning.', () => {
+				expect(onWarning).toHaveBeenCalledTimes(0)
+			})
+			it('does not display the nav element', () => {
+				expect(wrapper.find('nav').exists()).toBe(false)
+			})
 		})
 	})
 	describe('when tabs and other elements are mixed', () => {


### PR DESCRIPTION
Hi,

I added unit tests on already tested component to familiarize myself with the code.
I also fix some warning on the passing tests of the current code (stub of console does not work as expected)

During this phase I found a bug with the key listener.
According to the documentation, we can use the kebab-case standard even if it’s not a defined shortcut.
https://vuejs.org/v2/guide/events.html#Key-Modifiers
But it doesn’t seem to work on every system.
Other events seems to trigger the listeners ‘keydown.page-up’ and ‘page down’.
You can try it with the written tests.
According to Vue-test-utils the key to trigger it in tests are ‘pageup’ and ‘pagedown’.
https://vue-test-utils.vuejs.org/guides/dom-events.html

May it be an issue in Vuejs listener process on some engines?
For now I fixed it with the keyboard code.
After writing those tests, I make some minor change into the code to make it easier to reuse.

I would be happy to have feedback to know if pull requests like this one can be helpful or not or to view it merged :).
<img width="563" alt="Capture d’écran 2020-10-23 à 22 27 38" src="https://user-images.githubusercontent.com/39310468/97063988-45cf5400-15a3-11eb-8c32-8a7feb550347.png">
<img width="638" alt="Capture d’écran 2020-10-23 à 22 27 46" src="https://user-images.githubusercontent.com/39310468/97063991-4831ae00-15a3-11eb-9a06-e6cc27a25671.png">
