### PR TITLE
Check that userId is defined before querying

### DIFF
--- a/src/mixins/userStatus.js
+++ b/src/mixins/userStatus.js
@@ -43,6 +43,9 @@ export default {
 		 * @returns {Promise<void>}
 		 */
 		async fetchUserStatus(userId) {
+			if (!userId) {
+				return
+			}
 			const capabilities = getCapabilities()
 			if (!Object.prototype.hasOwnProperty.call(capabilities, 'user_status') || !capabilities.user_status.enabled) {
 				return


### PR DESCRIPTION
We have to check that the userId is defined before we run a request.

Closes #2155.