### PR TITLE
Also set Modal height/width to allow children to define their height/width and not only max-height/width

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -685,13 +685,19 @@ $header-size: 50px;
 	&:not(&--large):not(&--full) .modal-container {
 		max-width: 900px;
 		max-height: 80%;
+		width: 900px;
+		height: 80%;
 	}
 
 	// Sizing
+	// Always set max and height/width simultaneously here
+	// to allow children to contain themselves properly
 	&--full {
 		.modal-container {
 			max-width: 100%;
 			max-height: 100%;
+			width: 100%;
+			height: 100%;
 			border-radius: 0;
 		}
 	}
@@ -713,6 +719,8 @@ $header-size: 50px;
 		.modal-container {
 			max-width: 85%;
 			max-height: 90%;
+			width: 85%;
+			height: 90%;
 		}
 		.prev,
 		.next {


### PR DESCRIPTION
For viewer, to automatically contain the image, we need a specific css pattern that rely on a combination of max and height/width.
If only one is defined the chaining is broken.

| Before | After |
|:---------:|:------:|
|![dev skjnldsv com_apps_contacts_All%20contacts_adb58ef0-8850-4f41-8afa-6b6144ca894b_contacts (1)](https://user-images.githubusercontent.com/14975046/97162606-b763f980-177f-11eb-8a34-f1fda00d8e27.png)|![dev skjnldsv com_apps_contacts_All%20contacts_adb58ef0-8850-4f41-8afa-6b6144ca894b_contacts](https://user-images.githubusercontent.com/14975046/97162599-b632cc80-177f-11eb-981f-a3fe55cd0473.png)|