### PR TITLE
Fix flex order of AppNavigationCaption

### DIFF
--- a/src/components/AppNavigationCaption/AppNavigationCaption.vue
+++ b/src/components/AppNavigationCaption/AppNavigationCaption.vue
@@ -57,7 +57,6 @@ export default {
 .app-navigation-caption {
 	display: flex;
 	justify-content: space-between;
-	flex-direction: row-reverse;
 	padding: 0 8px 0 $clickable-area/2;
 
 	&__title {
@@ -69,7 +68,6 @@ export default {
 		text-overflow: ellipsis;
 		opacity: $opacity_normal;
 		box-shadow: none !important;
-		order: 1;
 		flex-shrink: 0;
 	}
 


### PR DESCRIPTION
```vue
<AppNavigationCaption
	title="Your caption goes here" />
```

| Before | After |
|:---------:|:------:|
|![image](https://user-images.githubusercontent.com/14975046/121481093-12bfc080-c9cc-11eb-8d10-38ddb258c26d.png)|![image](https://user-images.githubusercontent.com/14975046/121480983-f4f25b80-c9cb-11eb-8a9e-d66675e28fc8.png)|