### PR TITLE
Fix actions dropdown focus timing

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -171,7 +171,7 @@ export default {
 			:boundaries-element="boundariesElement"
 			:container="container"
 			@show="openMenu"
-			@apply-show="onOpen"
+			@after-show="onOpen"
 			@hide="closeMenu">
 			<!-- Menu open/close trigger button -->
 			<button slot="trigger"
@@ -502,8 +502,6 @@ export default {
 			 * Event emitted when the popover menu is closed
 			 */
 			this.$emit('open')
-
-			this.onOpen(e)
 		},
 		closeMenu(e) {
 			if (!this.opened) {

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -86,8 +86,18 @@ export default {
 			},
 			(val) => {
 				if (val) {
+					/**
+					 * Triggered after the tooltip was visually displayed.
+					 *
+					 * This is different from the 'show' and 'apply-show' which
+					 * run earlier than this where there is no guarantee that the
+					 * tooltip is already visible and in the DOM.
+					 */
 					this.$emit('after-show')
 				} else {
+					/**
+					 * Triggered after the tooltip was visually hidden.
+					 */
 					this.$emit('after-hide')
 				}
 			}

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -51,6 +51,7 @@ With a `<button>` as a trigger:
 
 <template>
 	<VPopover
+		ref="popover"
 		v-bind="$attrs"
 		popover-base-class="popover"
 		popover-wrapper-class="popover__wrapper"
@@ -73,6 +74,24 @@ export default {
 	name: 'Popover',
 	components: {
 		VPopover,
+	},
+
+	mounted() {
+		this.$watch(
+			() => {
+				// required because v-tooltip doesn't provide events
+				// and @show is too early
+				// see https://github.com/Akryum/v-tooltip/issues/661
+				return this.$refs.popover.isOpen
+			},
+			(val) => {
+				if (val) {
+					this.$emit('after-show')
+				} else {
+					this.$emit('after-hide')
+				}
+			}
+		)
 	},
 }
 </script>


### PR DESCRIPTION
Because "@after-show" is still happening too early due to v-tooltip's
use of "requestAnimationFrame" we can't rely on its events to tell us
when the popover is actually visible.

This workaround introduces an additional Popover event "after-show" and
"after-hide" that are based on monitoring the inner "isOpen" property
which is the one toggling the CSS visibility.

The Actions popover logic now uses "after-show" to reliably apply the
focus on the first action element.

Fixes https://github.com/nextcloud/nextcloud-vue/issues/1760
See https://github.com/Akryum/v-tooltip/issues/661 for the upstream issue.

