### PR TITLE
Show menu title for single Action

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -138,7 +138,8 @@ export default {
 		v-bind="firstActionBinding"
 		:class="{
 			[firstAction.icon]: firstAction.icon,
-			[firstActionClass]: firstActionClass }"
+			[firstActionClass]: firstActionClass,
+			'action-item--single--with-title': singleActionTitle }"
 		class="action-item action-item--single"
 		rel="nofollow noreferrer noopener"
 		:disabled="isDisabled"
@@ -147,6 +148,8 @@ export default {
 		@[firstActionEventBinding]="execFirstAction">
 		<!-- Render the icon slot content of the first action -->
 		<VNodes :vnodes="firstActionIconSlot" />
+
+		{{ singleActionTitle }}
 
 		<!-- fake slot to gather main action -->
 		<span :aria-hidden="true" hidden>
@@ -274,6 +277,14 @@ export default {
 		},
 
 		/**
+		 * Force the title to show for single actions
+		 */
+		forceTitle: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Specify the menu title
 		 */
 		menuTitle: {
@@ -369,6 +380,13 @@ export default {
 		isValidSingleAction() {
 			return this.actions.length === 1
 				&& this.firstActionElement !== null
+		},
+		/**
+		 * Return the title of the single action if forced
+		 * @returns {string}
+		 */
+		singleActionTitle() {
+			return this.forceTitle ? this.menuTitle : ''
 		},
 		isDisabled() {
 			return this.disabled
@@ -683,27 +701,6 @@ export default {
 		border: none;
 		border-radius: $clickable-area / 2;
 		background-color: transparent;
-	}
-
-	&::v-deep .material-design-icon {
-		width: $clickable-area;
-		height: $clickable-area;
-		opacity: $opacity_full;
-
-		.material-design-icon__svg {
-			vertical-align: middle;
-		}
-	}
-
-	// icon-more
-	&__menutoggle {
-		// align menu icon in center
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		opacity: $opacity_normal;
-		font-weight: bold;
-		line-height: $icon-size;
 
 		&--with-title {
 			position: relative;
@@ -728,6 +725,27 @@ export default {
 				left: ($clickable-area - 24px) / 2;
 			}
 		}
+	}
+
+	&::v-deep .material-design-icon {
+		width: $clickable-area;
+		height: $clickable-area;
+		opacity: $opacity_full;
+
+		.material-design-icon__svg {
+			vertical-align: middle;
+		}
+	}
+
+	// icon-more
+	&__menutoggle {
+		// align menu icon in center
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: $opacity_normal;
+		font-weight: bold;
+		line-height: $icon-size;
 
 		&--primary {
 			opacity: $opacity_full;


### PR DESCRIPTION
This changes the behavior of the `Actions` component so that if a `menu-title` is provided, it can be shown for single Actions as well by setting the `forceTitle` prop to `true`. This is necessary for the changes to the Breadcrumbs component requested in #2416 so that the breadcrumb title of the last crumb is also shown if only a single Action is given. In case of multiple Actions, i.e. with a dropdown, or when `menu-title` or `force-title` is not set, nothing changes.

Before:
![Screenshot 2022-01-04 at 15-03-58 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/148070644-e433e383-40aa-4c2c-a638-86e809f97d57.png)

After:
![Screenshot 2022-01-05 at 09-19-20 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/148183972-0c597830-22ae-42e0-b36f-8f0561ed8626.png)

~@skjnldsv @nextcloud/vuejs In the current form this is a breaking change, since `menu-title` will be shown if it is set, which it was not before for single actions. Do you prefer that I keep the previous behavior and make showing the title for single actions optional by a new prop?~
Edit: I decided to make it a non-breaking change by adding a prop `force-title` to show the title for single actions if a title is given. Having an additional prop seems ok, instead of introducing a breaking change.