### PR TITLE
Change background style target for tab icons

### DIFF
--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -345,13 +345,12 @@ export default {
 		height: 25px;
 		transition: opacity var(--animation-quick);
 		opacity: $opacity_normal;
-		background-position: center 8px;
-		background-size: 16px;
 
 		& > span {
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			background-size: 16px;
 		}
 	}
 


### PR DESCRIPTION
The style was applied to the containing element instead of the icon element.

Don't know why the `background-position: center 8px;` was needed, so I removed it. It was also shifting icons toward the bottom when applied to the icon.

Tested in `styleguide`.

Fix: https://github.com/nextcloud/activity/issues/669
Problem introduced here: https://github.com/nextcloud/nextcloud-vue/pull/1939