### PR TITLE
Fix rich-contenteditor default value init and small code cleanup

### DIFF
--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -268,9 +268,7 @@ export default {
 			const html = this.$refs.contenteditable.innerHTML
 			// Compare trimmed versions to be safe
 			if (this.value.trim() !== this.parseContent(html).trim()) {
-				const renderedContent = this.renderContent(this.value)
-				this.$refs.contenteditable.innerHTML = renderedContent
-				this.localValue = this.value
+				this.updateContent(this.value)
 			}
 		},
 	},
@@ -280,8 +278,7 @@ export default {
 		this.tribute.attach(this.$el)
 
 		// Update default value
-		const renderedContent = this.renderContent(this.value)
-		this.$refs.contenteditable.innerHTML = renderedContent
+		this.updateContent(this.value)
 
 	},
 	beforeDestroy() {
@@ -352,6 +349,16 @@ export default {
 			this.localValue = text
 			this.$emit('input', text)
 			this.$emit('update:value', text)
+		},
+
+		/**
+		 * Update content and local value
+		 * @param {string} value the message value
+		 */
+		updateContent(value) {
+			const renderedContent = this.renderContent(this.value)
+			this.$refs.contenteditable.innerHTML = renderedContent
+			this.localValue = this.value
 		},
 
 		/**


### PR DESCRIPTION
Make sure the default localValue is initialised and refactor duplicate method

Avoid stuff like those as localVaue is used to detect if the editor is empty (stupid ff bug)

![Capture d’écran_2020-11-13_09-49-58](https://user-images.githubusercontent.com/14975046/99048256-9da31e80-2595-11eb-97c2-4042cfd3bf46.png)
