### PR TITLE
Fix datepicker overflow when week numbers are shown

### DIFF
--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -82,6 +82,8 @@ export default {
 		:type="type"
 		:value="value"
 		:append-to-body="appendToBody"
+		:show-week-number="showWeekNumber"
+		:popup-class="{ 'show-week-number': showWeekNumber }"
 		v-bind="$attrs"
 		v-on="$listeners"
 		@select-year="handleSelectYear"
@@ -155,6 +157,11 @@ export default {
 		},
 
 		appendToBody: {
+			type: Boolean,
+			default: false,
+		},
+
+		showWeekNumber: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -53,6 +53,10 @@ $cell_height: 32px;
 			border-left: 1px solid var(--color-border);
 		}
 	}
+	
+	&.show-week-number .mx-calendar {
+		width: $cell_height * 8  + 2 * 5px; // week number + 7 days + padding
+	}
 
 	.mx-datepicker-header {
 		border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
This PR fixes the width of the datepicker when `show-week-number` is `true`.

<img width="634" alt="weeknumber" src="https://user-images.githubusercontent.com/2496460/117004440-5d239280-ace6-11eb-90d6-ad9ba5c41cd1.png">

Closes #1014.