### PR TITLE
Fix action button text for long translations

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -90,7 +90,7 @@
 
 		// long text area
 		p {
-			width: 150px;
+			width: 185px;
 			padding: #{$icon-margin / 2} 0;
 
 			cursor: pointer;
@@ -107,6 +107,11 @@
 
 		&__title {
 			font-weight: bold;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			white-space: nowrap;
+			max-width: 100%;
+			display: inline-block;
 		}
 	}
 }


### PR DESCRIPTION
the problem
![before_longtezt](https://user-images.githubusercontent.com/12728974/99420674-c90f6b80-28fd-11eb-88bf-bb41da517755.png)
