### PR TITLE
Add support for material design icons

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -82,6 +82,20 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 ```
 
 ### Custom icon slot
+To be used with `vue-material-design-icons` only. For icon classes use the `default-icon` slot.
+It can be used with one or multiple actions.
+```
+<Actions>
+	<MicrophoneOff
+		slot="icon"
+		decorative
+		title="" />
+	<ActionButton icon="icon-delete">Delete</ActionButton>
+	<ActionButton icon="icon-reply">Reply</ActionButton>
+</Actions>
+```
+
+### Custom icon slot in child elements
 ```
 <Actions :primary="true">
 	<ActionButton><template #icon><MagnifyIcon /></template>Search</ActionButton>
@@ -95,11 +109,14 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 	<element v-if="isValidSingleAction && !forceMenu"
 		v-tooltip.auto="firstAction.text"
 		v-bind="firstActionBinding"
-		:class="[firstAction.icon, firstActionClass]"
+		:class="{
+			[firstAction.icon]: !iconSlotIsPopulated ,
+			[firstActionClass]: !iconSlotIsPopulated }"
 		class="action-item action-item--single"
 		rel="noreferrer noopener"
 		@[firstActionEventBinding]="execFirstAction">
 		<!-- fake slot to gather main action -->
+		<slot name="icon" />
 		<span :aria-hidden="true" hidden>
 			<!-- @slot All action elements passed into the default slot will be used -->
 			<slot />
@@ -127,7 +144,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 				ref="menuButton"
 				class="icon action-item__menutoggle"
 				:class="{
-					[defaultIcon]: true,
+					[defaultIcon]: !iconSlotIsPopulated,
 					'action-item__menutoggle--with-title': menuTitle,
 					'action-item__menutoggle--primary': primary
 				}"
@@ -136,6 +153,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 				:aria-controls="randomId"
 				test-attr="1"
 				:aria-expanded="opened ? 'true' : 'false'">
+				<slot name="icon" />
 				{{ menuTitle }}
 			</button>
 
@@ -377,6 +395,10 @@ export default {
 			const staticClass = this.firstActionVNode && this.firstActionVNode.data.staticClass
 			const dynClass = this.firstActionVNode && this.firstActionVNode.data.class
 			return `${staticClass} ${dynClass}`
+		},
+
+		iconSlotIsPopulated() {
+			return !!this.$slots.icon
 		},
 	},
 


### PR DESCRIPTION
Add slot for Material design icons to the actions 


https://user-images.githubusercontent.com/26852655/108392906-0f30df80-720b-11eb-873a-a0421f994390.mp4


Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>