### PR TITLE
Add a hint about the tooltip directive

### DIFF
--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -24,6 +24,7 @@
 ### General description
 
 This component displays contenteditable div with automated @ autocompletion [at].
+Note you need to register the [tooltip directive](https://nextcloud-vue-components.netlify.app/#/Directives) in your entry file.
 
 ### Examples
 


### PR DESCRIPTION
Otherwise the error is shown in the console:
```
[Vue warn]: Failed to resolve directive: tooltip

(found in <RichContenteditable>)
```