### PR TITLE
Fix shrinking of last breadcrumb for narrow width

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -296,8 +296,22 @@ export default {
 	// Adjust action item appearance for crumbs with actions
 	// to match other crumbs
 	&::v-deep .action-item {
+		// Adjustments necessary to correctly shrink on small screens
+		max-width: 100%;
+		.trigger {
+			max-width: 100%;
+		}
+
 		&__menutoggle--with-title,
 		&--single--with-title {
+			// Adjustments necessary to correctly shrink on small screens
+			max-width: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			width: 100%;
+			display: inline-block;
+
 			background-color: unset;
 			border: none;
 

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -584,9 +584,19 @@ export default {
 	flex-grow: 1;
 	display: inline-flex;
 
-	&--collapsed  .crumb:last-child {
+	&--collapsed  .vue-crumb:last-child {
 		min-width: 100px;
 		flex-shrink: 1;
+	}
+
+	& #{&}__crumbs {
+		flex-shrink: 1;
+		max-width: 100%;
+		/**
+		 * This value is given by the min-width of the last crumb (100px) plus
+		 * two times the width of a crumb with an icon (first crumb and hidden crumbs actions).
+		 */
+		min-width: 228px;
 	}
 
 	& #{&}__crumbs,


### PR DESCRIPTION
After the major changes to the breadcrumb bar in #2411 and #2444 the last breadcrumb does not shrink anymore on small screens. This PR fixes it.

| | Before | After |
| ------------- |:-------------:| -----:|
| Without Actions      | ![before_without](https://user-images.githubusercontent.com/2496460/153669608-15b372ce-46e7-4344-b3f8-176320bbe4d9.gif)  | ![after_without](https://user-images.githubusercontent.com/2496460/153670377-49c9a68b-ae9c-43af-80e4-a64a5b6dd109.gif) |
| With Actions      | ![before_with](https://user-images.githubusercontent.com/2496460/153669696-9c79b9e5-b68c-4818-85b4-50c547a9e44a.gif) | ![after_with](https://user-images.githubusercontent.com/2496460/153670440-355ff073-ff5b-4b0c-a862-988a1a459873.gif) |