### PR TITLE
Make sure to pass all props and attributes to single-action Actions

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -411,6 +411,8 @@ export default {
 						href: this.firstAction.href,
 						target: this.firstAction.target,
 						'aria-label': this.firstAction.ariaLabel,
+						...this.firstAction.$attrs,
+						...this.firstAction.$props,
 					}
 				}
 				if (tag === 'ActionRouter') {
@@ -419,12 +421,16 @@ export default {
 						to: this.firstAction.to,
 						exact: this.firstAction.exact,
 						'aria-label': this.firstAction.ariaLabel,
+						...this.firstAction.$attrs,
+						...this.firstAction.$props,
 					}
 				}
 				if (tag === 'ActionButton') {
 					return {
 						is: 'button',
 						'aria-label': this.firstAction.ariaLabel,
+						...this.firstAction.$attrs,
+						...this.firstAction.$props,
 					}
 				}
 			}


### PR DESCRIPTION
Only a very narrow set of attributes were passed to the element if only one action were displayed.

Example (the download is NOT applied to the action without this PR):

```vue
<ActionLink
	download="123456"
	icon="icon-download"
	:close-after-click="true"
	:href="currentFile.davPath">
	{{ t('viewer', 'Download') }}
</ActionLink>
```
