### PR TITLE
Use data of parent component in InputConfirmCanel subcomponent

### DIFF
--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -51,18 +51,16 @@ export default {
 			default: '',
 			type: String,
 		},
-	},
-	data() {
-		return {
-			value: '',
-		}
+		value: {
+			default: '',
+			type: String,
+		},
 	},
 	computed: {
 		valueModel: {
 			get() { return this.value },
 			set(newValue) {
 				this.$emit('input', newValue)
-				this.value = newValue
 			},
 		},
 	},


### PR DESCRIPTION
Currently there is a bug in the `AppNavigationItem` component: When an item is editable, the user can open the edit form but that is always empty. This can easily be seen on the [styleguide site](https://nextcloud-vue-components.netlify.app/#/Components/App%20containers/AppNavigation?id=appnavigationitem). Just click on the edit icon and the text field is going to be empty.

This change will avoid that by avoiding duplication of the value in the subcomponent.

As I am a first-time contributor, I hope this is going to meet your requirements. If not, please tell me so.