### PR TITLE
fix: imports from emoji-mart-vue-fast

### DIFF
--- a/src/functions/emoji/emoji.js
+++ b/src/functions/emoji/emoji.js
@@ -21,8 +21,7 @@
  */
 
 import data from 'emoji-mart-vue-fast/data/all.json'
-import { EmojiIndex } from 'emoji-mart-vue-fast/src'
-import frequently from 'emoji-mart-vue-fast/src/utils/frequently'
+import { EmojiIndex, frequently } from 'emoji-mart-vue-fast'
 
 // export const allEmojis = index.buildIndex()
 


### PR DESCRIPTION
No need to import from src. These are exported fine in the dist.

Importing from src also caused issues in jest tests in the text app
as they do not transform the src import:
https://github.com/nextcloud/text/runs/5315732664?check_suite_focus=true#step:7:85