### PR TITLE
Make the popover menu more easily addressable

### DIFF
--- a/src/components/PopoverMenu/PopoverMenu.vue
+++ b/src/components/PopoverMenu/PopoverMenu.vue
@@ -25,7 +25,7 @@
 </docs>
 
 <template>
-	<ul>
+	<ul class="popover__menu">
 		<PopoverMenuItem v-for="(item, key) in menu" :key="key" :item="item" />
 	</ul>
 </template>

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<li>
+	<li class="popover__menuitem">
 		<!-- If item.href is set, a link will be directly used -->
 		<a v-if="item.href"
 			:href="(item.href) ? item.href : '#' "


### PR DESCRIPTION
Required in https://github.com/nextcloud/server/pull/25229 for overrides like for example dark mode stylesheets.

Otherwise the rules would be too generic.
