### PR TITLE
[MultiSelect] pass the #noResult slot to the underlying component

### DIFF
--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -215,7 +215,9 @@ export default {
 		</template>
 
 		<template #noResult>
-			<span>{{ t('No results') }}</span>
+			<slot name="noResult">
+				<span>{{ t('No results') }}</span>
+			</slot>
 		</template>
 	</VueMultiselect>
 </template>


### PR DESCRIPTION
Pretty much all the slots are passed down to Vue-Multiselect except `noResult` which is hardcoded. This is a naive way to pass it down and keep the default value if not defined. Maybe there's a more elegant way.