### PR TITLE
Use static emoji picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11747,9 +11747,9 @@
 			"dev": true
 		},
 		"emoji-mart-vue-fast": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.6.tgz",
-			"integrity": "sha512-nvGoIRMhgVYHFBcHJMjjYKS71RopuBRGuO/51DqOcIFreRJAaTvAwmk9eUjI1mwXHY7b/cCarrGi3FBE7Kz37A==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.7.tgz",
+			"integrity": "sha512-Nrk4IOjKcKKYyMnRm4lreEiPpvDX+h3FKI86SYs05dCFZ0WZIMTGok26dtWvJqseTThS1UghsNEjM4HrfDjIJg==",
 			"requires": {
 				"@babel/polyfill": "7.2.5",
 				"@babel/runtime": "7.3.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@nextcloud/router": "^1.0.2",
 		"core-js": "^3.6.5",
 		"debounce": "1.2.0",
-		"emoji-mart-vue-fast": "^7.0.4",
+		"emoji-mart-vue-fast": "^7.0.7",
 		"escape-html": "^1.0.3",
 		"hammerjs": "^2.0.8",
 		"linkifyjs": "~2.1.9",

--- a/src/components/EmojiPicker/EmojiPicker.vue
+++ b/src/components/EmojiPicker/EmojiPicker.vue
@@ -94,7 +94,7 @@
 		<template #trigger>
 			<slot />
 		</template>
-		<Picker
+		<StaticPicker
 			:auto-focus="true"
 			color="var(--color-primary)"
 			:data="emojiIndex"
@@ -112,7 +112,7 @@
 </template>
 
 <script>
-import { Picker, EmojiIndex } from 'emoji-mart-vue-fast'
+import { StaticPicker, EmojiIndex } from 'emoji-mart-vue-fast'
 import data from 'emoji-mart-vue-fast/data/all.json'
 import Popover from '../Popover'
 import { t } from '../../l10n'
@@ -120,7 +120,7 @@ import { t } from '../../l10n'
 export default {
 	name: 'EmojiPicker',
 	components: {
-		Picker,
+		StaticPicker,
 		Popover,
 	},
 	props: {


### PR DESCRIPTION
Solves constant CPU usage and energy impact when used in Talk app.

Also updated to 7.0.7.

See https://github.com/nextcloud/spreed/issues/4501 for context about the performance issue and some research about it.

Note: not reproducible on the demo page with the emoji picker, so it might be due to some layout configuration.