### PR TITLE
Add aria label to the ActionInput component

### DIFF
--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -82,6 +82,7 @@ For the multiselect component, all events will be passed through. Please see the
 						:value="value"
 						:placeholder="text"
 						:disabled="disabled"
+						:aria-label="ariaLabel"
 						v-bind="$attrs"
 						:class="{ focusable: isFocusable }"
 						class="action-input__input"
@@ -160,6 +161,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * aria-label attribute of the input field
+		 */
+		ariaLabel: String,
 	},
 
 	computed: {

--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -164,7 +164,10 @@ export default {
 		/**
 		 * aria-label attribute of the input field
 		 */
-		ariaLabel: String,
+		ariaLabel: {
+			type: String,
+			default: '',
+		},
 	},
 
 	computed: {


### PR DESCRIPTION
resolve https://github.com/nextcloud/calendar/issues/3932

ActionInput has been extended with attribute "aria-label"

Signed-off-by: julia.kirschenheuter <julia.kirschenheuter@nextcloud.com>