### PR TITLE
Make avatar menu focusable with keyboard

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -17,6 +17,9 @@ msgstr ""
 msgid "Animals & Nature"
 msgstr ""
 
+msgid "Avatar of {displayName}"
+msgstr ""
+
 msgid "Cancel changes"
 msgstr ""
 

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -36,7 +36,9 @@
 
 </docs>
 <template>
-	<div v-tooltip="tooltip"
+	<div
+		ref="main"
+		v-tooltip="tooltip"
 		v-click-outside="closeMenu"
 		:class="{
 			'avatardiv--unknown': userDoesNotExist,
@@ -61,8 +63,10 @@
 			v-if="hasMenu"
 			placement="auto"
 			:container="menuContainer"
-			:open="contactsMenuOpenState">
-			<PopoverMenu :menu="menu" />
+			:open="contactsMenuOpenState"
+			@after-show="handlePopoverAfterShow"
+			@after-hide="handlePopoverAfterHide">
+			<PopoverMenu ref="popoverMenu" :menu="menu" />
 			<template slot="trigger">
 				<div v-if="contactsMenuLoading" class="icon-loading" />
 				<DotsHorizontal v-else
@@ -433,6 +437,16 @@ export default {
 	},
 
 	methods: {
+		handlePopoverAfterShow() {
+			const links = this.$refs.popoverMenu.$el.getElementsByTagName('a')
+			if (links.length) {
+				links[0].focus()
+			}
+		},
+		handlePopoverAfterHide() {
+			// bring focus back to the trigger
+			this.$refs.main.focus()
+		},
 		handleUserStatusUpdated(state) {
 			if (this.user === state.userId) {
 				this.userStatus = {

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -44,7 +44,11 @@
 		}"
 		:style="avatarStyle"
 		class="avatardiv popovermenu-wrapper"
-		v-on="!disableMenu ? { click: toggleMenu } : {}">
+		:tabindex="disableMenu ? '-1' : '0'"
+		:aria-label="avatarAriaLabel"
+		:role="disableMenu ? '' : 'button'"
+		v-on="!disableMenu ? { click: toggleMenu } : {}"
+		@keydown.enter="toggleMenu">
 		<!-- Avatar icon or image -->
 		<div v-if="iconClass" :class="iconClass" class="avatar-class-icon" />
 		<img v-else-if="isAvatarLoaded && !userDoesNotExist"
@@ -98,6 +102,7 @@ import PopoverMenu from '../PopoverMenu'
 import Tooltip from '../../directives/Tooltip'
 import usernameToColor from '../../functions/usernameToColor'
 import { userStatus } from '../../mixins'
+import { t } from '../../l10n'
 import Popover from '../Popover/Popover'
 
 const browserStorage = getBuilder('nextcloud').persist().build()
@@ -257,6 +262,11 @@ export default {
 			type: String,
 			default: 'body',
 		},
+
+		ariaLabel: {
+			type: String,
+			default: null,
+		},
 	},
 	data() {
 		return {
@@ -271,6 +281,14 @@ export default {
 		}
 	},
 	computed: {
+		avatarAriaLabel() {
+			if (this.ariaLabel !== null) {
+				return this.ariaLabel
+			}
+
+			return t('Avatar of {displayName}', { displayName: this.displayName || this.userId })
+		},
+
 		canDisplayUserStatus() {
 			return this.showUserStatus
 				&& this.hasStatus


### PR DESCRIPTION
Fixes https://github.com/nextcloud/nextcloud-vue/issues/613

This makes the avatar component focussable with the keyboard and also hitting the enter key will open the menu.
However the menu is not navigable and I'm not sure if we want to reimplement arrow navigation there.

- [x] multiple menus can be open with keyboard as enter doesn't re-close the other menus => solved
- [x] impossible to navigate menu entries with keyboard => tabs

Also, I heard that there will be a revamp of that popover, so the interaction in that popover would be different