### PR TITLE
Add changelog file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ yarn-error.log*
 
 .marginalia
 
-CHANGELOG.md
-
 # Unit test / coverage reports
 coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,247 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [v3.2.0](https://github.com/nextcloud/nextcloud-vue/tree/v3.2.0) (2020-11-09)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v3.1.2...v3.2.0)
+
+### Added
+- Add default font and line size [\#1542](https://github.com/nextcloud/nextcloud-vue/pull/1542) ([GretaD](gretadoci@gmail.com))
+- Add tooltips in app sidebar header [\#1555](https://github.com/nextcloud/nextcloud-vue/pull/1555) ([PVince81](https://github.com/PVince81))
+
+### Fixed
+- Fix RichEditor rendering of unknown mention, undefined checks and fix default value init [\#1504](https://github.com/nextcloud/nextcloud-vue/pull/1504)  ([skjnldsv](https://github.com/skjnldsv))
+- Fix menu font for apps [\#1543](https://github.com/nextcloud/nextcloud-vue/pull/1543) ([GretaD](gretadoci@gmail.com))
+- Reverted "Also set Modal height/width to allow children to define their height/width and not only max-height/width" [\#1558](https://github.com/nextcloud/nextcloud-vue/pull/1558) ([skjnldsv](https://github.com/skjnldsv))
+- Fix action text margin for long texts [\#1525](https://github.com/nextcloud/nextcloud-vue/pull/1525) ([st3iny](https://github.com/st3iny))
+
+### Version bumps
+- Bump cypress config and split into two specs [\#1548](https://github.com/nextcloud/nextcloud-vue/pull/1548) ([skjnldsv](https://github.com/skjnldsv))
+- Bump core-js from 3.6.5 to 3.7.0 [\#1557](https://github.com/nextcloud/nextcloud-vue/pull/1557)
+- Bump vue-styleguidist from 4.33.5 to 4.33.6 [\#1553](https://github.com/nextcloud/nextcloud-vue/pull/1553)
+- Bump css-loader from 3.6.0 to 5.0.1 [\#1537](https://github.com/nextcloud/nextcloud-vue/pull/1537) [\#1552](https://github.com/nextcloud/nextcloud-vue/pull/1552)
+- Bump webpack-cli from 4.1.0 to 4.2.0 [\#1546](https://github.com/nextcloud/nextcloud-vue/pull/1546)
+- Bump jest from 26.6.1 to 26.6.3 [\#1541](https://github.com/nextcloud/nextcloud-vue/pull/1541) [\#1545](https://github.com/nextcloud/nextcloud-vue/pull/1545)
+- Bump babel-jest from 26.6.2 to 26.6.3 [\#1544](https://github.com/nextcloud/nextcloud-vue/pull/1544)
+- Bump vue-loader from 15.9.4 to 15.9.5 [\#1536](https://github.com/nextcloud/nextcloud-vue/pull/1536)
+- Bump node-sass from 4.14.1 to 5.0.0 and sass-loader to 10.0.5 [\#1534](https://github.com/nextcloud/nextcloud-vue/pull/1534)
+- Translations updates
+
+## [v2.9.0](https://github.com/nextcloud/nextcloud-vue/tree/v2.9.0) (2020-11-09)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.8.2...v2.9.0)
+
+### Added
+- Add default font and line size [\#1549](https://github.com/nextcloud/nextcloud-vue/pull/1549) ([GretaD](gretadoci@gmail.com))
+- Add tooltips in app sidebar header [\#1560](https://github.com/nextcloud/nextcloud-vue/pull/1560) ([PVince81](https://github.com/PVince81))
+
+## [v0.13.1](https://github.com/nextcloud/nextcloud-vue/tree/v0.13.1) (2020-11-06)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v0.13.0...v0.13.1)
+
+### Fixed
+
+- Add ability to choose popovermenu alignment in avatar component #1554
+
+## [v3.1.2](https://github.com/nextcloud/nextcloud-vue/tree/v3.1.2) (2020-11-02)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v3.1.1...v3.1.2)
+
+### Fixed
+- Use static emoji picker to solve performance issue with background CPU usage [\#1526](https://github.com/nextcloud/nextcloud-vue/pull/1526) ([PVince81](https://github.com/PVince81))
+- Fix setting navigation item blur [\#1503](https://github.com/nextcloud/nextcloud-vue/pull/1503) ([ma12-co](https://github.com/ma12-co))
+- Translations update [\#1519](https://github.com/nextcloud/nextcloud-vue/pull/1519)
+
+### Version bumps
+- Bump @vue/test-utils from 1.1.0 to 1.1.1 [\#1530](https://github.com/nextcloud/nextcloud-vue/pull/1530)
+- Bump webpack-merge from 5.2.0 to 5.3.0 [\#1528](https://github.com/nextcloud/nextcloud-vue/pull/1528)
+- Bump emoji-mart-vue-fast from 7.0.6 to 7.0.7 [\#1527](https://github.com/nextcloud/nextcloud-vue/pull/1527)
+- Bump cypress from 5.4.0 to 5.5.0 [\#1523](https://github.com/nextcloud/nextcloud-vue/pull/1523)
+- Bump @nextcloud/axios from 1.4.0 to 1.5.0 [\#1522](https://github.com/nextcloud/nextcloud-vue/pull/1522)
+- Bump file-loader from 6.1.1 to 6.2.0 [\#1521](https://github.com/nextcloud/nextcloud-vue/pull/1521)
+- Bump vue-loader from 15.9.3 to 15.9.4 [\#1520](https://github.com/nextcloud/nextcloud-vue/pull/1520)
+
+## [v2.8.2](https://github.com/nextcloud/nextcloud-vue/tree/v2.8.2) (2020-11-02)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.8.1...v2.8.2)
+
+### Fixed
+- Use static emoji picker to solve performance issue with background CPU usage [\#1526](https://github.com/nextcloud/nextcloud-vue/pull/1526) ([PVince81](https://github.com/PVince81))
+
+## [v3.1.1](https://github.com/nextcloud/nextcloud-vue/tree/v3.1.1) (2020-10-27)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v3.1.0...v3.1.1)
+
+### Fixed
+
+- Also set Modal height/width to allow children to define their height/width and not only max-height/width [\#1518](https://github.com/nextcloud/nextcloud-vue/pull/1518) ([skjnldsv](https://github.com/skjnldsv))
+- Don't show navigation of settings modal by default [\#1509](https://github.com/nextcloud/nextcloud-vue/pull/1509) ([ma12-co](https://github.com/ma12-co))
+- Adapt to new vue2-datepicker format props [\#1517](https://github.com/nextcloud/nextcloud-vue/pull/1517) ([eneiluj](https://github.com/eneiluj))
+
+## [v3.1.0](https://github.com/nextcloud/nextcloud-vue/tree/v3.1.0) (2020-10-21)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v3.0.0...v3.1.0)
+
+### Fixed
+
+- Do not show letter if we have an icon and keep image ratio [\#1501](https://github.com/nextcloud/nextcloud-vue/pull/1501) ([skjnldsv](https://github.com/skjnldsv))
+- Allow an "extra" slot for the AppNavigationItem [\##1493](https://github.com/nextcloud/nextcloud-vue/pull/1493) ([ChristophWurst](https://github.com/ChristophWurst))
+- Fix avatar caching for non-user rendering [\#1491](https://github.com/nextcloud/nextcloud-vue/pull/1491) ([skjnldsv](https://github.com/skjnldsv))
+
+## [v3.0.0](https://github.com/nextcloud/nextcloud-vue/tree/v3.0.0) (2020-10-20)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.8.1...v3.0.0)
+
+### Fixed
+- Make appSidebar scrollable inside [\#1485](https://github.com/nextcloud/nextcloud-vue/pull/1485) ([skjnldsv](https://github.com/skjnldsv))
+
+## [v2.8.1](https://github.com/nextcloud/nextcloud-vue/tree/v2.8.1) (2020-10-19)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.8.0...v2.8.1)
+
+### Fixed
+- Fix avatar caching for non-user rendering [\#1491](https://github.com/nextcloud/nextcloud-vue/pull/1491) ([skjnldsv](https://github.com/skjnldsv))
+
+## [v2.8.0](https://github.com/nextcloud/nextcloud-vue/tree/v2.8.0) (2020-10-19)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.7.0...v2.8.0)
+
+### Added
+- Add submit, multiline and maxlength support [\#1465](https://github.com/nextcloud/nextcloud-vue/pull/1465) ([skjnldsv](https://github.com/skjnldsv))
+- Cache hasAvatar info in sessionStorage to avoid flicker [\#1457](https://github.com/nextcloud/nextcloud-vue/pull/1457) ([PVince81](https://github.com/PVince81))
+- Adds information to README.md file how to use vue-devtools [\#1446](https://github.com/nextcloud/nextcloud-vue/pull/1446) ([StCyr](https://github.com/StCyr))
+- Add RichContenteditable component [\#1433](https://github.com/nextcloud/nextcloud-vue/pull/1433) ([skjnldsv](https://github.com/skjnldsv))
+- Snapshot test for usernameToColor function [\#1346](https://github.com/nextcloud/nextcloud-vue/pull/1346) ([juliushaertl](https://github.com/juliushaertl))
+- Add SettingsInputText compontents [\#650](https://github.com/nextcloud/nextcloud-vue/pull/650) ([GretaD](https://github.com/GretaD))
+
+### Changed
+- Translations updates
+
+### Fixed
+- Fix multiLine prop [\#1490](https://github.com/nextcloud/nextcloud-vue/pull/1490) ([skjnldsv](https://github.com/skjnldsv))
+- Fix autocomplete popup size and shadow [\#1481](https://github.com/nextcloud/nextcloud-vue/pull/1481) ([skjnldsv](https://github.com/skjnldsv))
+- Make mention inlined and ellipsised [\#1475](https://github.com/nextcloud/nextcloud-vue/pull/1475) ([skjnldsv](https://github.com/skjnldsv))
+- Fix npm run build by removing obsolete command [\#1456](https://github.com/nextcloud/nextcloud-vue/pull/1456) ([PVince81](https://github.com/PVince81))
+- Cleanup avatar fetching methods [\#1489](https://github.com/nextcloud/nextcloud-vue/pull/1489) ([skjnldsv](https://github.com/skjnldsv))
+- Fix padding of sidebar without secondary actions [\#1362](https://github.com/nextcloud/nextcloud-vue/pull/1362) ([raimund-schluessler](https://github.com/raimund-schluessler))
+
+## [v2.7.0](https://github.com/nextcloud/nextcloud-vue/tree/v2.7.0) (2020-10-08)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.9...v2.7.0)
+
+### Added
+- New app settings [\#1286](https://github.com/nextcloud/nextcloud-vue/pull/1286) ([ma12-co](https://github.com/ma21-co))
+
+## [v2.6.9](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.9) (2020-10-07)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.8...v2.6.9)
+
+### Added
+
+- Add loading state on AppSidebar and remove unwanted slot bind [\#1429](https://github.com/nextcloud/nextcloud-vue/pull/1429) ([skjnldsv](https://github.com/skjnldsv))
+
+### Fixed
+
+- Fix modal freeze [\#1432](https://github.com/nextcloud/nextcloud-vue/pull/1432) ([st3iny](https://github.com/st3iny))
+- Allow spaces in the name of a AppSidebarTab [\#1431](https://github.com/nextcloud/nextcloud-vue/pull/1431) ([juliushaertl](https://github.com/juliushaertl))
+
+## [v2.6.8](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.8) (2020-10-02)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.7...v2.6.8)
+
+### Fixed
+
+- Only use the icon on the avatar when there is one [\#1423](https://github.com/nextcloud/nextcloud-vue/pull/1423) ([nickvergessen](https://github.com/nickvergessen))
+
+## [v2.6.7](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.7) (2020-10-02)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.6...v2.6.7)
+
+### Fixed
+
+- Introduce a compact mode (default) for the user status on the avatar in case it is used without presenting the status information [\#1405](https://github.com/nextcloud/nextcloud-vue/pull/1405) ([juliushaertl](https://github.com/juliushaertl))
+
+
+## [v2.6.6](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.6) (2020-09-30)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.5...v2.6.6)
+
+### Fixed
+
+- Listen to user status events to update the status on avatars [\#1405](https://github.com/nextcloud/nextcloud-vue/pull/1405) ([nickvergessen](https://github.com/nickvergessen))
+
+## [v2.6.5](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.5) (2020-09-11)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.4...v2.6.5)
+
+### Fixed
+
+- Allow to set popover container  [\#1389](https://github.com/nextcloud/nextcloud-vue/pull/1389) (Thanks to [raimund-schluessler](https://github.com/raimund-schluessler))
+- Fix ActionInput label height [\#1361](https://github.com/nextcloud/nextcloud-vue/pull/1361) (Thanks to [tcitworld](https://github.com/tcitworld))
+- Fix status on different active/hover states [\#1399](https://github.com/nextcloud/nextcloud-vue/pull/1399)
+- Fix custom avatar handling in user bubble [\#1392](https://github.com/nextcloud/nextcloud-vue/pull/1392)
+
+## [v2.6.4](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.4) (2020-09-03)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.3...v2.6.4)
+
+### Fixed
+
+- Do not fetch user status if current user is a guest [\#1379](https://github.com/nextcloud/nextcloud-vue/pull/1379) ([danxuliu](https://github.com/danxuliu))
+- Fetch user status in avatar only if it is going to be shown [\#1380](https://github.com/nextcloud/nextcloud-vue/pull/1380) ([danxuliu](https://github.com/danxuliu))
+
+## [v2.6.3](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.3) (2020-09-01)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.2...v2.6.3)
+
+### Fixed
+
+- Fix active tab prop [\#1368](https://github.com/nextcloud/nextcloud-vue/pull/1368) ([skjnldsv](https://github.com/skjnldsv))
+
+## [v2.6.2](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.2) (2020-09-01)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.1...v2.6.2)
+
+### Fixed
+
+- Disable spell checking for cypress [\#1363](https://github.com/nextcloud/nextcloud-vue/pull/1363) ([raimund-schluessler](https://github.com/raimund-schluessler))
+
+### Added
+
+- Cover more cases in AppSidebare visual test [\#1357](https://github.com/nextcloud/nextcloud-vue/pull/1357) ([raimund-schluessler](https://github.com/raimund-schluessler))
+- Remove unwanted files leftovers [\#1356](https://github.com/nextcloud/nextcloud-vue/pull/1356) ([skjnldsv](https://github.com/skjnldsv))
+- Feature/cypress visual regression [\#1355](https://github.com/nextcloud/nextcloud-vue/pull/1355) ([skjnldsv](https://github.com/skjnldsv))
+- Translate '/l10n/messages.pot' in 'is' [\#1354](https://github.com/nextcloud/nextcloud-vue/pull/1354) ([transifex-integration[bot]](https://github.com/apps/transifex-integration))
+
+## [v2.6.1](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.1) (2020-08-27)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.6.0...v2.6.1)
+
+### Fixed bugs:
+
+- Allow to toggle linkification by prop [\#1337](https://github.com/nextcloud/nextcloud-vue/pull/1337) ([raimund-schluessler](https://github.com/raimund-schluessler))
+- Fix sidebar layout in compact mode [\#1338](https://github.com/nextcloud/nextcloud-vue/pull/1338) ([raimund-schluessler](https://github.com/raimund-schluessler))
+- Update status icons  [\#1341](https://github.com/nextcloud/nextcloud-vue/pull/1341)
+- Do not fetch user-status if user prop does not represent a user [\#1348](https://github.com/nextcloud/nextcloud-vue/pull/1348)
+- Allow to choose boundariesElement for actions popover [\#1351](https://github.com/nextcloud/nextcloud-vue/pull/1351)
+
+## [v2.6.0](https://github.com/nextcloud/nextcloud-vue/tree/v2.6.0) (2020-08-21)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v2.5.0...v2.6.0)
+
+### Implemented enhancements:
+
+- Allow to specify a custom action instead of the star [\#1310](https://github.com/nextcloud/nextcloud-vue/pull/1310) ([raimund-schluessler](https://github.com/raimund-schluessler))
+- Allow to toggle editable title by click [\#1288](https://github.com/nextcloud/nextcloud-vue/pull/1288) ([raimund-schluessler](https://github.com/raimund-schluessler))
+- Feature/641/use popover component for actions [\#832](https://github.com/nextcloud/nextcloud-vue/pull/832) ([ma12-co](https://github.com/ma12-co))
+
+### Fixed bugs:
+
+- Add `background-repeat:no-repeat` to icons [\#1330](https://github.com/nextcloud/nextcloud-vue/pull/1330) ([dk1a](https://github.com/dk1a))
+- Fix tabs & lint [\#1303](https://github.com/nextcloud/nextcloud-vue/pull/1303) ([skjnldsv](https://github.com/skjnldsv))
+- Do not display offline \(and invisible\) as a status [\#1312](https://github.com/nextcloud/nextcloud-vue/pull/1312) ([georgehrke](https://github.com/georgehrke))
+
+## Older releases
+
+See [the Github Releases page](https://github.com/nextcloud/nextcloud-vue/releases) for older changelog entries.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ index 3a9ab8f8c1..4bc2b4a4d0 100644
 ## Releasing a new version
 
 - Checkout latest master (pull);
-- Run `npm version patch` (`npm version minor` if minor). This will return a new version name;
+- Edit CHANGELOG.md and add new entries there for the new version, then create a commit;
+- Run `npm version patch` (`npm version minor` if minor). This will return a new version name, make sure it matches what was added in the CHANGELOG.md;
 - Push the tag and the master branch `git push origin master [printed-version-name]`;
 - Make the tag a release on github and add the changelog (https://github.com/nextcloud/nextcloud-vue/releases);
 - Click edit on a previous release and copy the body of the changelog;


### PR DESCRIPTION
Copied entries from Github Releases up to 2.6.0.

Because I heard that we're doing changelogs also in other repos like https://github.com/nextcloud/nextcloud-dialogs

For some reason CHANGELOG.md was in gitignore, maybe there were plans to automate this ?

Anyway, let me know if down to 2.6.0 is enough or whether it's useful to have even older entries.

I've adjusted the README to mention that whoever does a release needs to update the changelog as well.
