### PR TITLE
Fix documentation issue for AppNavigationItem due to unwrapped HTML

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -230,8 +230,8 @@ export default {
 		},
 		/**
 		* Passing in a route will make the root element of this
-		* component a <router-link /> that points to that route.
-		* By leaving this blank, the root element will be a <li>.
+		* component a `<router-link />` that points to that route.
+		* By leaving this blank, the root element will be a `<li>`.
 		*/
 		to: {
 			type: [String, Object],

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -37,7 +37,9 @@
 ```
 * With a spinning loader instead of the icon:
 
+```
 <AppNavigationItem title="Loading Item" :loading="true" />
+```
 
 ### Element with actions
 Wrap the children in a template. If you have more than 2 actions, a popover menu and a menu

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -60,7 +60,7 @@ button will be automatically created.
 ```
 
 ### Element with counter
-Just nest the counter into <AppNavigationItem> and add `slot="counter"` to it.
+Just nest the counter into `<AppNavigationItem>` and add `slot="counter"` to it.
 
 ```
 <AppNavigationItem title="Item with counter" icon="icon-folder">


### PR DESCRIPTION
### Summary

All unwrapped HTML in the documentation section are now wrapped with backticks, allowing them to be render as code in markdown

### Related issues

1. Example and codes for "Usage" > "Simple Element" > spinning loader did not render

| Before | After |
| :-- | :-- |
| ![image](https://user-images.githubusercontent.com/8733840/107154766-b2822900-69af-11eb-864e-94c599ce765b.png) | ![image](https://user-images.githubusercontent.com/8733840/107154768-b4e48300-69af-11eb-8cee-403f3beaf017.png)

2. Documentation for "Usage" > "Element with counter" renders incorrectly

| Before | After |
| :-- | :-- |
| ![image](https://user-images.githubusercontent.com/8733840/107154821-e9583f00-69af-11eb-94e6-7165c78e4a17.png) | ![image](https://user-images.githubusercontent.com/8733840/107154822-eb220280-69af-11eb-81d2-78aede5609aa.png)



3. Documentation for "PROPS, EVENTS & SLOTS" > `to` renders incorrectly

| Before | After |
| :-- | :-- |
| ![image](https://user-images.githubusercontent.com/8733840/107154656-1c4e0300-69af-11eb-9c7e-a73214d994c5.png) | ![image](https://user-images.githubusercontent.com/8733840/107154655-19eba900-69af-11eb-8061-895859623219.png) |




### Test link:

https://deploy-preview-1698--nextcloud-vue-components.netlify.app/#/Components/App%20containers/AppNavigation?id=appnavigationitem