### PR TITLE
Revert "Also set Modal height/width to allow children to define their height/width and not only max-height/width"

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -685,19 +685,13 @@ $header-size: 50px;
 	&:not(&--large):not(&--full) .modal-container {
 		max-width: 900px;
 		max-height: 80%;
-		width: 900px;
-		height: 80%;
 	}
 
 	// Sizing
-	// Always set max and height/width simultaneously here
-	// to allow children to contain themselves properly
 	&--full {
 		.modal-container {
 			max-width: 100%;
 			max-height: 100%;
-			width: 100%;
-			height: 100%;
 			border-radius: 0;
 		}
 	}
@@ -719,8 +713,6 @@ $header-size: 50px;
 		.modal-container {
 			max-width: 85%;
 			max-height: 90%;
-			width: 85%;
-			height: 90%;
 		}
 		.prev,
 		.next {


### PR DESCRIPTION
Reverts nextcloud/nextcloud-vue#1518

As @ma12-co mentionned, this was a wrong approach, as the modal should wrap the flow instead.
It make more sense to keep capping the height/width instead.
Sorry about the noise! :(