### PR TITLE
Use ActionButton for AppNavigationToggle

### DIFF
--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -25,7 +25,6 @@
 	<Actions class="app-navigation-toggle">
 		<ActionButton
 			:aria-expanded="open ? 'true' : 'false'"
-			:aria-label="label"
 			aria-controls="app-navigation-vue"
 			@click="toggleNavigation">
 			<Menu

--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -22,25 +22,39 @@
  -
  -->
 <template>
-	<a class="app-navigation-toggle"
-		href="#"
-		:aria-expanded="open ? 'true' : 'false'"
-		aria-controls="app-navigation-vue"
-		@click.prevent="toggleNavigation"
-		@keydown.space.exact.prevent="toggleNavigation">
-		<Menu :size="24" title="" decorative />
-	</a>
+	<Actions class="app-navigation-toggle">
+		<ActionButton
+			:aria-expanded="open ? 'true' : 'false'"
+			:aria-label="label"
+			aria-controls="app-navigation-vue"
+			@click="toggleNavigation">
+			<Menu
+				slot="icon"
+				:size="24"
+				title=""
+				decorative />
+			{{ label }}
+		</ActionButton>
+	</Actions>
 </template>
 
 <script>
+import Actions from '../Actions/Actions'
+import ActionButton from '../ActionButton/ActionButton'
+import l10n from '../../mixins/l10n'
+
 import Menu from 'vue-material-design-icons/Menu'
 
 export default {
 	name: 'AppNavigationToggle',
 
 	components: {
+		Actions,
+		ActionButton,
 		Menu,
 	},
+
+	mixins: [l10n],
 
 	props: {
 		open: {
@@ -49,6 +63,11 @@ export default {
 		},
 	},
 
+	computed: {
+		label() {
+			return this.open ? this.t('Close navigation') : this.t('Open navigation')
+		},
+	},
 	methods: {
 		toggleNavigation() {
 			this.$emit('update:open', !this.open)
@@ -58,24 +77,12 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.app-navigation-toggle {
+
+button.app-navigation-toggle {
 	position: absolute;
 	top: 0;
 	right: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: $clickable-area;
-	height: $clickable-area;
 	margin-right: - $clickable-area;
-	padding: 0;
-	cursor: pointer;
-	opacity: .6;
-
-	&:hover,
-	&:focus {
-		opacity: $opacity_full;
-	}
 }
 
 </style>


### PR DESCRIPTION
This is another approach to https://github.com/nextcloud/nextcloud-vue/pull/1843. We simply use `ActionButton` for the `AppNavigationToggle` now and let it do the heavy lifting.

hover/focus feedback after:
<img width="215" alt="Unbenannt" src="https://user-images.githubusercontent.com/2496460/114784387-7a1a1500-9d7b-11eb-8d3a-1e1c2ddaf13d.png">
<img width="170" alt="Unbenannt" src="https://user-images.githubusercontent.com/2496460/114784434-8bfbb800-9d7b-11eb-8489-0c81680e1882.png">



