### PR TITLE
Fix appnavigationitem layout

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -156,7 +156,10 @@ Just set the `pinned` prop.
 
 		<!-- Counter and Actions -->
 		<div v-if="hasUtils" class="app-navigation-entry__utils">
-			<slot name="counter" />
+			<div v-if="$slots.counter"
+				class="app-navigation-entry__counter-wrapper">
+				<slot name="counter" />
+			</div>
 			<Actions menu-align="right"
 				:placement="menuPlacement"
 				:open="menuOpen"
@@ -448,6 +451,7 @@ export default {
 	box-sizing: border-box;
 	width: 100%;
 	min-height: $clickable-area;
+	padding: 4px;
 
 	// When .active class is applied, change color background of link and utils. The
 	// !important prevents the focus state to override the active state.
@@ -582,11 +586,12 @@ export default {
 	display: flex;
 	align-items: center;
 	flex: 0 1 auto;
-	// visually balance the menu so it's not
-	// stuck to the scrollbar
-	.action-item {
-		margin-right: 2px;
-	}
+}
+
+/* counter */
+.app-navigation-entry__counter-wrapper {
+	// Add slightly more space to the right of the counter
+	margin-right: 2px;
 }
 
 // STATES


### PR DESCRIPTION
Fix #1868 and adds 4px padding on top and bottom too so that the actions hover circle doesn't intersect with the boundary of the element

![Screenshot from 2021-04-29 12-31-39](https://user-images.githubusercontent.com/26852655/116556421-54e9e280-a8f5-11eb-83a4-701edc22b3e6.png)
![Screenshot from 2021-04-29 12-31-58](https://user-images.githubusercontent.com/26852655/116556432-56b3a600-a8f5-11eb-9d29-17d4d9056ea2.png)

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>