### PR TITLE
Add a container property to popup components

### DIFF
--- a/src/components/AppSettingsDialog/AppSettingsDialog.vue
+++ b/src/components/AppSettingsDialog/AppSettingsDialog.vue
@@ -81,6 +81,14 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/**
+		 * Selector for the popover container
+		 */
+		container: {
+			type: String,
+			default: 'body',
+		},
 	},
 
 	data() {
@@ -244,6 +252,9 @@ export default {
 		// Return value of the render function
 		if (this.open) {
 			return createElement('Modal', {
+				attrs: {
+					container: this.container,
+				},
 				on: {
 					close: () => { this.handleCloseModal() },
 				},

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -54,6 +54,7 @@
 		<Popover
 			v-if="hasMenu"
 			placement="auto"
+			:container="menuContainer"
 			:open="contactsMenuOpenState">
 			<PopoverMenu :menu="menu" />
 			<template slot="trigger">
@@ -273,6 +274,14 @@ export default {
 		menuPosition: {
 			type: String,
 			default: 'center',
+		},
+
+		/**
+		 * Selector for the popover menu container
+		 */
+		menuContainer: {
+			type: String,
+			default: 'body',
 		},
 	},
 	data() {

--- a/src/components/EmojiPicker/EmojiPicker.vue
+++ b/src/components/EmojiPicker/EmojiPicker.vue
@@ -89,6 +89,7 @@
 <template>
 	<Popover
 		:open.sync="open"
+		:container="container"
 		popover-class="emoji-popover"
 		popover-inner-class="popover-emoji-picker-inner">
 		<template #trigger>
@@ -158,6 +159,14 @@ export default {
 		closeOnSelect: {
 			type: Boolean,
 			default: true,
+		},
+
+		/**
+		 * Selector for the popover container
+		 */
+		container: {
+			type: String,
+			default: 'body',
 		},
 	},
 	data() {

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -281,6 +281,14 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/**
+		 * Selector for the modal container
+		 */
+		container: {
+			type: String,
+			default: 'body',
+		},
 	},
 
 	data() {
@@ -338,8 +346,14 @@ export default {
 			this.handleSwipe(e)
 		})
 
-		// force mount the component to body
-		document.body.insertBefore(this.$el, document.body.lastChild)
+		if (this.container === 'body') {
+			// force mount the component to body
+			document.body.insertBefore(this.$el, document.body.lastChild)
+		} else {
+			const container = document.querySelector(this.container)
+			container.appendChild(this.$el)
+		}
+
 	},
 	destroyed() {
 		this.$el.remove()


### PR DESCRIPTION
Added container property for Modal, AppSettingsDialog, EmojiPicker and
the menu of the Avatar component.

These are needed to make it possible to use them in fullscreen mode.
See https://github.com/nextcloud/spreed/issues/5027