### PR TITLE
Add `buttonTitle` property to ActionButton and PopoverMenuItem

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -86,6 +86,7 @@ export default {
 			class="action-button"
 			:class="{ focusable: isFocusable }"
 			:aria-label="ariaLabel"
+			:title="buttonTitle"
 			type="button"
 			@click="onClick">
 			<!-- @slot Manually provide icon -->
@@ -140,6 +141,13 @@ export default {
 		disabled: {
 			type: Boolean,
 			default: false,
+		},
+		/**
+		 * Title (tooltip) for the button element.
+		 */
+		buttonTitle: {
+			type: String,
+			default: '',
 		},
 	},
 	computed: {

--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -82,6 +82,7 @@
 			class="menuitem focusable"
 			:class="{active: item.active}"
 			:disabled="item.disabled"
+			:title="item.buttonTitle"
 			type="button"
 			@click.stop.prevent="item.action">
 			<span :class="item.icon" />
@@ -135,6 +136,7 @@ export default {
 					href: 'https://nextcloud.com',
 					icon: 'icon-links',
 					text: 'Nextcloud',
+					buttonTitle: '',
 				}
 			},
 			// check the input types


### PR DESCRIPTION
The HTML button element supports the `title` property for tooltips.
Let's allow to set it in the ActionButton and PopoverMenuItem
components.

The name is `buttonTitle` instead of `title` because ActionButton
already has a `title` property with a different meaning and in
PopoverMenuItem elements other than button are supported. So let's be
explicit that this property is *only* for the `title` property of
`button` elements.