### PR TITLE
Allow material design icons for appnavigationitem

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -38,6 +38,9 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
+msgid "Edit item"
+msgstr ""
+
 msgid "External documentation for {title}"
 msgstr ""
 
@@ -123,6 +126,9 @@ msgid "Type to search time zone"
 msgstr ""
 
 msgid "Unable to search the group"
+msgstr ""
+
+msgid "Undo changes"
 msgstr ""
 
 msgid "Write message, @ to mention someone …"

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -168,10 +168,27 @@ Just set the `pinned` prop.
 				:force-menu="forceMenu"
 				:default-icon="menuIcon"
 				@update:open="onMenuToggle">
-				<ActionButton v-if="editable && !editingActive" icon="icon-rename" @click="handleEdit">
+				<template #icon>
+					<!-- @slot Slot for the custom menu icon -->
+					<slot name="menu-icon" />
+				</template>
+				<ActionButton
+					v-if="editable && !editingActive"
+					:aria-label="editButtonAriaLabel"
+					@click="handleEdit">
+					<template #icon>
+						<Pencil :size="20" decorative />
+					</template>
 					{{ editLabel }}
 				</ActionButton>
-				<ActionButton v-if="undo" icon="app-navigation-entry__deleted-button icon-history" @click="handleUndo" />
+				<ActionButton
+					v-if="undo"
+					:aria-label="undoButtonAriaLabel"
+					@click="handleUndo">
+					<template #icon>
+						<Undo :size="20" decorative />
+					</template>
+				</ActionButton>
 				<slot name="actions" />
 			</Actions>
 		</div>
@@ -194,6 +211,10 @@ import ActionButton from '../ActionButton/ActionButton'
 import AppNavigationIconCollapsible from './AppNavigationIconCollapsible'
 import isMobile from '../../mixins/isMobile'
 import InputConfirmCancel from './InputConfirmCancel'
+import { t } from '../../l10n'
+
+import Pencil from 'vue-material-design-icons/Pencil'
+import Undo from 'vue-material-design-icons/Undo'
 
 export default {
 	name: 'AppNavigationItem',
@@ -203,6 +224,8 @@ export default {
 		ActionButton,
 		AppNavigationIconCollapsible,
 		InputConfirmCancel,
+		Pencil,
+		Undo,
 	},
 	directives: {
 		ClickOutside,
@@ -394,6 +417,12 @@ export default {
 		},
 		isActive() {
 			return this.to && this.$route === this.to
+		},
+		editButtonAriaLabel() {
+			return this.editLabel ? this.editLabel : t('Edit item')
+		},
+		undoButtonAriaLabel() {
+			return t('Undo changes')
 		},
 	},
 	watch: {

--- a/src/components/AppNavigationSettings/AppNavigationSettings.vue
+++ b/src/components/AppNavigationSettings/AppNavigationSettings.vue
@@ -46,7 +46,7 @@ import { directive as ClickOutside } from 'v-click-outside'
 import { t } from '../../l10n'
 import { excludeClickOutsideClasses } from '../../mixins'
 
-import Cog from 'vue-material-design-icons/Cog.vue'
+import Cog from 'vue-material-design-icons/Cog'
 
 export default {
 	directives: {

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -46,7 +46,7 @@ include a standard-header like it's used by the files app.
 	</AppSidebar>
 </template>
 <script>
-	import Cog from 'vue-material-design-icons/Cog.vue'
+	import Cog from 'vue-material-design-icons/Cog'
 
 	export default {
 		components: {
@@ -273,8 +273,8 @@ import EmptyContent from '../EmptyContent/EmptyContent'
 import { t } from '../../l10n'
 import { directive as ClickOutside } from 'v-click-outside'
 
-import Close from 'vue-material-design-icons/Close.vue'
-import Star from 'vue-material-design-icons/Star.vue'
+import Close from 'vue-material-design-icons/Close'
+import Star from 'vue-material-design-icons/Star'
 
 export default {
 	name: 'AppSidebar',


### PR DESCRIPTION
This allows material design icons for the AppNavigationItem menu and replaces the ActionButton icons with md icons as well.
Closes #2198.

| | Before | After |
|-|-|-|
| Custom Icon |![Screenshot 2021-09-07 at 22-24-16 Week 36 of 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/2496460/132406460-355871fe-950c-418c-9724-955c31ee520e.png)|![Screenshot 2021-09-07 at 22-24-42 Week 36 of 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/2496460/132406469-c5f1fb71-4950-4b33-a1ee-ed8b6b511f02.png)|
| Editable |![Screenshot 2021-09-07 at 22-27-35 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/132406589-e2f6b251-ac87-406d-afa8-6954767a8467.png)|![Screenshot 2021-09-17 at 21-20-51 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/133842983-1adbdaa7-7c71-4aa8-9c5e-34b3159193ea.png)|
| Undo |![Screenshot 2021-09-07 at 22-27-42 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/132406629-d26bf556-98ae-4a10-8545-bfc157317c62.png)|![Screenshot 2021-09-17 at 21-21-14 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/133842888-53960900-2e5d-4300-a998-7acd2254a2b2.png)|
