### PR TITLE
Allow material design icon in breadcrumb

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -43,6 +43,7 @@ This component is meant to be used inside a Breadcrumbs component.
 			v-if="title || icon"
 			:to="to"
 			:href="href">
+			<!-- @slot Slot for passing a material design icon. Precedes the icon and title prop. -->
 			<slot name="icon">
 				<span v-if="icon" :class="icon" class="icon" />
 				<span v-else>{{ title }}</span>

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -43,8 +43,10 @@ This component is meant to be used inside a Breadcrumbs component.
 			v-if="title || icon"
 			:to="to"
 			:href="href">
-			<span v-if="icon" :class="icon" class="icon" />
-			<span v-else>{{ title }}</span>
+			<slot name="icon">
+				<span v-if="icon" :class="icon" class="icon" />
+				<span v-else>{{ title }}</span>
+			</slot>
 		</element>
 		<Actions ref="actions"
 			:force-menu="forceMenu"

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -35,7 +35,12 @@ is dropped on a creadcrumb.
 	<div>
 		<div class="container">
 			<Breadcrumbs @dropped="dropped">
-				<Breadcrumb title="Home" href="/" @dropped="droppedOnCrumb" />
+				<Breadcrumb title="Home" href="/" @dropped="droppedOnCrumb">
+					<Folder
+						slot="icon"
+						:size="24"
+						decorative />
+				</Breadcrumb>
 				<Breadcrumb title="Folder 1" href="/Folder 1" />
 				<Breadcrumb title="Folder 2" href="/Folder 1/Folder 2" :disable-drop="true" />
 				<Breadcrumb title="Folder 3" href="/Folder 1/Folder 2/Folder 3" />
@@ -55,7 +60,12 @@ is dropped on a creadcrumb.
 </template>
 
 <script>
+import Folder from 'vue-material-design-icons/Folder'
+
 export default {
+	components: {
+		Folder,
+	},
 	methods: {
 		dropped(e, path) {
 			alert('Global drop on ' + path)


### PR DESCRIPTION
This PR adds support for a material design icon in the breadcrumb bar.

![Screenshot_2021-05-07 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/117418159-65b0de80-af1b-11eb-8ed0-17e7f264b906.png)


Closes #1928.