### PR TITLE
Delay all tooltips

### DIFF
--- a/src/directives/Tooltip/index.js
+++ b/src/directives/Tooltip/index.js
@@ -28,5 +28,6 @@ import './index.scss'
 // issues and the use of !important
 VTooltip.options.defaultTemplate = `<div class="vue-tooltip" role="tooltip" data-v-${SCOPE_VERSION}><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>`
 VTooltip.options.defaultHtml = false
+VTooltip.options.defaultDelay = { show: 500, hide: 200 }
 
 export default VTooltip


### PR DESCRIPTION
Adds a slight delay to our tooltips, which at the moment appear immediately upon hovering elements.
Didn´t manage to capture the pointer in the gif, but you can get a sense of the timing of it by looking at the mouseover feedback

![GIF 5-26-2021 5-06-57 PM](https://user-images.githubusercontent.com/26852655/119694497-2c49ff80-be45-11eb-8b7f-3f992c29c3d9.gif)

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>