### PR TITLE
Make timestamp of unread msg not bold

### DIFF
--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -500,6 +500,7 @@ export default {
 	&__details {
 		color: var(--color-text-lighter);
 		margin: 0 8px;
+		font-weight: normal;
 	}
 }
 


### PR DESCRIPTION
fixes: https://github.com/nextcloud/mail/issues/5484

before
![timebold](https://user-images.githubusercontent.com/12728974/132568201-4b420a98-4f2b-49da-bd53-37c24bcd1308.png)
after
![timenotbold](https://user-images.githubusercontent.com/12728974/132568207-0ec4eb72-3d75-441e-b7e6-89ec5543289f.png)
