### PR TITLE
Richcontenteditable: bind event listeners

### DIFF
--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -121,6 +121,7 @@ export default {
 		class="rich-contenteditable__input"
 		role="textbox"
 		@input="onInput"
+		v-on="$listeners"
 		@keydown.delete="onDelete"
 		@keydown.enter.exact="onEnter"
 		@keydown.ctrl.enter.exact.stop.prevent="onCtrlEnter"


### PR DESCRIPTION
Useful to dismiss an edit from the parent.  

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>