### PR TITLE
Fix alignment of loading spinner in avatar menu

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -619,15 +619,17 @@ export default {
 			top: 0;
 			left: 0;
 		}
-		.icon-more {
+		.icon-more, .icon-loading {
 			display: flex;
 			align-items: center;
 			justify-content: center;
 			width: var(--size);
 			height: var(--size);
 			cursor: pointer;
-			opacity: 0;
 			background: none;
+		}
+		.icon-more {
+			opacity: 0;
 		}
 		&:focus,
 		&:hover {


### PR DESCRIPTION
Adjusts position of loading spinner to be the same as the three dots
icon.
This also indirectly fixes the location where the menu will appear which
was shifted before this fix.

This is a **regression** that was introduced in master/4.0.0

For https://github.com/nextcloud/spreed/issues/5492

Screenshots from testing in the Talk app:

Before:
<img width="179" alt="image" src="https://user-images.githubusercontent.com/277525/120449680-f39fae00-c38f-11eb-9a57-fc61ee44c720.png">
(randomly shifted due to spinner position)

After:
<img width="154" alt="image" src="https://user-images.githubusercontent.com/277525/120449225-8855dc00-c38f-11eb-9b77-2c85c4927391.png">

