### PR TITLE
Fix contenteditable state ad first load

### DIFF
--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -280,6 +280,9 @@ export default {
 		// Update default value
 		this.updateContent(this.value)
 
+		// Removes the contenteditable attribute at first load if the prop is
+		// set to false.
+		this.$refs.contenteditable.contentEditable = this.contenteditable
 	},
 	beforeDestroy() {
 		if (this.tribute) {


### PR DESCRIPTION
Fixes a bug in which the `<div contentaditable>` would be `contenteditable = true` even if the `contenteditable` prop was set to false.

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>