### PR TITLE
Fix alignment of md icons in single action

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -700,7 +700,7 @@ export default {
 		border-radius: $clickable-area / 2;
 		background-color: transparent;
 	}
-	
+
 	.material-design-icon {
 		width: $clickable-area;
 		height: $clickable-area;

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -701,7 +701,7 @@ export default {
 		background-color: transparent;
 	}
 
-	.material-design-icon {
+	&::v-deep .material-design-icon {
 		width: $clickable-area;
 		height: $clickable-area;
 		opacity: $opacity_full;

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -700,6 +700,16 @@ export default {
 		border-radius: $clickable-area / 2;
 		background-color: transparent;
 	}
+	
+	.material-design-icon {
+		width: $clickable-area;
+		height: $clickable-area;
+		opacity: $opacity_full;
+
+		.material-design-icon__svg {
+			vertical-align: middle;
+		}
+	}
 
 	// icon-more
 	&__menutoggle {


### PR DESCRIPTION
This fixes the alignment of the material design icon in a single action.

Before:
<img width="668" alt="Screenshot_2021-04-27 Nextcloud Vue Style Guide" src="https://user-images.githubusercontent.com/2496460/116228209-4369d480-a755-11eb-8544-f434282129c4.png">

After:
<img width="676" alt="After" src="https://user-images.githubusercontent.com/2496460/116228200-3fd64d80-a755-11eb-9599-5827a793bd45.png">


Closes #1884.