### PR TITLE
Add id prop to ListItemIcon to prevent v-binding to the Avatar

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -125,6 +125,7 @@ function setUserHasAvatar(userId, flag) {
 
 export default {
 	name: 'Avatar',
+
 	directives: {
 		tooltip: Tooltip,
 		ClickOutside,

--- a/src/components/ListItemIcon/ListItemIcon.vue
+++ b/src/components/ListItemIcon/ListItemIcon.vue
@@ -57,7 +57,7 @@ It might be used for list rendering or within the multiselect for example
 </docs>
 
 <template>
-	<span class="option" :style="cssVars">
+	<span :id="id" class="option" :style="cssVars">
 		<Avatar
 			v-bind="$attrs"
 			:disable-menu="true"
@@ -173,6 +173,14 @@ export default {
 		isNoUser: {
 			type: Boolean,
 			default: false,
+		},
+
+		/**
+		 * Unique list item ID
+		 */
+		id: {
+			type: String,
+			default: null,
 		},
 	},
 


### PR DESCRIPTION
Because we `v-bind="$attrs"` to the avatar component, declaring id pass it to the `$props` and make sure we are not having a duplicate ID on the page
![image](https://user-images.githubusercontent.com/14975046/114148097-b54ebb00-9919-11eb-9cde-0aeb678a7a4e.png)
