### PR TITLE
Fix the space between navigation icon and label

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -546,7 +546,6 @@ export default {
 			max-width: 100%;
 			white-space: nowrap;
 			text-overflow: ellipsis;
-			padding-left: 6px;
 		}
 
 		.editingContainer {
@@ -566,7 +565,8 @@ export default {
 		.app-navigation-entry {
 			display: inline-flex;
 			flex-wrap: wrap;
-			padding-left: $clickable-area - $icon-margin;
+			padding-left: $icon-size;
+			padding-right: 0;
 		}
 	}
 }

--- a/src/components/AppNavigationSettings/AppNavigationSettings.vue
+++ b/src/components/AppNavigationSettings/AppNavigationSettings.vue
@@ -125,7 +125,6 @@ export default {
 				max-width: 100%;
 				white-space: nowrap;
 				text-overflow: ellipsis;
-				padding-left: 6px;
 			}
 		}
 	}


### PR DESCRIPTION
there's a lot of space between the icon and the label. On mail app that doesnt look good when we have more than one level submailbox. Even though we removed the option to add more than one level submailbox, the people who added more than one level before we removed it, have problem reading the name of their mailboxes. 

**before**
![beforeicon](https://user-images.githubusercontent.com/12728974/140324747-fbcc09e1-fa22-45b5-92c4-47e8780d73e8.png)


**after**
![folderlevel](https://user-images.githubusercontent.com/12728974/141108054-e5a1a7b1-0aa3-44b3-b85a-ce33dac72168.png)

