### PR TITLE
Make ActionInput icon prop not required

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -132,7 +132,6 @@ export default {
 		icon: {
 			type: String,
 			default: '',
-			required: true,
 		},
 		/**
 		 * type attribute of the input field


### PR DESCRIPTION
The icon prop should not  be required, since we also have an icon slot.

Should be like for the other Actions:
https://github.com/nextcloud/nextcloud-vue/blob/1db42ea9d1ce104ca52ccb02255ea79cf938c874/src/mixins/actionText.js#L29-L35

Closes #2316.