### PR TITLE
Allow to inject preloaded user statuses

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -172,6 +172,13 @@ export default {
 			default: true,
 		},
 		/**
+		 * When the user status was preloaded via another source it can be handed in with this property to save the request.
+		 */
+		preloadedUserStatus: {
+			type: Object,
+			default: undefined,
+		},
+		/**
 		 * Is the user a guest user (then we have to user a different endpoint)
 		 */
 		isGuest: {
@@ -414,7 +421,14 @@ export default {
 	mounted() {
 		this.loadAvatarUrl()
 		if (this.showUserStatus && this.user && !this.isNoUser) {
-			this.fetchUserStatus(this.user)
+			if (!this.preloadedUserStatus) {
+				this.fetchUserStatus(this.user)
+			} else {
+				this.userStatus.status = this.preloadedUserStatus.status || ''
+				this.userStatus.message = this.preloadedUserStatus.message || ''
+				this.userStatus.icon = this.preloadedUserStatus.icon || ''
+				this.hasStatus = this.preloadedUserStatus.status !== null
+			}
 			subscribe('user_status:status.updated', this.handleUserStatusUpdated)
 		}
 	},

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -173,6 +173,8 @@ export default {
 		},
 		/**
 		 * When the user status was preloaded via another source it can be handed in with this property to save the request.
+		 * If this property is not set the status will be fetched automatically.
+		 * If a preloaded no-status is available provide this object with properties "status", "icon" and "message" set to null.
 		 */
 		preloadedUserStatus: {
 			type: Object,


### PR DESCRIPTION
Fix #1428 

Improves talk loading (by skipping 40+ status requests) when the status is preloaded already