### PR TITLE
Add tooltips in app sidebar header

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -130,9 +130,10 @@
 				}"
 				class="app-sidebar-header">
 				<!-- close sidebar button -->
-				<a href="#"
+				<a
+					v-tooltip.auto="t('close')"
+					href="#"
 					class="app-sidebar__close icon-close"
-					:title="t('close')"
 					@click.prevent="closeSidebar" />
 
 				<!-- container for figure and description, allows easy switching to compact mode -->
@@ -178,6 +179,7 @@
 							<!-- main title -->
 							<h2 v-show="!titleEditable"
 								v-linkify="{text: title, linkify: linkifyTitle}"
+								v-tooltip.auto="titleTooltip"
 								class="app-sidebar-header__maintitle"
 								@click.self="editTitle">
 								{{ title }}
@@ -234,6 +236,7 @@
 import Actions from '../Actions'
 import Focus from '../../directives/Focus'
 import Linkify from '../../directives/Linkify'
+import Tooltip from '../../directives/Tooltip'
 import l10n from '../../mixins/l10n'
 import AppSidebarTabs from './AppSidebarTabs'
 import EmptyContent from '../EmptyContent/EmptyContent'
@@ -252,6 +255,7 @@ export default {
 		focus: Focus,
 		linkify: Linkify,
 		ClickOutside,
+		Tooltip,
 	},
 
 	mixins: [l10n],
@@ -347,6 +351,15 @@ export default {
 		linkifyTitle: {
 			type: Boolean,
 			default: false,
+		},
+
+		/**
+		 * Tooltip to display for the title.
+		 * Can be set to the same text in case it's too long.
+		 */
+		titleTooltip: {
+			type: String,
+			default: '',
 		},
 	},
 


### PR DESCRIPTION
Added nicer looking tooltip for the close button.
Added optional tooltip for the app sidebar header.

Tested with Talk where I locally set the titleTolltip property to the same value as the title:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/277525/98368377-8913d300-2037-11eb-98b6-db1d848f6b7e.png">

And the close button:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/277525/98368513-c24c4300-2037-11eb-8076-66ac7db0dfea.png">

I didn't want to make it default to the title as it might not always look good depending on use case.
In the case of the Talk app, the title is a user defined room name.
For other apps it might be static text that doesn't ellipsize nor needs a tooltip.
