### PR TITLE
Reduce size of status icons in Avatar component

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -669,8 +669,10 @@ export default {
 		position: absolute;
 		right: -4px;
 		bottom: -4px;
-		height: 18px;
-		width: 18px;
+		max-height: 18px;
+		max-width: 18px;
+		height: 40%;
+		width: 40%;
 		line-height: 15px;
 		font-size: var(--default-font-size);
 		border: 2px solid var(--color-main-background);


### PR DESCRIPTION
Now use 40% with of parent a max size of 18px. For talk participant bar
the size remains unchanged still 18px, but for the new avatar component
in the navbar the size is now 13px.

Before: 
![image](https://user-images.githubusercontent.com/23653902/137744109-f4f56597-d3e3-4deb-88d8-13ad5aa1fe88.png)


After:
![image](https://user-images.githubusercontent.com/23653902/137744036-620a9f59-7837-4cfb-8342-2103a36efece.png)

Fix https://github.com/nextcloud/server/issues/29353

Signed-off-by: Carl Schwan <carl@carlschwan.eu>