### PR TITLE
Fix Settings css

### DIFF
--- a/src/components/SettingsSection/SettingsSection.vue
+++ b/src/components/SettingsSection/SettingsSection.vue
@@ -102,6 +102,10 @@ export default {
 	margin-bottom: auto;
 	padding: 30px;
 
+	&:not(:last-child) {
+		border-bottom: 1px solid var(--color-border);
+	}
+
 	&__title {
 		display: inline-flex;
 		align-items: center;
@@ -130,7 +134,7 @@ export default {
 	}
 
 	&__desc {
-		margin-top: -1em;
+		margin-top: -0.2em;
 		margin-bottom: 1em;
 		opacity: $opacity_normal;
 	}


### PR DESCRIPTION
Under the assumption it is a bug and not a new design feature, this fixes:
- SettingsSection was missing the separating border at the bottom
- Distance of Header and desciption adapted:

Settings before Vue:
![policy_setting_old](https://user-images.githubusercontent.com/47433654/111826202-af505600-88e8-11eb-9d0a-dc22b6d97c62.PNG)

Settings currently on Vue-Components:
![policy_setting_vue_wrong](https://user-images.githubusercontent.com/47433654/111826140-9ba4ef80-88e8-11eb-85c1-68055f01693e.PNG)

Settings after this PR is merged:
![policy_setting_vue_new](https://user-images.githubusercontent.com/47433654/111826210-b37c7380-88e8-11eb-903e-96fa16b082d5.PNG)
