### PR TITLE
Resizable columns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,9 +2,11 @@ module.exports = {
 	globals: {
 		SCOPE_VERSION: true,
 		TRANSLATIONS: true,
-		oc_userconfig: true
+		oc_userconfig: true,
+		appName: true,
+		appversion: true,
 	},
 	extends: [
-		'@nextcloud'
+		'@nextcloud',
 	],
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 		TRANSLATIONS: true,
 		oc_userconfig: true,
 		appName: true,
-		appversion: true,
+		appVersion: true,
 	},
 	extends: [
 		'@nextcloud',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8185,7 +8185,8 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -10323,7 +10324,8 @@
 		"chownr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -15049,114 +15051,6 @@
 				"bindings": "^1.5.0",
 				"nan": "^2.12.1",
 				"node-pre-gyp": "*"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				},
-				"nopt": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"tar": {
-					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-				}
 			}
 		},
 		"function-bind": {
@@ -16601,39 +16495,6 @@
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"requires": {
-						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/types": {
-					"version": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -21882,6 +21743,8 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
 			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"minipass": "^2.9.0"
 			},
@@ -21890,6 +21753,8 @@
 					"version": "2.9.0",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
 					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -21898,7 +21763,9 @@
 				"yallist": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -21943,6 +21810,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -22044,7 +21912,8 @@
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"dev": true
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -22658,7 +22527,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -23257,17 +23127,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -27065,6 +26938,11 @@
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
+		},
+		"splitpanes": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-2.3.6.tgz",
+			"integrity": "sha512-2sif1pmOQw/N+/jRbVzqTJ32lkhJax8jQfaXCebRK/SFCadHOnAaXDcWW8PpEcr9vKpfzH7gxJ8Sq/74HECr/g=="
 		},
 		"sprintf-js": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"linkifyjs": "~2.1.9",
 		"md5": "^2.2.1",
 		"regenerator-runtime": "^0.13.5",
+		"splitpanes": "^2.3.6",
 		"string-length": "^4.0.1",
 		"striptags": "^3.1.1",
 		"style-loader": "^2.0.0",

--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -72,7 +72,7 @@ The list size must be between the min and the max width value.
 		<div v-if="isMobile"
 			:class="showDetails ? 'app-content-wrapper--show-details' : 'app-content-wrapper--show-list'"
 			class="app-content-wrapper app-content-wrapper--mobile">
-			<AppDetailsToggle v-if="showDetails" @click.native.stop.prevent="hideDetails" />
+			<AppDetailsToggle v-if="hasList && showDetails" @click.native.stop.prevent="hideDetails" />
 
 			<slot name="list" />
 			<slot />

--- a/src/components/AppContent/AppDetailsToggle.vue
+++ b/src/components/AppContent/AppDetailsToggle.vue
@@ -1,0 +1,68 @@
+<!--
+  - @copyright Copyright (c) 2021 John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @author John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<a v-tooltip="t('contacts', 'Go back to the list')" class="app-details-toggle icon-confirm" href="#" />
+</template>
+
+<script>
+export default {
+	name: 'AppDetailsToggle',
+
+	beforeMount() {
+		this.toggleAppNavigationButton(true)
+	},
+
+	beforeDestroy() {
+		this.toggleAppNavigationButton(false)
+	},
+
+	methods: {
+		toggleAppNavigationButton(hide = true) {
+			const appNavigationToggle = document.querySelector('.app-navigation .app-navigation-toggle')
+			if (appNavigationToggle) {
+				appNavigationToggle.style.display = hide ? 'none' : null
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.app-details-toggle {
+	position: fixed;
+	width: $clickable-area;
+	height: $clickable-area;
+	padding: $icon-margin;
+	cursor: pointer;
+	opacity: .6;
+	transform: rotate(180deg);
+	background-color: var(--color-main-background);
+	z-index: 2000;
+
+	&:active,
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
+}
+</style>

--- a/src/components/AppContent/AppDetailsToggle.vue
+++ b/src/components/AppContent/AppDetailsToggle.vue
@@ -21,12 +21,23 @@
   -->
 
 <template>
-	<a v-tooltip="t('contacts', 'Go back to the list')" class="app-details-toggle icon-confirm" href="#" />
+	<a v-tooltip="title" class="app-details-toggle icon-confirm" href="#" />
 </template>
 
 <script>
+import { emit } from '@nextcloud/event-bus'
+
+import l10n from '../../mixins/l10n'
 export default {
 	name: 'AppDetailsToggle',
+
+	mixins: [l10n],
+
+	computed: {
+		title() {
+			return this.t('Go back to the list')
+		},
+	},
 
 	beforeMount() {
 		this.toggleAppNavigationButton(true)
@@ -41,6 +52,11 @@ export default {
 			const appNavigationToggle = document.querySelector('.app-navigation .app-navigation-toggle')
 			if (appNavigationToggle) {
 				appNavigationToggle.style.display = hide ? 'none' : null
+
+				// If we hide the NavigationToggle, we need to make sure the Navigation is also closed
+				if (hide === true) {
+					emit('toggle-navigation', { open: false })
+				}
 			}
 		},
 	},


### PR DESCRIPTION
Hi! So this is the new counterpart to a Pull Request originally made in https://github.com/nextcloud/mail/pull/4123. 

It was suggested to move the implemention into the global component, so that other apps are able to use this as well. Here are some details about the implementation:

This is (still) using the [splitpanes](https://antoniandre.github.io/splitpanes/) package to do the heavy lifting. We've got two columns: `main` and `aside`. These two columns have `min`, `max` and default `size` widths defined [here](https://github.com/nextcloud/nextcloud-vue/compare/master...dotplex:enhancement/resizable-columns?expand=1#diff-937d3d5f5c1cfb86c454474540a49bc24a57cdabe0876f60e4e0aa018a5b9223R79-R90).

`splitpanes` fires an event called `resized` after a resize has occurred, which triggers a save to `localStorage` with the `size` values for `main` and `aside` in [`onPaneResize()`](https://github.com/nextcloud/nextcloud-vue/compare/master...dotplex:enhancement/resizable-columns?expand=1#diff-937d3d5f5c1cfb86c454474540a49bc24a57cdabe0876f60e4e0aa018a5b9223R127-R133). The pane sizes are **scoped to the parent component**, which means that each app implementing this will store their own sizes automatically. To do that, I am pulling the parent component's name (`this.$parent.$options.name`) to construct a [`paneIdentifier`](https://github.com/nextcloud/nextcloud-vue/compare/master...dotplex:enhancement/resizable-columns?expand=1#diff-937d3d5f5c1cfb86c454474540a49bc24a57cdabe0876f60e4e0aa018a5b9223R78) which is then used to store and read from localStorage. 

So for example, the Mail app implements this insde of the `MailboxThread` component. Thus the record in `localStorage` will look something like this: 

```
pane-sizes.MailboxThread: {"aside":"23.60","main":"76.40"}
```

As for the DOM structure: the `<slot>` inside `<main id="app-content-vue">` has now been wrapped inside `<div id="app-content-wrapper">`, which had to be moved up from within the component of the Mail app. This is something that needs to be checked I guess. Does any other app use that `#app-content-wrapper` div?

Apps that implement this component and just use the default slot should not be affected by this change, other than the new wrapping div. Maybe we could even move the default `<slot>` out of div#app-content-wrapper again... 🤔  That way there wouldn't be any change at all to a component that is not using the named slots. I'd love some feedback on that!

Oh and also: can someone please check why there are so many changes/additions to the `package-lock.json` file? Just adding the splitpanes-package shouldn't create that big of a difference I believe. 🤷‍♂️ 