### PR TITLE
Safely check the global appName and handle its inexistence

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -172,11 +172,10 @@ export default {
 		/**
 		 * Specify the config key for the pane config sizes
 		 * Default is the global var appName if you use the webpack-vue-config
-		 * Otherwise it will be undefined and you will have to provide one
 		 */
 		paneConfigKey: {
 			type: String,
-			default: appName,
+			default: '',
 		},
 
 		/**
@@ -203,8 +202,21 @@ export default {
 
 	computed: {
 		paneConfigID() {
-			// Using the webpack-vue-config, appName is a global variable
-			return `pane-list-size-${this.paneConfigKey}`
+			// If provided, let's use it
+			if (this.paneConfigKey !== '') {
+				return `pane-list-size-${this.paneConfigKey}`
+			}
+
+			try {
+				// Using the webpack-vue-config, appName is a global variable
+				// This will throw a ReferenceError when the global variable is missing
+				// In that case either you provide paneConfigKey or else it fallback
+				// to a global storage key
+				return `pane-list-size-${appName}`
+			} catch (e) {
+				console.info('[INFO] AppContent:', 'falling back to global nextcloud pane config')
+				return 'pane-list-size-nextcloud'
+			}
 		},
 
 		detailsPaneSize() {


### PR DESCRIPTION
Variable is set -> default is used, developers *can* overwrite the prop value
Variable is not set -> prop become required

Right now you can't use the AppContent without the global variable, because the code that sets the default is always evaluated and will throw a ReferenceError before the developer can even specify their own value. Ref https://github.com/nextcloud/mail/pull/5165#issuecomment-858724634.

Then we can avoid hacks like https://github.com/nextcloud/spreed/commit/c6627446672379bf1913ffe898df460d1776b4af

The code is untested because neither @GretaD nor I can build this library at the moment.