### PR TITLE
Restrict the @nextcloud/capabilities version to 1.0.2 due to incompatibilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@nextcloud/auth": "^1.2.3",
 		"@nextcloud/axios": "^1.3.2",
 		"@nextcloud/browser-storage": "^0.1.1",
-		"@nextcloud/capabilities": "^1.0.2",
+		"@nextcloud/capabilities": "1.0.2",
 		"@nextcloud/dialogs": "^3.0.0",
 		"@nextcloud/event-bus": "^1.1.4",
 		"@nextcloud/l10n": "^1.2.3",


### PR DESCRIPTION
Currently, there is an incompatibility with `@nextcloud/capabilities` in verison `1.0.3`.

As the current version of `@nextcloud/vue` is using the caret operator, the version `1.0.3` is accepted by `npm` as a possible solution for the dependency. This runs other projects into trouble as the dependency is failing later on.

This PR is merely a hotfix until compatible with the current version of `@nextcloud/capabilities`.