### PR TITLE
Fix empty user bubble

### DIFF
--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -112,6 +112,7 @@ This component has the following slot:
 
 <script>
 import Popover from '../Popover'
+import UserBubbleDiv from './UserBubbleDiv'
 import Avatar from '../Avatar'
 
 export default {
@@ -119,6 +120,7 @@ export default {
 	components: {
 		Popover,
 		Avatar,
+		UserBubbleDiv,
 	},
 	props: {
 		/**
@@ -198,12 +200,14 @@ export default {
 		/**
 		 * If userbubble is empty, let's NOT
 		 * use the Popover component
-		 * @returns {string} 'Popover' or 'div'
+		 * We need a component instead of a simple div here,
+		 * because otherwise the trigger template will not be shown.
+		 * @returns {string} 'Popover' or 'UserBubbleDiv'
 		 */
 		isPopoverComponent() {
 			return !this.popoverEmpty
 				? 'Popover'
-				: 'div'
+				: 'UserBubbleDiv'
 		},
 
 		/**

--- a/src/components/UserBubble/UserBubbleDiv.vue
+++ b/src/components/UserBubble/UserBubbleDiv.vue
@@ -1,0 +1,32 @@
+<!--
+ - @copyright Copyright (c) 2021 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+<template>
+	<div>
+		<slot name="trigger" />
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'UserBubbleDiv',
+}
+</script>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -76,6 +76,7 @@ module.exports = {
 				'src/components/*Picker/*.vue',
 				'src/components/RichContenteditable/!(RichContenteditable).vue',
 				'src/components/Settings*/*.vue',
+				'src/components/UserBubble/UserBubbleDiv.vue',
 			],
 			sections: [
 				{


### PR DESCRIPTION
Fixes #2200. Supersedes #2234.

The problem was that we use a `div` in case the default slot is empty and then `<template #trigger>` is simply not rendered anymore.
I introduced a component which just renders a `div` as a wrapper for the #trigger slot in case the default slot is empty.

UserBubble without default slot on netlify:
![Screenshot 2021-09-13 at 22-25-02 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/133151458-85eb89d7-258e-449b-b833-b6b1412a3a1e.png)
