### PR TITLE
Don't rely on Vue.prototype.t and properly extract all strings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,8 +37,6 @@ import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 Some components require Nextcloud functionality to work, so it is currently recommended to extend Vue with the following:
 
 ```js static
-Vue.prototype.t = window.t
-Vue.prototype.n = window.n
 Vue.prototype.OC = window.OC
 Vue.prototype.OCA = window.OCA
 ```

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -29,6 +29,9 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+msgid "Close navigation"
+msgstr ""
+
 msgid "Confirm changes"
 msgstr ""
 
@@ -50,6 +53,9 @@ msgstr ""
 msgid "Global"
 msgstr ""
 
+msgid "Go back to the list"
+msgstr ""
+
 msgid "Message limit of {count} characters reached"
 msgstr ""
 
@@ -63,6 +69,9 @@ msgid "No results"
 msgstr ""
 
 msgid "Objects"
+msgstr ""
+
+msgid "Open navigation"
 msgstr ""
 
 msgid "Pause slideshow"

--- a/src/components/AppContent/AppDetailsToggle.vue
+++ b/src/components/AppContent/AppDetailsToggle.vue
@@ -27,15 +27,13 @@
 <script>
 import { emit } from '@nextcloud/event-bus'
 
-import l10n from '../../mixins/l10n'
+import { t } from '../../l10n'
 export default {
 	name: 'AppDetailsToggle',
 
-	mixins: [l10n],
-
 	computed: {
 		title() {
-			return this.t('Go back to the list')
+			return t('Go back to the list')
 		},
 	},
 

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -55,6 +55,8 @@
 	</div>
 </template>
 <script>
+import { t } from '../../l10n'
+
 import ArrowRight from 'vue-material-design-icons/ArrowRight'
 import Close from 'vue-material-design-icons/Close'
 

--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -40,7 +40,7 @@
 <script>
 import Actions from '../Actions/Actions'
 import ActionButton from '../ActionButton/ActionButton'
-import l10n from '../../mixins/l10n'
+import { t } from '../../l10n'
 
 import Menu from 'vue-material-design-icons/Menu'
 
@@ -53,8 +53,6 @@ export default {
 		Menu,
 	},
 
-	mixins: [l10n],
-
 	props: {
 		open: {
 			type: Boolean,
@@ -64,7 +62,7 @@ export default {
 
 	computed: {
 		label() {
-			return this.open ? this.t('Close navigation') : this.t('Open navigation')
+			return this.open ? t('Close navigation') : t('Open navigation')
 		},
 	},
 	methods: {

--- a/src/components/AppSettingsDialog/AppSettingsDialog.vue
+++ b/src/components/AppSettingsDialog/AppSettingsDialog.vue
@@ -54,6 +54,8 @@ export default {
 <script>
 import Modal from '../Modal'
 import isMobile from '../../mixins/isMobile'
+import { t } from '../../l10n'
+
 import debounce from 'debounce'
 
 export default {

--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -150,6 +150,8 @@ import DatePicker from 'vue2-datepicker'
 import Popover from '../Popover/index'
 import TimezonePicker from '../TimezonePicker'
 
+import l10n from '../../mixins/l10n'
+
 export default {
 	name: 'DatetimePicker',
 
@@ -158,6 +160,8 @@ export default {
 		Popover,
 		TimezonePicker,
 	},
+
+	mixins: [l10n],
 
 	inheritAttrs: false,
 

--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -148,7 +148,7 @@ import Tribute from 'tributejs/dist/tribute.esm'
 import debounce from 'debounce'
 import stringLength from 'string-length'
 
-import { t } from '../../l10n.js'
+import { t } from '../../l10n'
 import AutoCompleteResult from './AutoCompleteResult'
 import richEditor from '../../mixins/richEditor/index'
 

--- a/src/components/SettingsSelectGroup/SettingsSelectGroup.vue
+++ b/src/components/SettingsSelectGroup/SettingsSelectGroup.vue
@@ -48,6 +48,8 @@ import GenRandomId from '../../utils/GenRandomId'
 import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import l10n from '../../mixins/l10n'
+import { t } from '../../l10n'
+
 export default {
 	name: 'SettingsSelectGroup',
 	components: {

--- a/styleguide/global.requires.js
+++ b/styleguide/global.requires.js
@@ -86,9 +86,6 @@ window.OC = {
 window.OCA = {}
 window.appName = 'nextcloud-vue'
 
-window.t = (app, text) => text
-
-Vue.prototype.t = window.t
 Vue.prototype.OC = window.OC
 Vue.prototype.OCA = window.OCA
 


### PR DESCRIPTION
This removes the necessity to bind `window.t` to `Vue.prototype.t`. This makes using the components a bit less error prone on first usage and cleans up the Vue instance. The Netlify build still looks fine and e.g. the Calendar app works well.

We should furthermore not use `this.t(...)` (i.e. the `l10n` mixin) as it breaks the l10n extraction. The mixin is fine if we need `t` for the template though.

Closes #586.