### PR TITLE
Revert "Bump linkifyjs from 2.1.9 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"emoji-mart-vue-fast": "^7.0.7",
 				"escape-html": "^1.0.3",
 				"hammerjs": "^2.0.8",
-				"linkifyjs": "~3.0.0",
+				"linkifyjs": "~2.1.9",
 				"md5": "^2.2.1",
 				"splitpanes": "^2.3.6",
 				"string-length": "^5.0.0",
@@ -22474,9 +22474,14 @@
 			"dev": true
 		},
 		"node_modules/linkifyjs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.0.tgz",
-			"integrity": "sha512-pbaVEs7PMhRgrxKz44dkElP1A3wpd20L8BFhd0y1H8DcNaV3IPHdIVNu1LiBUZPf+5FJEwnIwudjI3yLqNyp1g=="
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
+			"integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
+			"peerDependencies": {
+				"jquery": ">= 1.11.0",
+				"react": ">= 0.14.0",
+				"react-dom": ">= 0.14.0"
+			}
 		},
 		"node_modules/listify": {
 			"version": "1.0.3",
@@ -24799,7 +24804,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -26674,7 +26678,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -27101,7 +27104,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -28899,7 +28901,6 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
 			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -52438,9 +52439,10 @@
 			"dev": true
 		},
 		"linkifyjs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.0.tgz",
-			"integrity": "sha512-pbaVEs7PMhRgrxKz44dkElP1A3wpd20L8BFhd0y1H8DcNaV3IPHdIVNu1LiBUZPf+5FJEwnIwudjI3yLqNyp1g=="
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
+			"integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
+			"requires": {}
 		},
 		"listify": {
 			"version": "1.0.3",
@@ -54292,8 +54294,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"devOptional": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -55782,7 +55783,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -56109,7 +56109,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -57487,7 +57486,6 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
 			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"emoji-mart-vue-fast": "^7.0.7",
 		"escape-html": "^1.0.3",
 		"hammerjs": "^2.0.8",
-		"linkifyjs": "~3.0.0",
+		"linkifyjs": "~2.1.9",
 		"md5": "^2.2.1",
 		"splitpanes": "^2.3.6",
 		"string-length": "^5.0.0",


### PR DESCRIPTION
Revert #2245 after accidental merge, adjustments need to be made due to breaking changes