### PR TITLE
Remove AppNavigationItem flex order for AppNavigationCaption

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -447,7 +447,6 @@ export default {
 	display: flex;
 	flex-shrink: 0;
 	flex-wrap: wrap;
-	order: 1;
 	box-sizing: border-box;
 	width: 100%;
 	min-height: $clickable-area;


### PR DESCRIPTION
This was a trick to differentiate the pinned to the non-pinned entries, but other elements does not have this `pinned` order feature (like the AppNavigationCaption), and therefore gets stuck all in the top.

![image](https://user-images.githubusercontent.com/14975046/116847362-ad1d2f00-abea-11eb-8dbd-621ac5965b9e.png)
