### PR TITLE
Minimize bundled translations

### DIFF
--- a/src/l10n.js
+++ b/src/l10n.js
@@ -2,7 +2,38 @@ import { getGettextBuilder } from '@nextcloud/l10n/dist/gettext'
 
 const gtBuilder = getGettextBuilder()
 	.detectLocale()
-TRANSLATIONS.map(data => gtBuilder.addTranslation(data.locale, data.json))
+
+// Decompress Translations to gettext format and add to gtBuilder
+TRANSLATIONS.forEach((lang) => {
+	const translations = {}
+
+	for (const key in lang.translations) {
+		// Plural
+		if (lang.translations[key].pluralId) {
+			translations[key] = {
+				msgid: key,
+				msgid_plural: lang.translations[key].pluralId,
+				msgstr: lang.translations[key].msgstr,
+			}
+			continue
+		}
+
+		// Singular
+		translations[key] = {
+			msgid: key,
+			msgstr: [
+				lang.translations[key],
+			],
+		}
+	}
+
+	gtBuilder.addTranslation(lang.locale, {
+		translations: {
+			'': translations,
+		},
+	})
+})
+
 const gt = gtBuilder.build()
 
 const n = gt.ngettext.bind(gt)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -31,9 +31,28 @@ const translations = fs
 
 		const po = fs.readFileSync(path)
 		const json = gettextParser.po.parse(po)
+
+		// Compress translations Content
+		const translations = {}
+		for (key in json.translations['']) {
+			if (key !== '') {
+				// Plural
+				if ('msgid_plural'in json.translations[''][key]) {
+					translations[json.translations[''][key].msgid] = {
+						pluralId: json.translations[''][key].msgid_plural,
+						msgstr: json.translations[''][key].msgstr
+					}
+					continue
+				}
+
+				// Singular
+				translations[json.translations[''][key].msgid] = json.translations[''][key].msgstr[0]
+			}
+		}
+
 		return {
 			locale,
-			json,
+			translations,
 		}
 	})
 


### PR DESCRIPTION
#### Why?
On Password-Policy the usage of _SettingsSection_ instead of a simple _div_ blew up the package-size from `100 KiB` to `330 KiB` of which `140 KB `are the `l10n.js` of vue-Components. So i thought about how to reduce this.

#### Idea
The current implementation inserts the pot-file as json, and packs this within the bundle. However, there is a huge overhead on that kind of storing. So the idea was to reduce the overhead by storing only necessary data.
As model i initially used the json-format as translations are stored within apps.

#### Approach
- Unfortunately i didn't find a npm-package/a way to store in the desired format, the recommended package (po2json) seems to be unmaintained and breaks on plural-translations.
- Therefore this approach now manually transforms/compresses the format and decompresses it before inserting into gettextBuilder.
- I must admit on the one hand this feels a bit hacky, as it compresses to a custom format on webpack-build, just to store the data and decompresses then on l10n insertion manually.
=> `Webpack-build compresses -> Component stores compressed data -> l10n.js decompresses when loading gettext`
- The meta-information out of the header currently gets lost, but as far as i see, this works without. To be sure, on could think about restoring the `plural-forms`, `language` and `content-type` headers.

#### Result
This approach **reduces the size of the bundled l10n.js from** `142 KB` **to** `32 KB`**!**
Thus, the bundled password_policy settings reduce from `346 KiB` to `237 KiB`, while e.g. the forms-app bundle reduces from `2.75 MiB` to `2.21 MiB`.

#### More Information:

The way translations are stored currently (Only 1 plural and 2 singular translations):
```
{
  "locale": "de_DE",
  "json": {
    "charset": "utf-8",
    "headers": {
      "Last-Translator": "Mario Siegmann <mario_siegmann@web.de>, 2020",
      "Language-Team": "German (Germany) (https://www.transifex.com/nextcloud/teams/64236/de_DE/)",
      "Content-Type": "text/plain; charset=UTF-8",
      "Language": "de_DE",
      "Plural-Forms": "nplurals=2; plural=(n != 1);"
    },
    "translations": {
      "": {
        "": {
          "msgid": "",
          "comments": {
            "translator": "\nTranslators:\nPhilipp Fischbeck <pfischbeck@googlemail.com>, 2020\nProfDrJones <jones@fs.cs.hm.edu>, 2020\nMark Ziegler <mark.ziegler@rakekniven.de>, 2020\nMario Siegmann <mario_siegmann@web.de>, 2020\n"
          },
          "msgstr": [
            "Last-Translator: Mario Siegmann <mario_siegmann@web.de>, 2020\nLanguage-Team: German (Germany) (https://www.transifex.com/nextcloud/teams/64236/de_DE/)\nContent-Type: text/plain; charset=UTF-8\nLanguage: de_DE\nPlural-Forms: nplurals=2; plural=(n != 1);\n"
          ]
        },
        "%n Action": {
          "msgid": "%n Action",
          "msgid_plural": "%n Actions",
          "msgstr": [
            "%n Aktion",
            "%n Aktionen"
          ]
        },
        "Actions": {
          "msgid": "Actions",
          "comments": {
            "reference": "src/components/Actions/Actions.vue:254"
          },
          "msgstr": [
            "Aktionen"
          ]
        },
        "Activities": {
          "msgid": "Activities",
          "comments": {
            "reference": "src/components/EmojiPicker/EmojiPicker.vue:176"
          },
          "msgstr": [
            "Aktivitäten"
          ]
        },
      }
    }
  }
}
```
The way i would store it here (same translation Data!):
```
{
  "locale": "de_DE",
  "translations": {
    "%n Action": {                       // Plural translation needs some specific handling
      "pluralId": "%n Actions",
      "msgstr": [
        "%n Aktion",
        "%n Aktionen"
      ]
    },
    "Actions": "Aktionen",           // Singular Translation
    "Activities": "Aktivitäten",
  }
},
```

Colorful image of the **bundles before**:
![grafik](https://user-images.githubusercontent.com/47433654/111983245-34ff1c00-8b0a-11eb-9e9f-bc2e9b33d6bf.png)

Colorful image of the **bundles after**:
![grafik](https://user-images.githubusercontent.com/47433654/111983306-47795580-8b0a-11eb-8b21-205a4f79eeb5.png)
