### PR TITLE
Fix md icon position for Actions with title

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -724,8 +724,8 @@ export default {
 				height: 24px;
 				line-height: $icon-size;
 				position: absolute;
-				top: ($clickable-area - 24px) / 2;
-				left: ($clickable-area - 24px) / 2;
+				top: 0;
+				left: 0;
 			}
 		}
 


### PR DESCRIPTION
For Actions with menu-title showing a material design icon, the icon position was off.
Before:
![Screenshot 2022-01-04 at 13-55-57 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/148062336-3a4937b5-aff2-48fd-b571-6113bb2f596d.png)

After:
![Screenshot 2022-01-04 at 14-01-27 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/148063005-345617b9-9b31-48a0-8466-a41e50e0d1c1.png)

