### PR TITLE
Fix first and last action input padding

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -409,12 +409,12 @@ $input-margin: 4px;
 // add the same bottomMargin as the right padding
 // for visual balance
 li:last-child > .action-input {
-	margin-bottom: $icon-margin - $input-margin;
+	padding-bottom: $icon-margin - $input-margin;
 }
 
 // same for first item
 li:first-child > .action-input {
-	margin-top: $icon-margin - $input-margin;
+	padding-top: $icon-margin - $input-margin;
 }
 
 </style>


### PR DESCRIPTION
This fixes the padding of the ActionInput in case it is the first or last entry. The currently set margin lead to a gap between the popover arrow and the input element.

Before:
![Screenshot_2021-05-17 Nextcloud Vue Style Guide(2)](https://user-images.githubusercontent.com/2496460/118547136-3c812100-b759-11eb-84ac-88dbfbffadfc.png)

After:
![Screenshot_2021-05-17 Nextcloud Vue Style Guide(3)](https://user-images.githubusercontent.com/2496460/118548543-b6fe7080-b75a-11eb-8b19-ec9d6c5aeb2d.png)

In case one switches from ActionButton to ActionInput like it happens in Calendar, this will still lead to a "jumping" of the popover menu, since the ActionButton has a different height than the ActionInput with the additional padding (see https://github.com/nextcloud/calendar/pull/3016). But the gap is not there anymore.

![actioninput](https://user-images.githubusercontent.com/2496460/118549122-53287780-b75b-11eb-8bba-6954bc52a935.gif)


On a side note: I would say the additional padding is not really necessary (or at least to high). But since this is supposed to be a bug fix PR, I didn't remove it, but instead made it work properly 😉. @jancborchardt maybe to check if this is really what it is supposed to look like.