### PR TITLE
Decrease padding right of AppNavigationCaption and ListItem to 4 px

### DIFF
--- a/src/components/AppNavigationCaption/AppNavigationCaption.vue
+++ b/src/components/AppNavigationCaption/AppNavigationCaption.vue
@@ -57,7 +57,7 @@ export default {
 .app-navigation-caption {
 	display: flex;
 	justify-content: space-between;
-	padding: 0 8px 0 $clickable-area/2;
+	padding: 0 4px 0 $clickable-area/2;
 
 	&__title {
 		font-weight: bold;

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -432,6 +432,7 @@ export default {
 	flex: 0 0 auto;
 	justify-content: flex-start;
 	padding: 8px;
+	padding-right: 4px;
 	border-radius: 16px;
 	margin: 2px 0;
 	width: 100%;


### PR DESCRIPTION
The right padding of `AppNavigationCaption` was to big, leading to a misalignment of the ActionMenus of `AppNavigationItem` and `AppNavigationCaption`. This PR adjusts the padding to the correct value, see
https://github.com/nextcloud/nextcloud-vue/blob/0173e9e9b14b12066415b0152eebfc67e32966ed/src/components/AppNavigationItem/AppNavigationItem.vue#L484

Before:
![Screenshot 2021-12-14 at 21-53-09 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/146077676-a3814678-51ed-4399-ae92-9196d109f54a.png)

After:
![Screenshot 2021-12-14 at 21-58-33 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/146078421-8f1e2a3c-10fc-42e0-a329-d3d9faa8d0e7.png)

