### PR TITLE
Increase max width of action button

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -100,13 +100,17 @@
 
 		// long text area
 		p {
-			width: 185px;
+			width: 220px;
 			padding: #{$icon-margin / 2} 0;
 
 			cursor: pointer;
 			text-align: left;
 
 			line-height: 1.6em;
+
+			// in case there are no spaces like long email addresses
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 
 		&__longtext {


### PR DESCRIPTION
Allows for longer German words which cannot be wrapper when they don't
contain spaces.

In case a longer text if present that doesn't fit and cannot wrap, like
an email address, an ellipsis will now be shown.

Before:
![Bildschirmfoto von 2021-01-21 15-51-16](https://user-images.githubusercontent.com/213943/105367489-c92f2e80-5c00-11eb-816b-6d975850b84f.png)

After:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/277525/105484806-3f3c9f80-5cac-11eb-82eb-773d66a14044.png">
