### PR TITLE
Disable actions when the only action is disabeld

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -141,7 +141,7 @@ export default {
 			[firstActionClass]: firstActionClass }"
 		class="action-item action-item--single"
 		rel="noreferrer noopener"
-		:disabled="disabled"
+		:disabled="isDisabled"
 		@focus="onFocus"
 		@blur="onBlur"
 		@[firstActionEventBinding]="execFirstAction">
@@ -385,6 +385,10 @@ export default {
 		isValidSingleAction() {
 			return this.actions.length === 1
 				&& this.firstActionElement !== null
+		},
+		isDisabled() {
+			return this.disabled
+				|| (this.actions.length === 1 && this.firstAction?.$props?.disabled)
 		},
 		/**
 		 * First action vnode


### PR DESCRIPTION
If there is only one Action and it is disabled, the whole Actions component gets disabled now. Before, the Action would still be enabled.

After:
<img width="671" alt="disabled-button" src="https://user-images.githubusercontent.com/2496460/132579029-60d5f8e6-a416-4605-a8dd-a1c8f23fed5f.png">

Before:
<img width="680" alt="ActionDisabled" src="https://user-images.githubusercontent.com/2496460/116807395-57d21680-ab33-11eb-8c02-7bf406246a11.png">

Closes #1904.