### PR TITLE
Fix md icon size in ActionInput

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -270,6 +270,16 @@ $input-margin: 4px;
 
 	font-weight: normal;
 
+	&::v-deep .material-design-icon {
+		width: $clickable-area;
+		height: $clickable-area;
+		opacity: $opacity_full;
+
+		.material-design-icon__svg {
+			vertical-align: middle;
+		}
+	}
+
 	// do not change the opacity of the datepicker
 	&:not(.action-input--picker) {
 		opacity: $opacity_normal;


### PR DESCRIPTION
This fixes the size of the material design icon in the ActionInput component.

Before:
![Screenshot_2021-05-17 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/118546085-c16b3b00-b757-11eb-8d46-2bc585bbd392.png)

After:
![Screenshot_2021-05-17 Nextcloud Vue Style Guide(1)](https://user-images.githubusercontent.com/2496460/118546697-99300c00-b758-11eb-8319-3dde2a054443.png)
