### PR TITLE
Correctly align md icon in ActionRouter component

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -88,7 +88,7 @@
 			background-repeat: no-repeat;
 		}
 
-		.material-design-icon {
+		&::v-deep .material-design-icon {
 			width: $clickable-area;
 			height: $clickable-area;
 			opacity: $opacity_full;


### PR DESCRIPTION
This fixes the alignment of the icon slot of the ActionRouter component in case the `router-link` renders to an `a` tag.

Before:
![Screenshot_2021-05-05 Inventar - Nextcloud](https://user-images.githubusercontent.com/2496460/117109967-bc84af80-ad85-11eb-8df3-77948f073214.png)


After:
![Screenshot_2021-05-05 Inventar - Nextcloud(1)](https://user-images.githubusercontent.com/2496460/117109951-b989bf00-ad85-11eb-82bb-09b84f06676e.png)
