### PR TITLE
Use MD icon for hidden crumbs action button icons

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -104,6 +104,8 @@ import ValidateSlot from '../../utils/ValidateSlot'
 import Breadcrumb from '../Breadcrumb'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 
+import IconFolder from 'vue-material-design-icons/Folder'
+
 export default {
 	name: 'Breadcrumbs',
 	components: {
@@ -111,6 +113,7 @@ export default {
 		ActionRouter,
 		ActionLink,
 		Breadcrumb,
+		IconFolder,
 	},
 	props: {
 		/**
@@ -492,12 +495,17 @@ export default {
 					element = 'ActionRouter'
 					path = to
 				}
+				const folderIcon = createElement('IconFolder', {
+					props: {
+						size: 20,
+					},
+					slot: 'icon',
+				})
 				return createElement(element, {
 					class: 'crumb',
 					props: {
 						to,
 						href,
-						icon: 'icon-folder',
 					},
 					// Prevent the breadcrumbs from being draggable
 					attrs: {
@@ -512,7 +520,7 @@ export default {
 						dragleave: ($event) => this.dragLeave($event, disabled),
 					},
 				},
-				crumb.componentOptions.propsData.title
+				[crumb.componentOptions.propsData.title, folderIcon]
 				)
 			}))
 			)


### PR DESCRIPTION
This replaces the folder icons of the hidden crumbs actions dropdown with a material design icon.

Before:
![Screenshot 2021-12-21 at 12-12-10 Inventory - Nextcloud](https://user-images.githubusercontent.com/2496460/146920756-1327908a-18a4-46f0-a5cc-37df6b8a106b.png)

After:
![Screenshot 2021-12-21 at 12-10-42 Inventory - Nextcloud](https://user-images.githubusercontent.com/2496460/146920665-8c88a16a-cad3-49cd-a95d-def1af7bd972.png)

Part of fixing #2410.
