### PR TITLE
Change appearance of the slot "icon" at AppNavigationItem

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -133,7 +133,7 @@ Just set the `pinned` prop.
 			<!-- never show the icon over the collapsible if mobile -->
 			<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
 				class="app-navigation-entry-icon">
-				<slot v-if="!loading" v-show="isIconShown" name="icon" />
+				<slot v-show="!loading && isIconShown" name="icon" />
 			</div>
 			<span v-if="!editingActive" class="app-navigation-entry__title" :title="title">
 				{{ title }}


### PR DESCRIPTION
change appearance of the slot "icon": instead of removing the icon-slot from DOM the icon-slot will be hidden. This is needed to keep the focus on the element inside of slot.

Required for https://github.com/nextcloud/calendar/pull/3960