### PR TITLE
AppNavigationItem: hide utils if edit mode is active

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -155,7 +155,7 @@ Just set the `pinned` prop.
 		</div>
 
 		<!-- Counter and Actions -->
-		<div v-if="hasUtils" class="app-navigation-entry__utils">
+		<div v-if="hasUtils && !editingActive" class="app-navigation-entry__utils">
 			<div v-if="$slots.counter"
 				class="app-navigation-entry__counter-wrapper">
 				<slot name="counter" />


### PR DESCRIPTION
If there are other actions or a counter in an AppNavigationItem and the edit mode is activated, the close button was not accessible:

![Screenshot](https://user-images.githubusercontent.com/6277619/120239154-f7cbae80-c25d-11eb-9e2f-9e1a0f599355.png)
