### PR TITLE
Fix AppContent mobile display

### DIFF
--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -332,18 +332,18 @@ export default {
 .app-content-wrapper--mobile {
 	&.app-content-wrapper--show-list ::v-deep {
 		.app-content-list {
-			display: initial !important;
+			display: block;
 		}
 		.app-content-details {
-			display: none !important;
+			display: none;
 		}
 	}
 	&.app-content-wrapper--show-details ::v-deep {
 		.app-content-list {
-			display: none !important;
+			display: none;
 		}
 		.app-content-details {
-			display: initial !important;
+			display: block;
 		}
 	}
 }


### PR DESCRIPTION
Initial somehow fallback to `inline`, For proper sizing and people using virtual scrollers, let's go back to traditional `block`
Also, because this is a high-level scoped selector, !important is not needed and will allow apps to override this if needed :shrug: 

Fixes contacts + circles