### PR TITLE
Quickfix for action button and material design icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29917,6 +29917,12 @@
 				"vue-style-loader": "^4.1.0"
 			}
 		},
+		"vue-material-design-icons": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-4.11.0.tgz",
+			"integrity": "sha512-3Tyeqi9jtONQ/x8WkJqiBs4t5Bd5O1t7RdM/GIPKVYoVdaRy0oy3nbRjnMGyONBlqC/NpPjzhWeoZWUMEI04nA==",
+			"dev": true
+		},
 		"vue-multiselect": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
 		"vue-eslint-parser": "^7.1.0",
 		"vue-jest": "^3.0.5",
 		"vue-loader": "^15.9.1",
+		"vue-material-design-icons": "^4.11.0",
 		"vue-styleguidist": "^4.33.9",
 		"vue-template-compiler": "^2.6.11",
 		"webpack": "^4.42.1",

--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -88,6 +88,16 @@
 			background-repeat: no-repeat;
 		}
 
+		.material-design-icon {
+			width: $clickable-area;
+			height: $clickable-area;
+			opacity: $opacity_full;
+
+			.material-design-icon__svg {
+				vertical-align: middle;
+			}
+		}
+
 		// long text area
 		p {
 			width: 185px;

--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -49,8 +49,7 @@ You can also use a custom icon, for example from the vue-material-design-icons l
 		<ActionButton>
 			<HandLeft
 				slot="icon"
-				:size="24"
-				fill-color="#000000"
+				:size="16"
 				decorative
 				title="" />
 			Raise left hand
@@ -58,8 +57,7 @@ You can also use a custom icon, for example from the vue-material-design-icons l
 		<ActionButton>
 			<HandRight
 				slot="icon"
-				:size="24"
-				fill-color="#000000"
+				:size="16"
 				decorative
 				title="" />
 			Raise right hand

--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -40,6 +40,44 @@ If you're using a long text you can specify a title
 		<ActionButton icon="icon-delete" title="Long button" @click="alert('Delete')">This button is associated with a very long text.\nAnd with new lines too.</ActionButton>
 	</Actions>
 ```
+
+You can also use a custom icon, for example from the vue-material-design-icons library:
+
+```vue
+<template>
+	<Actions>
+		<ActionButton>
+			<HandLeft
+				slot="icon"
+				:size="24"
+				fill-color="#000000"
+				decorative
+				title="" />
+			Raise left hand
+		</ActionButton>
+		<ActionButton>
+			<HandRight
+				slot="icon"
+				:size="24"
+				fill-color="#000000"
+				decorative
+				title="" />
+			Raise right hand
+		</ActionButton>
+	</Actions>
+</template>
+<script>
+import HandLeft from 'vue-material-design-icons/HandLeft'
+import HandRight from 'vue-material-design-icons/HandRight'
+
+export default {
+	components: {
+		HandLeft,
+		HandRight,
+	},
+}
+</script>
+```
 </docs>
 
 <template>


### PR DESCRIPTION
When using a material design icon in the icon slot, this fix will
properly align it vertically.

We need it because the ActionButton consumer cannot override the styles with `::v-deep` since the popover itself might be in the document body

When testing the docs you might need to scroll up or down to see the dropdown because of https://github.com/nextcloud/server/issues/23872 which also occurs in the docs...
