### PR TITLE
Bump cypress github-action to v2

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm ci
 
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         with:
           record: true
           parallel: true


### PR DESCRIPTION
Fixes 
``` js
Error: The `set-env` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files.
For more information see: github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands
```