### PR TITLE
Aria-expanded must be a false string, not absent

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -134,7 +134,8 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 				:aria-label="ariaLabel"
 				aria-haspopup="true"
 				:aria-controls="randomId"
-				:aria-expanded="opened">
+				test-attr="1"
+				:aria-expanded="opened ? 'true' : 'false'">
 				{{ menuTitle }}
 			</button>
 

--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -24,7 +24,7 @@
 <template>
 	<a class="app-navigation-toggle"
 		href="#"
-		:aria-expanded="open"
+		:aria-expanded="open ? 'true' : 'false'"
 		aria-controls="app-navigation-vue"
 		@click.prevent="toggleNavigation"
 		@keydown.space.exact.prevent="toggleNavigation" />


### PR DESCRIPTION
When setting the boolean to false, the DOM attribute "aria-expanded"
disappears.

For screen readers to be able to say "Actions push button collapsed" instead of just "Actions push button" the
attribute must be present and set to the string "false" instead of
absent.

Discovered this by comparing screen reader behavior with the example from https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20161214/examples/menu-button/menu-button-1/menu-button-1.html
