### PR TITLE
Fix ListItemIcon listeners

### DIFF
--- a/src/components/ListItemIcon/ListItemIcon.vue
+++ b/src/components/ListItemIcon/ListItemIcon.vue
@@ -57,7 +57,10 @@ It might be used for list rendering or within the multiselect for example
 </docs>
 
 <template>
-	<span :id="id" class="option" :style="cssVars">
+	<span :id="id"
+		class="option"
+		:style="cssVars"
+		v-on="$listeners">
 		<Avatar
 			v-bind="$attrs"
 			:disable-menu="true"


### PR DESCRIPTION
Needed to make sure the events listeners we apply to the parent are forwarded

You can test on the docs, on master, adding a `@click=` does not work.
Here, it does :)
```vue
<template>
	<ListItemIcon title="User 1" @click="alert" />
</template>

<script>
export default {
	methods: {
		alert() {
			alert(...arguments)
		}
	}
}
</script>
```
