### PR TITLE
Allow custom action menu icon for breadcrumb

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -32,6 +32,7 @@ This component is meant to be used inside a Breadcrumbs component.
 	<div ref="crumb"
 		class="vue-crumb"
 		:class="{'vue-crumb--with-action': $slots.default, 'vue-crumb--hovered': hovering}"
+		:[crumbId]="''"
 		draggable="false"
 		@dragstart.prevent="() => {/** Prevent the breadcrumb from being draggable. */}"
 		@drop.prevent="dropped"
@@ -52,8 +53,12 @@ This component is meant to be used inside a Breadcrumbs component.
 		<Actions ref="actions"
 			:force-menu="forceMenu"
 			:open="open"
-			@update:open="onOpenChange"
-			container=".vue-crumb--with-action.dropdown">
+			:container="`.vue-crumb--with-action[${crumbId}]`"
+			@update:open="onOpenChange">
+			<template #icon>
+				<!-- @slot Slot for the custom menu icon -->
+				<slot name="menu-icon" />
+			</template>
 			<!-- @slot All action elements passed into the default slot will be used -->
 			<slot />
 		</Actions>
@@ -63,6 +68,7 @@ This component is meant to be used inside a Breadcrumbs component.
 
 <script>
 import Actions from '../Actions'
+import GenRandomId from '../../utils/GenRandomId'
 
 import ChevronRight from 'vue-material-design-icons/ChevronRight'
 
@@ -130,6 +136,11 @@ export default {
 			 * Variable to track if we hover over the breadcrumb
 			 */
 			hovering: false,
+			/**
+			 * The unique id of the breadcrumb. Necessary to append the
+			 * Actions menu to the correct crumb.
+			 */
+			crumbId: `crumb-id-${GenRandomId()}`,
 		}
 	},
 	computed: {

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -45,8 +45,20 @@ is dropped on a creadcrumb.
 				<Breadcrumb title="Folder 3" href="/Folder 1/Folder 2/Folder 3" />
 				<Breadcrumb title="Folder 4" href="/Folder 1/Folder 2/Folder 3/Folder 4" />
 				<Breadcrumb title="Folder 5" href="/Folder 1/Folder 2/Folder 3/Folder 4/Folder 5" :disable-drop="true">
-					<ActionButton icon="icon-share" @click="alert('Share')">
+					<template #menu-icon>
+						<MenuDown :size="20" />
+					</template>
+					<ActionButton @click="alert('Share')">
+						<template #icon>
+							<ShareVariant :size="20" />
+						</template>
 						Share
+					</ActionButton>
+					<ActionButton @click="alert('Download')">
+						<template #icon>
+							<Download :size="20" />
+						</template>
+						Download
 					</ActionButton>
 				</Breadcrumb>
 			</Breadcrumbs>
@@ -59,11 +71,17 @@ is dropped on a creadcrumb.
 </template>
 
 <script>
+import Download from 'vue-material-design-icons/Download'
 import Folder from 'vue-material-design-icons/Folder'
+import MenuDown from 'vue-material-design-icons/MenuDown'
+import ShareVariant from 'vue-material-design-icons/ShareVariant'
 
 export default {
 	components: {
+		Download,
 		Folder,
+		MenuDown,
+		ShareVariant,
 	},
 	methods: {
 		dropped(e, path) {


### PR DESCRIPTION
This PR implements to customize the menu icon for the `Actions` menu of each breadcrumb. We can now e.g. use `MenuDown` for the actions menu of the last breadcrumb. I adjusted the docs to demonstrate this:
![Screenshot 2021-12-21 at 20-55-39 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/146989992-5551945e-bad5-43ab-81e3-354628912810.png)
