### PR TITLE
Ensure that crumbs to hide have correct class

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -278,11 +278,13 @@ export default {
 		getWidth(el) {
 			if (!el.classList) return 0
 			const hide = el.classList.contains('crumb--hidden')
+			el.style.minWidth = 'auto'
 			el.classList.remove('crumb--hidden')
 			const w = el.offsetWidth
 			if (hide) {
 				el.classList.add('crumb--hidden')
 			}
+			el.style.minWidth = ''
 			return w
 		},
 		/**


### PR DESCRIPTION
In some cases, breadcrumbs which should be hidden would not have the correct class set, causing them to still be visible. This was because the breadcrumbs were not rendered yet, when the class was applied. Hence `crumb.elm` was `undefined` and the class could not be applied. In case a rerender was triggered (e.g. by opening the Dropdown menu), the correct class was then set and the crumbs were correctly hidden.

I changed the code to now double check after the render function was called and has finished (in the `updated` hook), that the correct class is set for the crumbs to hide.

This PR also fixes a small papercut introduced by #1771 where the `min-width` would cause the last crumb to be wider than necessary if the content was narrow. In some cases this caused the crumbs to be completely hidden, although one crumb could be visible. I fixed it by now temporarily removing `min-width` when getting the crumb width in javascript.

Before:
![before](https://user-images.githubusercontent.com/2496460/113122645-1e487b80-9214-11eb-8265-37f205ec64b0.gif)


After:
![after](https://user-images.githubusercontent.com/2496460/113122623-1ab4f480-9214-11eb-8055-3c23a531d98e.gif)
