### PR TITLE
Fix error spam of icon only buttons part2

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -361,7 +361,7 @@ export default {
 
 	methods: {
 		getText() {
-			return this.$slots?.default[0]?.text ? this.$slots.default[0].text.trim() : null
+			return this.$slots?.default && this.$slots?.default[0]?.text ? this.$slots.default[0].text.trim() : null
 		},
 
 		/**


### PR DESCRIPTION
Was broken again by this suggestion:
https://github.com/nextcloud/nextcloud-vue/pull/2540#discussion_r821644569

I didn't notice it as npm link is broken with the vue lib and I seem to not have recompiled all levels