### PR TITLE
Remove whitespace from PopoverMenuItem when displaying emoji

### DIFF
--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -307,6 +307,7 @@ li {
 			* TODO: to remove */
 		> img {
 			width: $icon-size;
+			height: $icon-size;
 			margin: $icon-margin;
 		}
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/23653902/143223761-1f2bf352-8ad8-4dfc-8059-ec459caadbf1.png)


After:
![image](https://user-images.githubusercontent.com/23653902/143223287-5810ba45-174e-4397-ac0c-30a06bf543f3.png)

Signed-off-by: Carl Schwan <carl@carlschwan.eu>