### PR TITLE
Prevent overflow of action-link in Firefox

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -54,6 +54,7 @@
 		margin: 0;
 		padding: 0;
 		padding-right: $icon-margin;
+		box-sizing: border-box; // otherwise router-link overflows in Firefox
 
 		cursor: pointer;
 		white-space: nowrap;


### PR DESCRIPTION
This prevents the ActionLink component from overflowing the dropdown menu in Firefox, which caused a scrollbar if the Actions were close to the viewport edge.

Before:
<img width="117" alt="Before" src="https://user-images.githubusercontent.com/2496460/117347915-e8995100-aea9-11eb-9a5f-c2f9615596f6.png">

After:
<img width="208" alt="After" src="https://user-images.githubusercontent.com/2496460/117347930-ec2cd800-aea9-11eb-896d-63a03d91da50.png">

Closes #1887.