### PR TITLE
Allow to append datepicker to body

### DIFF
--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -81,7 +81,7 @@ export default {
 		:formatter="formatter"
 		:type="type"
 		:value="value"
-		:append-to-body="false"
+		:append-to-body="appendToBody"
 		v-bind="$attrs"
 		v-on="$listeners"
 		@select-year="handleSelectYear"
@@ -152,6 +152,11 @@ export default {
 			default() {
 				return new Date()
 			},
+		},
+
+		appendToBody: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -31,18 +31,22 @@ $cell_height: 32px;
 			color: var(--color-text-lighter);
 		}
 	}
+}
 
-	// Datepicker popup wrapper
-	.mx-datepicker-main {
-		color: var(--color-main-text);
-		border: 1px solid var(--color-border);
-		background-color: var(--color-main-background);
-		font-family: var(--font-face) !important;
-		line-height: 1.5;
+// Datepicker popup wrapper
+.mx-datepicker-main {
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	background-color: var(--color-main-background);
+	font-family: var(--font-face) !important;
+	line-height: 1.5;
+
+	svg {
+		fill: var(--color-main-text);
 	}
 
-	.mx-datepicker-popup {
-		z-index: 1000;
+	&.mx-datepicker-popup {
+		z-index: 2000;
 		box-shadow: none;
 
 		.mx-datepicker-sidebar + .mx-datepicker-content {


### PR DESCRIPTION
This is the trivial but imperfect fix for #998. We allow to attach the datepicker to body instead of the parent DOM element, so that the datepicker is not cropped by the AppSidebar.

The good thing about this solution is that the probability of breaking anything is quite low, since the default behaviour is unchanged (the change to the CSS is only necessary, because the datepicker attached to body has no `.mx-datepicker` container anymore).

The bad thing is, that the datepicker will scroll with body when attached to it (but it re-opens at the right position):

![datepicker](https://user-images.githubusercontent.com/2496460/116056189-c9b2e780-a67d-11eb-94ae-727539babdae.gif)

I have a more sophisticated solution in #1881 which solves the scrolling problem and works very nicely, but it requires changes to AppSidebar and to the datepicker library we use. I will provide a separate PR for it.