### PR TITLE
Actions forward focus and blur events on trigger

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -115,6 +115,8 @@ It can be used with one or multiple actions.
 		class="action-item action-item--single"
 		rel="noreferrer noopener"
 		:disabled="disabled"
+		@focus="onFocus"
+		@blur="onBlur"
 		@[firstActionEventBinding]="execFirstAction">
 		<!-- fake slot to gather main action -->
 		<slot name="icon" />
@@ -154,7 +156,9 @@ It can be used with one or multiple actions.
 				aria-haspopup="true"
 				:aria-controls="randomId"
 				test-attr="1"
-				:aria-expanded="opened ? 'true' : 'false'">
+				:aria-expanded="opened ? 'true' : 'false'"
+				@focus="onFocus"
+				@blur="onBlur">
 				<slot name="icon" />
 				{{ menuTitle }}
 			</button>
@@ -593,6 +597,12 @@ export default {
 		initActions() {
 			// filter out invalid slots
 			this.actions = (this.$slots.default || []).filter(node => !!node && !!node.componentOptions)
+		},
+		onFocus(event) {
+			this.$emit('focus', event)
+		},
+		onBlur(event) {
+			this.$emit('blur', event)
 		},
 	},
 }


### PR DESCRIPTION
Whenever the trigger of a single action item or the trigger of an action
menu is focussed or blurred, re-emit the event on the Action component
for outside processing.

Fixes https://github.com/nextcloud/nextcloud-vue/issues/1617

Can be seen in use in https://github.com/nextcloud/spreed/pull/4666 where we need to track whether a button is focussed to prevent removing the hover and preventing to hide the buttons there.