### PR TITLE
Fix videoplayer controls in viewer

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -728,7 +728,8 @@ $header-size: 50px;
 		.prev,
 		.next {
 			position: absolute;
-			width: 10%;
+			width: 8%;
+			height: 35vw;
 		}
 		.prev {
 			left: 0;
@@ -744,8 +745,9 @@ $header-size: 50px;
 		}
 		.prev,
 		.next {
-			width: 10%;
+			width: 8%;
 			min-width: $clickable-area;
+			height: 35vw;
 		}
 	}
 }


### PR DESCRIPTION
In some aspect ratios the videoplayer controls are hidden behind the prev and next divs. This PR makes sure that the videoplayer controls are always usable.

## Before
https://user-images.githubusercontent.com/42591237/125089325-973a5780-e0ce-11eb-8671-de043990f7bc.mp4

## After
https://user-images.githubusercontent.com/42591237/125089347-9acdde80-e0ce-11eb-82a6-ca2f5228e5c9.mp4

Signed-off-by: szaimen <szaimen@e.mail.de>