### PR TITLE
Adapt to new vue2-datepicker format props

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"vue-color": "^2.7.1",
 		"vue-multiselect": "^2.1.6",
 		"vue-visible": "^1.0.2",
-		"vue2-datepicker": "^3.6.2"
+		"vue2-datepicker": "^3.6.3"
 	},
 	"engines": {
 		"node": ">=10.0.0"

--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -78,6 +78,7 @@ export default {
 		:clearable="clearable"
 		:minute-step="minuteStep"
 		:format="format"
+		:formatter="formatter"
 		:type="type"
 		:value="value"
 		:append-to-body="false"
@@ -125,7 +126,7 @@ export default {
 		},
 
 		format: {
-			type: [String, Object],
+			type: String,
 			default() {
 				const map = {
 					date: 'YYYY-MM-DD',
@@ -136,6 +137,13 @@ export default {
 					week: 'w',
 				}
 				return map[this.type] || map.date
+			},
+		},
+
+		formatter: {
+			type: Object,
+			default() {
+				return null
 			},
 		},
 


### PR DESCRIPTION
We are getting vue2-datepicker 3.7.0 and since 3.6.3, the `format` prop not a string/object anymore. It's now just a string and there is a new `formatter` object prop.

As there is no default for this prop in vue2-datepicker, I wonder if it's better to have `{}` or `null` as default in `@nc/vue`