### PR TITLE
Replace AppNavigationCounter with CounterBubble

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -64,9 +64,9 @@ Just nest the counter into `<AppNavigationItem>` and add `slot="counter"` to it.
 
 ```
 <AppNavigationItem title="Item with counter" icon="icon-folder">
-	<AppNavigationCounter slot="counter">
+	<CounterBubble slot="counter">
 		99+
-	</AppNavigationCounter>
+	</CounterBubble>
 </AppNavigationItem>
 ```
 

--- a/src/components/CounterBubble/CounterBubble.vue
+++ b/src/components/CounterBubble/CounterBubble.vue
@@ -20,37 +20,34 @@
  -
  -->
 
-<docs>
+ <docs>
 
 ### Normal Counter
 
 ```
-<AppNavigationCounter>314+</AppNavigationCounter>
+<CounterBubble>314+</CounterBubble>
 ```
 
 ### Highlighted Counter (i.e. mentions)
 
 ```
-<AppNavigationCounter :highlighted="true">@admin</AppNavigationCounter>
-<AppNavigationCounter :highlighted="true">314+</AppNavigationCounter>
+<CounterBubble :highlighted="true">@admin</CounterBubble>
+<CounterBubble :highlighted="true">314+</CounterBubble>
 ```
 
 </docs>
 
 <template>
-	<div :class="{ 'app-navigation-entry__counter--highlighted': highlighted }"
-		class="app-navigation-entry__counter">
+	<div :class="{ 'counter-bubble__counter--highlighted': highlighted }"
+		class="counter-bubble__counter">
 		<slot />
 	</div>
 </template>
 
 <script>
 
-/**
- * @deprecated use [CounterBubble](#/Components/CounterBubble) instead
- */
 export default {
-	name: 'AppNavigationCounter',
+	name: 'CounterBubble',
 
 	props: {
 		highlighted: {
@@ -63,7 +60,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.app-navigation-entry__counter {
+.counter-bubble__counter {
 	font-size: calc(var(--default-font-size) * .8);
 	overflow: hidden;
 	width: fit-content;

--- a/src/components/CounterBubble/index.js
+++ b/src/components/CounterBubble/index.js
@@ -1,0 +1,25 @@
+/**
+ * @copyright Copyright (c) 2021 Vincent Petry <vincent@nextcloud.com>
+ *
+ * @author Vincent Petry <vincent@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import CounterBubble from './CounterBubble'
+
+export default CounterBubble

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -30,7 +30,7 @@
 		:counter-number="44"
 		:counter-highlighted="true">
 		<template #icon>
-			<avatar size="44" user="janedoe" display-name="Jane Doe" />
+			<avatar :size="44" user="janedoe" display-name="Jane Doe" />
 		</template>
 		<template #subtitle>
 			In this slot you can put both text and other components such as icons
@@ -54,7 +54,7 @@
 		:title="'Title of the element'"
 		:bold="false">
 		<template #icon>
-			<avatar size="44" user="janedoe" display-name="Jane Doe" />
+			<avatar :size="44" user="janedoe" display-name="Jane Doe" />
 		</template>
 		<template #subtitle>
 			In this slot you can put both text and other components such as icons
@@ -79,7 +79,7 @@
 		:bold="false"
 		:details="'One hour ago'">
 		<template #icon>
-			<avatar size="44" user="janedoe" display-name="Jane Doe" />
+			<avatar :size="44" user="janedoe" display-name="Jane Doe" />
 		</template>
 		<template #subtitle>
 			In this slot you can put both text and other components such as icons

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -35,9 +35,9 @@
 		<template #subtitle>
 			In this slot you can put both text and other components such as icons
 		</template>
-		<AppNavigationCounter #counter>
+		<CounterBubble #counter>
 			7
-		</AppNavigationCounter>
+		</CounterBubble>
 		<template #actions>
 			<ActionButton>
 				Button one
@@ -59,9 +59,9 @@
 		<template #subtitle>
 			In this slot you can put both text and other components such as icons
 		</template>
-		<AppNavigationCounter #counter>
+		<CounterBubble #counter>
 			7
-		</AppNavigationCounter>
+		</CounterBubble>
 		<template #actions>
 			<ActionButton>
 				Button one
@@ -84,9 +84,9 @@
 		<template #subtitle>
 			In this slot you can put both text and other components such as icons
 		</template>
-		<AppNavigationCounter #counter>
+		<CounterBubble #counter>
 			7
-		</AppNavigationCounter>
+		</CounterBubble>
 	</listItem>
 </ul>
 
@@ -145,11 +145,11 @@
 
 							<!-- Counter -->
 							<span v-if="!displayActions" class="line-two__counter">
-								<AppNavigationCounter
+								<CounterBubble
 									v-if="counterNumber != 0"
 									:highlighted="counterHighlighted">
 									{{ counterNumber }}
-								</AppNavigationCounter>
+								</CounterBubble>
 							</span>
 						</div>
 					</div>
@@ -182,14 +182,14 @@
 
 <script>
 import Actions from '../Actions'
-import AppNavigationCounter from '../AppNavigationCounter'
+import CounterBubble from '../CounterBubble'
 
 export default {
 	name: 'ListItem',
 
 	components: {
 		Actions,
-		AppNavigationCounter,
+		CounterBubble,
 	},
 
 	props: {
@@ -268,7 +268,7 @@ export default {
 
 		/**
 		 * If different from from 0 this component will display the
-		 * AppNavigationCounter component
+		 * CounterBubble component
 		 */
 		 counterNumber: {
 			 type: [Number, String],

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -54,6 +54,7 @@ import Breadcrumbs from './Breadcrumbs'
 import CheckboxRadio from './CheckboxRadio'
 import ColorPicker from './ColorPicker'
 import Content from './Content'
+import CounterBubble from './CounterBubble'
 import DatetimePicker from './DatetimePicker'
 import EmptyContent from './EmptyContent'
 import ListItem from './ListItem'
@@ -100,6 +101,7 @@ export {
 	CheckboxRadio,
 	ColorPicker,
 	Content,
+	CounterBubble,
 	DatetimePicker,
 	EmptyContent,
 	ListItem,


### PR DESCRIPTION
Because we need a more generic bubble, like in this example:
![image](https://user-images.githubusercontent.com/277525/116516181-92d31080-a8cd-11eb-974e-e6d870645d01.png)
This is from https://github.com/nextcloud/spreed/pull/5534

Keep the old file to not break existing imports.

I've tested it with some local Talk code that is using AppNavigationCounter and it properly redirects the component.

The only issue I see is that the style guide doesn't show the deprecation notice and replaces the component with the name:
![image](https://user-images.githubusercontent.com/277525/116535795-742c4400-a8e4-11eb-8e92-5da19446dd43.png)

