### PR TITLE
Do not duplicate character in Highlight directive, only highlight first match occurence

### DIFF
--- a/src/utils/FindRanges.js
+++ b/src/utils/FindRanges.js
@@ -38,7 +38,7 @@ const FindRanges = (text, search) => {
 		currentIndex = index + search.length
 		ranges.push({ start: index, end: currentIndex })
 
-		index = text.toLowerCase().indexOf(search.toLowerCase(), index + 1)
+		index = text.toLowerCase().indexOf(search.toLowerCase(), currentIndex)
 		i++
 	}
 	return ranges

--- a/tests/unit/components/Highlight/Highlight.spec.js
+++ b/tests/unit/components/Highlight/Highlight.spec.js
@@ -1,0 +1,140 @@
+/**
+ * @copyright Copyright (c) 2021 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { mount } from '@vue/test-utils'
+import Highlight from '../../../../src/components/Highlight/Highlight.vue'
+
+describe('Highlight.vue', () => {
+	'use strict'
+
+	describe('validate given ranges', () => {
+		it('should ensure ranges are well formed (start before end)', () => {
+			const wrapper = mount(Highlight, {
+				propsData: {
+					text: 'Highlight me',
+					search: 'me',
+					highlight: [
+						{ start: 3, end: 1},
+						{ start: 5, end: 7},
+					]
+				},
+			})
+
+			expect(wrapper.vm.ranges).toEqual([
+				{start: 1, end: 3},
+				{start: 5, end: 7},
+			])
+		})
+
+		it('should discard ranges completely out of bound', () => {
+			const wrapper = mount(Highlight, {
+				propsData: {
+					text: 'Highlight me',
+					search: 'me',
+					highlight: [
+						{ start: -10, end: -2 },
+						{ start: 1, end: 3 },
+						{ start: 5, end: 7 },
+						{ start: 20, end: 25 },
+					]
+				},
+			})
+
+			expect(wrapper.vm.ranges).toEqual([
+				{start: 1, end: 3},
+				{start: 5, end: 7},
+			])
+		})
+
+		it('should limit ranges to the string length', () => {
+			const wrapper = mount(Highlight, {
+				propsData: {
+					text: 'Highlight me',
+					search: 'me',
+					highlight: [
+						{ start: -10, end: -2 },
+						{ start: -2, end: 1 },
+						{ start: 3, end: 3 },
+						{ start: 5, end: 7 },
+						{ start: 10, end: 25 },
+						{ start: 20, end: 25 },
+					]
+				},
+			})
+
+			expect(wrapper.vm.ranges).toEqual([
+				{start: 0, end: 1},
+				{start: 3, end: 3},
+				{start: 5, end: 7},
+				{start: 10, end: 12},
+			])
+		})
+
+		it('should sort ranges ascendingly', () => {
+			const wrapper = mount(Highlight, {
+				propsData: {
+					text: 'Highlight me',
+					search: 'me',
+					highlight: [
+						{ start: -10, end: -2 },
+						{ start: -2, end: 1 },
+						{ start: 20, end: 25 },
+						{ start: 10, end: 25 },
+						{ start: 5, end: 7 },
+						{ start: 3, end: 3 },
+					]
+				},
+			})
+
+			expect(wrapper.vm.ranges).toEqual([
+				{start: 0, end: 1},
+				{start: 3, end: 3},
+				{start: 5, end: 7},
+				{start: 10, end: 12},
+			])
+		})
+
+		it('should merge overlapping or adjacent ranges', () => {
+			const wrapper = mount(Highlight, {
+				propsData: {
+					text: 'Highlight me',
+					search: 'me',
+					highlight: [
+						{ start: -2, end: 1 },
+						{ start: 1, end: 3 },
+						{ start: 5, end: 7 },
+						{ start: 6, end: 25 },
+						{ start: 6, end: 25 },
+						{ start: 7, end: 9 },
+						{ start: 20, end: 25 },
+						{ start: -10, end: -2 },
+					]
+				},
+			})
+
+			expect(wrapper.vm.ranges).toEqual([
+				{start: 0, end: 3},
+				{start: 5, end: 12},
+			])
+		})
+	})
+})

--- a/tests/unit/utils/FindRanges.spec.js
+++ b/tests/unit/utils/FindRanges.spec.js
@@ -1,0 +1,69 @@
+/**
+ * @copyright Copyright (c) 2021 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import FindRanges from '../../../src/utils/FindRanges'
+
+describe('FindRanges.js', () => {
+	'use strict'
+
+	describe('find matching ranges', () => {
+		it('should find the matching range', () => {
+			const ranges = FindRanges('ananas', 'anan')
+
+			expect(ranges).toEqual([
+				{start: 0, end: 4},
+			])
+		})
+
+		it('should find all non-overlapping ranges', () => {
+			const ranges1 = FindRanges('ananas', 'an')
+
+			expect(ranges1).toEqual([
+				{start: 0, end: 2},
+				{start: 2, end: 4},
+			])
+
+			const ranges2 = FindRanges('ananas', 'a')
+
+			expect(ranges2).toEqual([
+				{start: 0, end: 1},
+				{start: 2, end: 3},
+				{start: 4, end: 5},
+			])
+		})
+
+		it('should only find first occurence of overlapping ranges', () => {
+			const ranges1 = FindRanges('ananas', 'ana')
+
+			expect(ranges1).toEqual([
+				{start: 0, end: 3},
+			])
+
+			const ranges2 = FindRanges('oooo', 'oo')
+
+			expect(ranges2).toEqual([
+				{start: 0, end: 2},
+				{start: 2, end: 4},
+			])
+		})
+	})
+})


### PR DESCRIPTION
This ensures that we do not duplicate characters in the Highlight component, even if the user supplies overlapping ranges. And that we only match the first occurence of overlapping matches when the user supplies a string to search for.

I also added some unit tests to check for the correct functioning.

After:
![after](https://user-images.githubusercontent.com/2496460/132829019-cffa01e5-ea9e-478d-9abb-2665c0e5bf23.png)

Before:
![before](https://user-images.githubusercontent.com/2496460/132829038-b89536ac-aac5-4254-990f-e4d6216a2952.png)

Closes #2191.