### PR TITLE
Allow Breadcrumbs "to" prop to be an object

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -93,7 +93,7 @@ export default {
 		 * If set, the breadcrumbs will be rendered by router-link.
 		 */
 		to: {
-			type: String,
+			type: [String, Object],
 			default: undefined,
 		},
 		/**


### PR DESCRIPTION
Matching the API https://v3.router.vuejs.org/api/#to