### PR TITLE
Fix dragging onto hidden crumbs

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -52,7 +52,8 @@ This component is meant to be used inside a Breadcrumbs component.
 		<Actions ref="actions"
 			:force-menu="forceMenu"
 			:open="open"
-			@update:open="onOpenChange">
+			@update:open="onOpenChange"
+			container=".vue-crumb--with-action.dropdown">
 			<!-- @slot All action elements passed into the default slot will be used -->
 			<slot />
 		</Actions>


### PR DESCRIPTION
This fixes dragging stuff onto crumbs that are hidden. Before the menu would immediately close after leaving the three-dots-menu, since the dropdown was attached to body, thus triggering the dragLeave handler when hovering over the dropdown.

I wanted to show a screencast, but peek doesn't work with Wayland anymore, so you gotta trust me with this one :wink:  :see_no_evil: