### PR TITLE
Fix labelledby in tab section

### DIFF
--- a/src/components/AppSidebarTab/AppSidebarTab.vue
+++ b/src/components/AppSidebarTab/AppSidebarTab.vue
@@ -28,7 +28,7 @@
 		:id="`tab-${id}`"
 		:class="{'app-sidebar__tab--active': isActive}"
 		:aria-hidden="!isActive"
-		:aria-labelledby="name"
+		:aria-labelledby="id"
 		class="app-sidebar__tab"
 		tabindex="0"
 		role="tabpanel"


### PR DESCRIPTION
The aria-labelledby must contain the id of an element that contains the
label and not a direct text. This fixes it by pointing back to the
matching tab heading element.

As an additional bonus, this will semantically link this "tabpanel" to
the matching "tab".

Tested with Talk and a screen reader: the screen reader now says "Participants region" or "Settings region" when clicking inside the tab.