### PR TITLE
Increase padding right of AppNavigationItem to 8 px

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -481,7 +481,7 @@ export default {
 	box-sizing: border-box;
 	width: 100%;
 	min-height: $clickable-area;
-	padding-right: 4px;
+	padding-right: 8px;
 
 	// When .active class is applied, change color background of link and utils. The
 	// !important prevents the focus state to override the active state.


### PR DESCRIPTION
This is the alternative to #2406. We increase the padding-right of `AppNavigationItem` to 8 px here.

The result is the same, the `ActionsMenu`s of `AppNavigationItem`, `AppNavigationCaption` and `ListItem` are nicely aligned, they just all have a right-padding of 8 px here:
<img width="253" alt="8px" src="https://user-images.githubusercontent.com/2496460/146167782-3df8f9b4-31c6-4cbf-b242-7a810acc79d8.png">

Make your choice between #2406 and this one and approve the PR you like better 😉 
