### PR TITLE
Fix action text margin for long texts

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -91,7 +91,6 @@
 		p {
 			width: 150px;
 			padding: #{$icon-margin / 2} 0;
-			margin: auto;
 
 			cursor: pointer;
 			text-align: left;


### PR DESCRIPTION
Long ActionTexts have a weird margin.

This effectively reverts #688. However, the bug mentioned there is not present after applying this PR. I guess there were other improvements that fixed the button issue.

Before:
![action-text-margin](https://user-images.githubusercontent.com/1479486/97605806-62d6ad80-1a0f-11eb-82f5-ece4e6abefe8.png)

After:
![action-text-margin-after](https://user-images.githubusercontent.com/1479486/97605814-65390780-1a0f-11eb-9c72-7d022afd44fe.png)
