### PR TITLE
Add nofollow to tell search engines that links are not endorsed

### DIFF
--- a/src/components/ActionLink/ActionLink.vue
+++ b/src/components/ActionLink/ActionLink.vue
@@ -41,7 +41,7 @@ This component is made to be used inside of the [Actions](#Actions) component sl
 			:aria-label="ariaLabel"
 			:target="target"
 			class="action-link focusable"
-			rel="noreferrer noopener"
+			rel="nofollow noreferrer noopener"
 			@click="onClick">
 
 			<!-- @slot Manually provide icon -->

--- a/src/components/ActionRouter/ActionRouter.vue
+++ b/src/components/ActionRouter/ActionRouter.vue
@@ -27,7 +27,7 @@
 			:exact="exact"
 			class="action-router focusable"
 			:aria-label="ariaLabel"
-			rel="noreferrer noopener"
+			rel="nofollow noreferrer noopener"
 			@click.native="onClick">
 			<!-- @slot Manually provide icon -->
 			<slot name="icon">

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -140,7 +140,7 @@ export default {
 			[firstAction.icon]: firstAction.icon,
 			[firstActionClass]: firstActionClass }"
 		class="action-item action-item--single"
-		rel="noreferrer noopener"
+		rel="nofollow noreferrer noopener"
 		:disabled="isDisabled"
 		@focus="onFocus"
 		@blur="onBlur"

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -28,7 +28,7 @@
 			:target="(item.target) ? item.target : '' "
 			:download="item.download"
 			class="focusable"
-			rel="noreferrer noopener"
+			rel="nofollow noreferrer noopener"
 			@click="action">
 			<span v-if="!iconIsUrl" :class="item.icon" />
 			<img v-else :src="item.icon">

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -68,7 +68,7 @@ export default {
 							target: '_blank',
 							className: 'external',
 							attributes: {
-								rel: 'noopener noreferrer',
+								rel: 'nofollow noopener noreferrer',
 							},
 						})
 					}


### PR DESCRIPTION
Links passed to components are not necessarily endorsed so this adds `nofollow` onto the existing `noopener noreferrer`

As detailed in https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types :)