### PR TITLE
Feature/noid/avatar menu use actions component

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -52,13 +52,14 @@
 			:srcset="avatarSrcSetLoaded"
 			alt="">
 		<Popover
+			v-if="hasMenu"
 			placement="auto"
 			:open="contactsMenuOpenState">
 			<template>
-				<PopoverMenu :is-open="contactsMenuOpenState" :menu="menu" />
+				<PopoverMenu :menu="menu" />
 			</template>
 			<template slot="trigger">
-				<div v-if="hasMenu" class="icon-more" :style="{'width': size + 'px'}" />
+				<div class="icon-more" :style="{'width': size + 'px'}" />
 			</template>
 		</Popover>
 
@@ -600,11 +601,11 @@ export default {
 			display: flex;
 			cursor: pointer;
 			opacity: 0;
-			cursor: pointer;
 			background: none;
 			font-size: 18px;
 			align-items: center;
 			justify-content: center;
+
 			@include iconfont('more');
 			&::before {
 				display: block;

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -87,7 +87,7 @@
 			:open="contactsMenuOpenState">
 			<template>
 				<ul>
-					<PopoverMenuItem v-for="(item, key) in contactsMenuActions" :key="key" :item="item" />
+					<PopoverMenuItem v-for="(item, key) in menu" :key="key" :item="item" />
 				</ul>
 				<p>Dummy content</p>
 			</template>

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -51,7 +51,16 @@
 			:src="avatarUrlLoaded"
 			:srcset="avatarSrcSetLoaded"
 			alt="">
-		<div v-if="hasMenu" class="icon-more" />
+		<Popover
+			placement="auto"
+			:open="contactsMenuOpenState">
+			<template>
+				<PopoverMenu :is-open="contactsMenuOpenState" :menu="menu" />
+			</template>
+			<template slot="trigger">
+				<div v-if="hasMenu" class="icon-more" :style="{'width': size + 'px'}" />
+			</template>
+		</Popover>
 
 		<!-- Avatar status -->
 		<div v-if="showUserStatusIconOnAvatar" class="avatardiv__user-status avatardiv__user-status--icon">
@@ -82,22 +91,13 @@
 		<div v-if="userDoesNotExist && !iconClass" class="unknown">
 			{{ initials }}
 		</div>
-		<Popover
-			placement="auto"
-			:open="contactsMenuOpenState">
-			<template>
-				<ul>
-					<PopoverMenuItem v-for="(item, key) in menu" :key="key" :item="item" />
-				</ul>
-				<p>Dummy content</p>
-			</template>
-		</Popover>
 	</div>
 </template>
 
 <script>
 import { getBuilder } from '@nextcloud/browser-storage'
 import { directive as ClickOutside } from 'v-click-outside'
+import PopoverMenu from '../PopoverMenu'
 import { getCurrentUser } from '@nextcloud/auth'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import axios from '@nextcloud/axios'
@@ -106,7 +106,6 @@ import Tooltip from '../../directives/Tooltip'
 import usernameToColor from '../../functions/usernameToColor'
 import { userStatus } from '../../mixins'
 import Popover from '../Popover/Popover'
-import PopoverMenuItem from '../PopoverMenu/PopoverMenuItem'
 
 const browserStorage = getBuilder('nextcloud').persist().build()
 
@@ -132,7 +131,7 @@ export default {
 	},
 	components: {
 		Popover,
-		PopoverMenuItem,
+		PopoverMenu,
 	},
 	mixins: [userStatus],
 	props: {
@@ -592,20 +591,20 @@ export default {
 
 	&--with-menu {
 		cursor: pointer;
-		.icon-more {
+		::v-deep .trigger {
 			position: absolute;
 			top: 0;
 			left: 0;
+		}
+		.icon-more {
 			display: flex;
-			align-items: center;
-			justify-content: center;
-			width: inherit;
-			height: inherit;
 			cursor: pointer;
 			opacity: 0;
+			cursor: pointer;
 			background: none;
 			font-size: 18px;
-
+			align-items: center;
+			justify-content: center;
 			@include iconfont('more');
 			&::before {
 				display: block;
@@ -717,12 +716,6 @@ export default {
 	.popovermenu-wrapper {
 		position: relative;
 		display: inline-block;
-	}
-
-	.popovermenu {
-		display: block;
-		margin: 0;
-		font-size: var(--default-font-size);
 	}
 }
 

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -82,21 +82,22 @@
 		<div v-if="userDoesNotExist && !iconClass" class="unknown">
 			{{ initials }}
 		</div>
-
-		<!-- Menu container -->
-		<div v-if="hasMenu"
-			v-show="contactsMenuOpenState"
-			class="popovermenu"
-			:class="`menu-${menuPosition}`">
-			<PopoverMenu :is-open="contactsMenuOpenState" :menu="menu" />
-		</div>
+		<Popover
+			placement="auto"
+			:open="contactsMenuOpenState">
+			<template>
+				<ul>
+					<PopoverMenuItem v-for="(item, key) in contactsMenuActions" :key="key" :item="item" />
+				</ul>
+				<p>Dummy content</p>
+			</template>
+		</Popover>
 	</div>
 </template>
 
 <script>
 import { getBuilder } from '@nextcloud/browser-storage'
 import { directive as ClickOutside } from 'v-click-outside'
-import PopoverMenu from '../PopoverMenu'
 import { getCurrentUser } from '@nextcloud/auth'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import axios from '@nextcloud/axios'
@@ -104,6 +105,8 @@ import { generateUrl } from '@nextcloud/router'
 import Tooltip from '../../directives/Tooltip'
 import usernameToColor from '../../functions/usernameToColor'
 import { userStatus } from '../../mixins'
+import Popover from '../Popover/Popover'
+import PopoverMenuItem from '../PopoverMenu/PopoverMenuItem'
 
 const browserStorage = getBuilder('nextcloud').persist().build()
 
@@ -128,7 +131,8 @@ export default {
 		ClickOutside,
 	},
 	components: {
-		PopoverMenu,
+		Popover,
+		PopoverMenuItem,
 	},
 	mixins: [userStatus],
 	props: {

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -59,7 +59,7 @@
 				<PopoverMenu :menu="menu" />
 			</template>
 			<template slot="trigger">
-				<div class="icon-more" :style="{'width': size + 'px'}" />
+				<div :class="contactsMenuLoading ? 'icon-loading' : 'icon-more'" :style="{'width': size + 'px', 'height': size + 'px'}" />
 			</template>
 		</Popover>
 
@@ -284,6 +284,7 @@ export default {
 			userDoesNotExist: false,
 			isAvatarLoaded: false,
 			isMenuLoaded: false,
+			contactsMenuLoading: false,
 			contactsMenuActions: [],
 			contactsMenuOpenState: false,
 		}
@@ -450,6 +451,7 @@ export default {
 			this.contactsMenuOpenState = false
 		},
 		async fetchContactsMenu() {
+			this.contactsMenuLoading = true
 			try {
 				const user = encodeURIComponent(this.user)
 				const { data } = await axios.post(generateUrl('contactsmenu/findOne'), `shareType=0&shareWith=${user}`)
@@ -457,6 +459,7 @@ export default {
 			} catch (e) {
 				this.contactsMenuOpenState = false
 			}
+			this.contactsMenuLoading = false
 			this.isMenuLoaded = true
 		},
 

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -52,8 +52,8 @@ With a `<button>` as a trigger:
 <template>
 	<VPopover
 		v-bind="$attrs"
-		popover-base-class="popover"
-		:popover-wrapper-class="doShowMenu ? 'popover__wrapper' : 'popover__wrapper popover__hidden'"
+		:popover-base-class="doShowMenu ? 'popover' : 'popover popover__hidden'"
+		popover-wrapper-class="popover__wrapper"
 		popover-arrow-class="popover__arrow"
 		popover-inner-class="popover__inner"
 		v-on="$listeners">
@@ -113,7 +113,12 @@ $arrow-width: 10px;
 	filter: drop-shadow(0 1px 10px var(--color-box-shadow));
 
 	&__hidden {
-		visibility: hidden;
+		/* same as visibility-hidden but keep the size to avoid resizes on show */
+		/* !important is here to override inline styles set by v-tooltip for initial show */
+		visibility: hidden !important;
+		left: -10000px !important;
+		top: auto !important;
+		transform: transform3d(-10000, -10000, 0) !important;
 	}
 
 	&__inner {

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -53,7 +53,7 @@ With a `<button>` as a trigger:
 	<VPopover
 		v-bind="$attrs"
 		popover-base-class="popover"
-		popover-wrapper-class="popover__wrapper"
+		:popover-wrapper-class="open ? 'popover__wrapper' : 'hidden-visually'"
 		popover-arrow-class="popover__arrow"
 		popover-inner-class="popover__inner"
 		v-on="$listeners">
@@ -73,6 +73,12 @@ export default {
 	name: 'Popover',
 	components: {
 		VPopover,
+	},
+	props: {
+		open: {
+			type: Boolean,
+			default: false,
+		},
 	},
 }
 </script>

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -53,7 +53,7 @@ With a `<button>` as a trigger:
 	<VPopover
 		v-bind="$attrs"
 		popover-base-class="popover"
-		:popover-wrapper-class="open ? 'popover__wrapper' : 'hidden-visually'"
+		:popover-wrapper-class="doShowMenu ? 'popover__wrapper' : 'popover__wrapper popover__hidden'"
 		popover-arrow-class="popover__arrow"
 		popover-inner-class="popover__inner"
 		v-on="$listeners">
@@ -80,6 +80,26 @@ export default {
 			default: false,
 		},
 	},
+	data() {
+		return {
+			doShowMenu: false,
+		}
+	},
+
+	watch: {
+		open(newValue) {
+			if (newValue === true) {
+				// show with delay to allow position calculation to happen for dynamic contents,
+				// otherwise the popover will appear in the wrong place first and be visible,
+				// and then in the next tick it repositions itself
+				window.setTimeout(() => {
+					this.doShowMenu = newValue
+				}, 1)
+			} else {
+				this.doShowMenu = false
+			}
+		},
+	},
 }
 </script>
 
@@ -91,6 +111,10 @@ $arrow-width: 10px;
 	display: block !important;
 
 	filter: drop-shadow(0 1px 10px var(--color-box-shadow));
+
+	&__hidden {
+		visibility: hidden;
+	}
 
 	&__inner {
 		padding: 0;

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -300,7 +300,7 @@ li {
 		/* DEPRECATED! old img in popover fallback
 			* TODO: to remove */
 		> img {
-			width: $clickable-area;
+			width: $icon-size;
 			padding: $icon-margin;
 		}
 


### PR DESCRIPTION
This makes the Avatar component use the Actions component for its menu.

- [ ] requires: https://github.com/nextcloud/nextcloud-vue/pull/831 as base

<img width="282" alt="image" src="https://user-images.githubusercontent.com/277525/105041886-d6fb7d00-5a63-11eb-903a-05d9a021bd93.png">

Issues:

- [ ] need a way to set button size for Actions from attributes
- [ ] opening the menu has the repositioning/resize glitch from https://github.com/nextcloud/nextcloud-vue/pull/831, will need a different approach for differentiating "open state" vs "data loaded and safe to display" state. Maybe need to add a loading attribute to the actions
- [ ] keyboard nav still not working, can't enter the menu. Seems to be a bug in Actions component.
- [ ] make sure that all action types are supported, need to check all the formats returned by the endpoint


