### PR TITLE
Set navigation role and aria label on app navigation

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -57,6 +57,7 @@ emit('toggle-navigation', {
 	<div
 		id="app-navigation-vue"
 		class="app-navigation"
+		role="navigation"
 		:class="{'app-navigation--close':!open }">
 		<AppNavigationToggle :open="open" @update:open="toggleNavigation" />
 		<slot />


### PR DESCRIPTION
Makes it possible for screen readers to say the text of aria label
followed by the term "navigation" when entering that region.

Also added an optional arial label for the toggle.

In the talk app I've set the aria label to "Conversation list" so when entering the left sidebar (or jumping to any element inside) the screen reader says "Conversation list navigation".
