### PR TITLE
Add prop to UserBubble component to show the avatar only

### DIFF
--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -94,7 +94,7 @@ This component has the following slot:
 				class="user-bubble__avatar" />
 
 			<!-- Title -->
-			<span class="user-bubble__title">
+			<span v-if="!avatarOnly" class="user-bubble__title">
 				{{ displayName || user }}
 			</span>
 
@@ -192,6 +192,13 @@ export default {
 			type: Number,
 			default: 2,
 		},
+		/**
+		 * Show the avatar only
+		 */
+		avatarOnly: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		/**
@@ -244,7 +251,7 @@ export default {
 		},
 
 		styles() {
-			return {
+			const styles = {
 				content: {
 					height: this.size + 'px',
 					lineHeight: this.size + 'px',
@@ -254,6 +261,12 @@ export default {
 					marginLeft: this.margin + 'px',
 				},
 			}
+
+			if (this.avatarOnly) {
+				styles.avatar.marginRight = styles.avatar.marginLeft
+			}
+
+			return styles
 		},
 	},
 	methods: {


### PR DESCRIPTION
Adds a new prop to the UserBubble component to only show the avatar. This feature is requested in the mail app for showing thread recipients in a more compact fashion (ref https://github.com/nextcloud/mail/pull/4315#issuecomment-786748992).

Look at https://github.com/nextcloud/mail/pull/4315 or https://github.com/nextcloud/mail/pull/4704 for a demo.

![Screenshot_2021-03-08 Mail - Nextcloud(1)](https://user-images.githubusercontent.com/1479486/110334432-0f124b80-8023-11eb-82c4-f472fd70c2d1.png)

