### PR TITLE
Fix translation extraction

### DIFF
--- a/build/extract-l10n.js
+++ b/build/extract-l10n.js
@@ -11,8 +11,8 @@ extractor
         }),
         JsExtractors.callExpression('n', {
             arguments: {
-                text: 1,
-                textPlural: 2,
+                text: 0,
+                textPlural: 1,
             }
         }),
     ])

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -26,6 +26,9 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
+msgid "External documentation for {title}"
+msgstr ""
+
 msgid "Flags"
 msgstr ""
 
@@ -81,6 +84,9 @@ msgid "Smileys & Emotion"
 msgstr ""
 
 msgid "Start slideshow"
+msgstr ""
+
+msgid "Submit"
 msgstr ""
 
 msgid "Symbols"

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -131,7 +131,7 @@
 				class="app-sidebar-header">
 				<!-- close sidebar button -->
 				<a
-					v-tooltip.auto="t('close')"
+					v-tooltip.auto="closeTranslated"
 					href="#"
 					class="app-sidebar__close icon-close"
 					@click.prevent="closeSidebar" />
@@ -237,9 +237,9 @@ import Actions from '../Actions'
 import Focus from '../../directives/Focus'
 import Linkify from '../../directives/Linkify'
 import Tooltip from '../../directives/Tooltip'
-import l10n from '../../mixins/l10n'
 import AppSidebarTabs from './AppSidebarTabs'
 import EmptyContent from '../EmptyContent/EmptyContent'
+import { t } from '../../l10n'
 import { directive as ClickOutside } from 'v-click-outside'
 
 export default {
@@ -257,8 +257,6 @@ export default {
 		ClickOutside,
 		Tooltip,
 	},
-
-	mixins: [l10n],
 
 	props: {
 		active: {
@@ -365,6 +363,7 @@ export default {
 
 	data() {
 		return {
+			closeTranslated: t('Close'),
 			isStarred: this.starred,
 		}
 	},

--- a/src/components/SettingsInputText/SettingsInputText.vue
+++ b/src/components/SettingsInputText/SettingsInputText.vue
@@ -33,7 +33,7 @@
 				@input="onInput"
 				@change="onChange">
 			<input :id="idSubmit"
-				:value="t('Submit')"
+				:value="submitTranslated"
 				type="submit"
 				class="action-input__submit">
 			<label v-show="!disabled" :for="idSubmit" class="action-input__label" />
@@ -45,7 +45,9 @@
 </template>
 
 <script>
+import { t } from '../../l10n'
 import GenRandomId from '../../utils/GenRandomId'
+
 export default {
 	name: 'SettingsInputText',
 	props: {
@@ -90,6 +92,13 @@ export default {
 			validator: id => id.trim() !== '',
 		},
 	},
+
+	data() {
+		return {
+			submitTranslated: t('Submit'),
+		}
+	},
+
 	computed: {
 		/**
 		 * @returns {string}

--- a/src/components/SettingsSection/SettingsSection.vue
+++ b/src/components/SettingsSection/SettingsSection.vue
@@ -48,7 +48,7 @@ This component is to be used in the settings section of nextcloud.
 				:href="docUrl"
 				class="settings-section__info"
 				role=""
-				:title="t('External documentation for {title}', {title})" />
+				:title="docTitleTranslated" />
 		</h2>
 		<p v-if="hasDescription"
 			class="settings-section__desc">
@@ -59,14 +59,14 @@ This component is to be used in the settings section of nextcloud.
 </template>
 
 <script>
-import l10n from '../../mixins/l10n'
+import { t } from '../../l10n'
 
 export default {
 	name: 'SettingsSection',
 	components: {
 
 	},
-	mixins: [l10n],
+
 	props: {
 		title: {
 			type: String,
@@ -80,6 +80,14 @@ export default {
 			type: String,
 			default: '',
 		},
+	},
+
+	data() {
+		return {
+			docTitleTranslated: t('External documentation for {title}', {
+				title: this.title,
+			}),
+		}
 	},
 
 	computed: {


### PR DESCRIPTION
Two small things:
- As plural-translations have a format of `n('%n Action', '%n Actions', n)` the extraction needs to use parameters 0 and 1. Didn't get recognized, as there are currently no plural-translations on this repo.
- Currently, translations do not get extracted if they are directly written within a html-property. Normally that should be fixed on extraction, however, the author seems to be on a bigger rewrite (since two years? https://github.com/lukasgeiter/gettext-extractor/issues/31 🤔), so this is a quick and simple workaround to put them on new lines.