### PR TITLE
Fix Actions css

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -100,13 +100,14 @@
 
 		// long text area
 		p {
-			width: 220px;
-			padding: #{$icon-margin / 2} 0;
+			max-width: 220px;
+			line-height: 1.6em;
+
+			// 14px are currently 1em line-height. Mixing units as '44px - 1.6em' does not work.
+			padding: #{($clickable-area - 1.6*14px) / 2} 0;
 
 			cursor: pointer;
 			text-align: left;
-
-			line-height: 1.6em;
 
 			// in case there are no spaces like long email addresses
 			overflow: hidden;


### PR DESCRIPTION
Once again, just two small css-fixes:
- Longtext-actions had a fixed width, which was a bit unhandy in case the text length was just close above the switching-length
- Longtext-actions were a bit misaligned in height.

Left **before**, right **after:**
![grafik](https://user-images.githubusercontent.com/47433654/114276422-cc2f0380-9a26-11eb-90bc-6b713fcd365b.png)![grafik](https://user-images.githubusercontent.com/47433654/114276356-91c56680-9a26-11eb-9187-0bec51242e0b.png)


![grafik](https://user-images.githubusercontent.com/47433654/114276436-d7822f00-9a26-11eb-97f0-10d78f3809c6.png)![grafik](https://user-images.githubusercontent.com/47433654/114276337-7fe3c380-9a26-11eb-98fc-5cb8658a04f5.png)