### PR TITLE
Allow last crumb to shrink if all crumbs collapsed

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -220,6 +220,14 @@ export default {
 	height: $clickable-area;
 	padding: 0;
 
+	&:last-child {
+		max-width: 210px;
+
+		a {
+			flex-shrink: 1;
+		}
+	}
+
 	&::before {
 		display: flex;
 		align-items: center;
@@ -234,6 +242,10 @@ export default {
 
 	&--with-action a {
 		padding-right: 2px;
+	}
+
+	> a, > span {
+		max-width: 100%;
 	}
 
 	a {

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -502,7 +502,7 @@ export default {
 			: []
 		this.addCrumbs(crumbs, crumbs2, crumbs1.length)
 
-		return createElement('div', { class: 'breadcrumb', ref: 'container' }, crumbs)
+		return createElement('div', { class: ['breadcrumb', { 'breadcrumb--collapsed': (this.hiddenCrumbs.length === breadcrumbs.length - 2) }], ref: 'container' }, crumbs)
 	},
 }
 </script>
@@ -511,6 +511,11 @@ export default {
 .breadcrumb {
 	width: 100%;
 	flex-grow: 1;
+
+	&--collapsed  .crumb:last-child {
+		min-width: 100px;
+		flex-shrink: 1;
+	}
 
 	.crumb--hovered{
 		background-color: var(--color-primary-light);


### PR DESCRIPTION
This PR allow the last breadcrumb in the breadcrumbs bar to shrink, in case all other breadcrumbs are already hidden. This prevents the breadcrumb from overflowing on narrow screens (e.g. iPhone 8).

Before:
![Screenshot_2021-03-20 Inventar - Nextcloud](https://user-images.githubusercontent.com/2496460/111873547-0a3d8800-8991-11eb-9abc-6cd05e48fb07.png)

![before](https://user-images.githubusercontent.com/2496460/111873557-175a7700-8991-11eb-938a-0b55340c35be.gif)


After:
![Screenshot_2021-03-20 Inventar - Nextcloud(1)](https://user-images.githubusercontent.com/2496460/111873556-1295c300-8991-11eb-8ebf-757d36997326.png)

![after](https://user-images.githubusercontent.com/2496460/111873562-1f1a1b80-8991-11eb-8895-76bce1a5ae43.gif)
