### PR TITLE
Reduce top whitespace in the sidebar of text app on mobile

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -681,7 +681,7 @@ $top-buttons-spacing: 6px;
 		// header background
 		&__figure {
 			width: 100%;
-			height: 250px;
+			height: 20vh;
 			max-height: 250px;
 			background-repeat: no-repeat;
 			background-position: center;


### PR DESCRIPTION
Signed-off-by: Luka Trovic <luka@nextcloud.com>

Before the fix:
![image](https://user-images.githubusercontent.com/89908051/146325585-155fdf53-98d6-435d-8c0c-c5000916f4ca.png)

After the fix:
![image](https://user-images.githubusercontent.com/89908051/146325287-ae151b25-a913-4ad1-95f8-98205645abda.png)
