### PR TITLE
Remote semantics of h6 in user bubble

### DIFF
--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -94,9 +94,9 @@ This component has the following slot:
 				class="user-bubble__avatar" />
 
 			<!-- Title -->
-			<h6 class="user-bubble__title">
+			<span class="user-bubble__title">
 				{{ displayName || user }}
-			</h6>
+			</span>
 
 			<!-- @slot Optional slot just after the title -->
 			<span v-if="$slots.title" class="user-bubble__secondary">


### PR DESCRIPTION
This will prevent screen readers to say "Heading level 6" + the
contents instead of just reading the contents.

Tested with Orca and Firefox.