### PR TITLE
Fix user bubble when username contains a space

### DIFF
--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -80,6 +80,19 @@ export default {
 						status: 'away',
 					},
 					subline: 'Visiting London',
+				},
+				'Test 03': {
+					icon: 'icon-user',
+					id: 'Test 03',
+					label: 'Test 03',
+					source: 'users',
+					status: {
+						clearAt: null,
+						icon: '🎡',
+						message: 'Having space in my name',
+						status: 'in space',
+					},
+					subline: 'Visiting London',
 				}
 			}
 		}

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -32,7 +32,7 @@ const MENTION_START = '(?:^|\\s)'
 // Anything that is not text or end-of-line. Non-capturing group
 const MENTION_END = '(?:[^a-z]|$)'
 export const USERID_REGEX = new RegExp(`${MENTION_START}(@[a-zA-Z0-9_.@\\-']+)(${MENTION_END})`, 'gi')
-export const USERID_REGEX_WITH_SPACE = new RegExp(`${MENTION_START}(@"[a-zA-Z0-9 _.@\\-']+")(${MENTION_END})`, 'gi')
+export const USERID_REGEX_WITH_SPACE = new RegExp(`${MENTION_START}(@&quot;[a-zA-Z0-9 _.@\\-']+&quot;)(${MENTION_END})`, 'gi')
 
 export default {
 	props: {
@@ -74,8 +74,7 @@ export default {
 					}
 
 					// Extracting the id, nuking the " and @
-					const id = part.replace(/[@"]/gi, '')
-
+					const id = part.replace(/@|&quot;/gi, '')
 					// Compiling template and prepend with the space we removed during the split
 					return ' ' + this.genSelectTemplate(id)
 				})


### PR DESCRIPTION
The user bubble is broken when there is a space in the username.

This was due to the parsed value being sanitized before applying regexp on it.

I simply changed the regexp to match `&quot;` instead of `"`.

This should fix: https://github.com/nextcloud/server/issues/26861

Before | After
-- | --
![Screenshot from 2021-05-11 18-44-02](https://user-images.githubusercontent.com/6653109/117853868-31c21a00-b289-11eb-80c0-4df4bd80ef36.png) | ![Screenshot from 2021-05-11 18-45-17](https://user-images.githubusercontent.com/6653109/117853861-2ff85680-b289-11eb-98a9-20d54178003c.png)





