### PR TITLE
Replace linkify-urls with linkifyjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"emoji-mart-vue-fast": "^7.0.7",
 		"escape-html": "^1.0.3",
 		"hammerjs": "^2.0.8",
-		"linkify-urls": "^3.1.1",
 		"linkifyjs": "~2.1.9",
 		"md5": "^2.2.1",
 		"regenerator-runtime": "^0.13.5",

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -21,7 +21,7 @@
  */
 
 import escapeHtml from 'escape-html'
-import linkifyUrls from 'linkify-urls'
+import linkifyStr from 'linkifyjs/string'
 import stripTags from 'striptags'
 import Vue from 'vue'
 
@@ -63,11 +63,12 @@ export default {
 					// on the the uneven indexes. We only want to generate the mentions html
 					if (!part.startsWith('@')) {
 						// This part doesn't contain a mention, let's make sure links are parsed
-						return linkifyUrls(part, {
+						return linkifyStr(part, {
+							defaultProtocol: 'https',
+							target: '_blank',
+							className: 'external',
 							attributes: {
 								rel: 'noopener noreferrer',
-								target: '_blank',
-								class: 'external',
 							},
 						})
 					}


### PR DESCRIPTION
Linkify-urls is redundant as we already had a library.
Linkify-urls is not compatible with Safari as it's designed to be used
on Node JS and it uses non-polyfillable regexp features.

<img width="574" alt="image" src="https://user-images.githubusercontent.com/277525/105515668-4035f700-5cd5-11eb-8844-bda09bafebfa.png">

@nickvergessen please test this with Safari, also with Talk.

