### PR TITLE
Fix longtext appearance for avatar popover menu

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -376,7 +376,7 @@ export default {
 				return {
 					href: item.hyperlink,
 					icon: item.icon,
-					text: item.title,
+					longtext: item.title,
 				}
 			})
 

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -284,6 +284,10 @@ li {
 			line-height: 1.6em;
 			padding: 8px 0;
 			white-space: normal;
+
+			// in case there are no spaces like long email addresses
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 
 		// TODO: do we really supports it?


### PR DESCRIPTION
Use longtext with the avatar menu as it will mostly contain user names
and email addresses which can become long.

The longtext mode automatically triggers wrapping by default.
However, in the case of long email addresses we can't wrap on spaces, so
an ellipsis has been added as well.

(note, there is no white-space mode that can break in the middle of a string, so this is the best we got)

<img width="233" alt="image" src="https://user-images.githubusercontent.com/277525/105166503-ce647e80-5b17-11eb-83f4-aa4ec977c5ee.png">

For https://github.com/nextcloud/spreed/pull/4976#issuecomment-763517914