### PR TITLE
Automatically use Nextcloud translated months, days and years

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10637,15 +10637,6 @@
 				"url": "https://opencollective.com/browserslist"
 			}
 		},
-		"node_modules/browserslist/node_modules/caniuse-lite": {
-			"version": "1.0.30001236",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-			"integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
-		},
 		"node_modules/bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -11205,10 +11196,13 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001125",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
-			"integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
-			"dev": true
+			"version": "1.0.30001286",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
+			"integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
+			}
 		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
@@ -43057,13 +43051,6 @@
 				"electron-to-chromium": "^1.3.723",
 				"escalade": "^3.1.1",
 				"node-releases": "^1.1.71"
-			},
-			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001236",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-					"integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ=="
-				}
 			}
 		},
 		"bser": {
@@ -43497,10 +43484,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001125",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
-			"integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
-			"dev": true
+			"version": "1.0.30001286",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
+			"integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ=="
 		},
 		"caseless": {
 			"version": "0.12.0",


### PR DESCRIPTION
First step towards properly defined translations.

The only thing missing is translating nice strings in the input, for that we need to use the `formatter` prop with moment, so far this can be done in the app directly:

https://github.com/mengxiong10/vue2-datepicker/tree/v3.10.0#formatter
```js
formatter: {
    stringify: (date) => {
        return date ? moment(date).format('LL') : ''
    },
},
```

Supersede: https://github.com/nextcloud/nextcloud-vue/pull/146