### PR TITLE
Transpile calendar-js

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -139,6 +139,7 @@ module.exports = {
 				loader: 'babel-loader',
 				exclude: BabelLoaderExcludeNodeModulesExcept([
 					'tributejs',
+					'calendar-js',
 				]),
 			},
 			{


### PR DESCRIPTION
Calendar-js is not transpiled by default and needs to be transpiled manually in every package that depends on it.