### PR TITLE
Set default slideshowdelay to 5000 ms

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -271,7 +271,7 @@ export default {
 		 */
 		slideshowDelay: {
 			type: Number,
-			default: 3000,
+			default: 5000,
 		},
 		/**
 		 * Allow to pause an ongoing slideshow


### PR DESCRIPTION
3000 ms is a bit short for most images, imho. Hence I propose increasing it to 5000 ms.

Signed-off-by: szaimen <szaimen@e.mail.de>