### PR TITLE
Wrap icon span in icon slot for ActionButton

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -85,12 +85,12 @@ export default {
 			:aria-label="ariaLabel"
 			:class="{ focusable: isFocusable }"
 			@click="onClick">
-			<span :class="[isIconUrl ? 'action-button__icon--url' : icon]"
-				:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-				class="action-button__icon">
-				<!-- @slot Manually provide icon -->
-				<slot name="icon" />
-			</span>
+			<!-- @slot Manually provide icon -->
+			<slot name="icon">
+				<span :class="[isIconUrl ? 'action-button__icon--url' : icon]"
+					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
+					class="action-button__icon" />
+			</slot>
 
 			<!-- long text with title -->
 			<p v-if="title">


### PR DESCRIPTION
This moves the icon span into the icon slot for the `ActionButton` component. This aligns it with the other Actions ~and prevents setting a background icon *and* providing an material design icon via slot.~ Nevermind, I just realized you can still provide a material design icon *and* have an icon set at the background.

But at least, this PR aligns it with how the other Action components handle it.

Closes #1925