### PR TITLE
Ensure the closed event is dispatched in AppSidebar 

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -397,6 +397,11 @@ export default {
 		},
 	},
 
+	beforeDestroy() {
+		// Make sure that the 'closed' event is dispatched even if this element is destroyed before the 'after-leave' event is received.
+		this.$emit('closed')
+	},
+
 	methods: {
 		onBeforeEnter(element) {
 			/**


### PR DESCRIPTION
When the sidebar is animated with a v-if, the closed `event` will not be received by the parent's event listeners as the `AppSidebar` is destroyed before the end of the transition.

This PR adds a `beforeDestroy` hook in `AppSidebar` to emit the `closed` event before the destruction.