### PR TITLE
Add action menu with trigger per link

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -161,7 +161,8 @@ export default {
 	<!-- more than one action -->
 	<div v-else
 		v-show="hasMultipleActions || forceMenu"
-		:class="{'action-item--open': opened}"
+		:class="{'action-item--open': opened,
+			'action-item--title--with-trigger': useTitleAsActionTrigger,}"
 		class="action-item">
 		<!-- If more than one action, create a popovermenu -->
 		<Popover
@@ -169,35 +170,40 @@ export default {
 			:handle-resize="true"
 			:open.sync="opened"
 			:placement="placement"
+			class="action-item--popover"
 			:boundaries-element="boundariesElement"
 			:container="container"
+			trigger="click"
 			@show="openMenu"
 			@after-show="onOpen"
 			@hide="closeMenu">
 			<!-- Menu open/close trigger button -->
 			<template #trigger>
-				<button ref="menuButton"
-					:disabled="disabled"
-					class="icon action-item__menutoggle"
-					:class="{
-						[defaultIcon]: !iconSlotIsPopulated,
-						'action-item__menutoggle--with-title': menuTitle,
-						'action-item__menutoggle--with-icon-slot': iconSlotIsPopulated,
-						'action-item__menutoggle--default-icon': !iconSlotIsPopulated && defaultIcon === '',
-						'action-item__menutoggle--primary': primary
-					}"
-					aria-haspopup="true"
-					:aria-label="ariaLabel"
-					:aria-controls="randomId"
-					:aria-expanded="opened ? 'true' : 'false'"
-					test-attr="1"
-					type="button"
-					@focus="onFocus"
-					@blur="onBlur">
-					<slot v-if="iconSlotIsPopulated" name="icon" />
-					<DotsHorizontal v-else-if="defaultIcon === ''" :size="20" decorative />
-					{{ menuTitle }}
-				</button>
+				<slot name="trigger">
+					<button
+						ref="menuButton"
+						:disabled="disabled"
+						class="icon action-item__menutoggle"
+						:class="{
+							[defaultIcon]: !iconSlotIsPopulated,
+							'action-item__menutoggle--with-title': menuTitle,
+							'action-item__menutoggle--with-icon-slot': iconSlotIsPopulated,
+							'action-item__menutoggle--default-icon': !iconSlotIsPopulated && defaultIcon === '',
+							'action-item__menutoggle--primary': primary
+						}"
+						aria-haspopup="true"
+						:aria-label="ariaLabel"
+						:aria-controls="randomId"
+						:aria-expanded="opened ? 'true' : 'false'"
+						test-attr="1"
+						type="button"
+						@focus="onFocus"
+						@blur="onBlur">
+						<slot v-if="iconSlotIsPopulated" name="icon" />
+						<DotsHorizontal v-else-if="defaultIcon === ''" :size="20" decorative />
+						{{ menuTitle }}
+					</button>
+				</slot>
 			</template>
 
 			<!-- Menu content -->
@@ -346,6 +352,14 @@ export default {
 		 * Disabled state of the main button (single action or menu toggle)
 		 */
 		disabled: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Use title as popover trigger
+		 */
+		useTitleAsActionTrigger: {
 			type: Boolean,
 			default: false,
 		},
@@ -541,8 +555,8 @@ export default {
 			this.opened = false
 			this.focusIndex = 0
 
-			// focus back the menu button
-			this.$refs.menuButton.focus()
+			// focus back the menu button if one exists
+			this.$refs.menuButton?.focus()
 		},
 
 		onOpen(event) {
@@ -774,6 +788,16 @@ export default {
 		& > [hidden] {
 			display: none;
 		}
+	}
+
+	&--popover {
+		display: flex;
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	&--title--with-trigger {
+		width: 100%;
 	}
 }
 

--- a/src/components/AppNavigationItem/AppNavigationItemTitle.vue
+++ b/src/components/AppNavigationItem/AppNavigationItemTitle.vue
@@ -1,0 +1,110 @@
+<template>
+	<a
+		class="app-navigation-entry-link"
+		href="#"
+		:aria-description="ariaDescription"
+		@click="onClick">
+		<!-- icon if not collapsible -->
+		<!-- never show the icon over the collapsible if mobile -->
+		<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
+			class="app-navigation-entry-icon">
+			<slot />
+		</div>
+		<span v-if="!editingActive" class="app-navigation-entry__title" :title="title">
+			{{ title }}
+		</span>
+		<div v-if="editingActive" class="editingContainer">
+			<InputConfirmCancel
+				ref="editingInput"
+				:value="editingValue"
+				:placeholder="editPlaceholder !== '' ? editPlaceholder : title"
+				@input="$emit('input', $event)"
+				@cancel="$emit('cancel', false)"
+				@confirm="handleEditingDone" />
+		</div>
+	</a>
+</template>
+
+<script>
+import InputConfirmCancel from './InputConfirmCancel'
+
+export default {
+	name: 'AppNavigationItemTitle',
+	components: {
+		InputConfirmCancel,
+	},
+	props: {
+		/**
+		 * Displays a loading animated icon on the left of the element
+		 * instead of the icon.
+		 */
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * Refers to the icon on the left, this prop accepts a class
+		 * like 'icon-category-enabled'.
+		 */
+		icon: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Flag for icon on the left side
+		 */
+		isIconShown: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * Flag for editing process
+		 */
+		editingActive: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * The title of the element.
+		 */
+		title: {
+			type: String,
+			required: true,
+		},
+		/**
+		 * Only for items in 'editable' mode, sets the placeholder text for the editing form.
+		 */
+		editPlaceholder: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Value of the editing element
+		 */
+		editingValue: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Entry aria details
+		 */
+		ariaDescription: {
+			type: String,
+			default: null,
+		},
+
+	},
+	methods: {
+		handleEditingDone() {
+			this.$emit('update:title', this.editingValue)
+			this.$emit('update:editingValue', '')
+			this.$emit('update:editingActive', false)
+		},
+
+		// forward click event
+		onClick(event) {
+			this.$emit('click', event)
+		},
+	},
+}
+</script>


### PR DESCRIPTION
resolves #2543 
resolves https://github.com/nextcloud/calendar/issues/3965

Add slot "trigger" for Actions.vue to place menu inside of popover.
Add trigger="click" to Popover for correct listeners.
Add AppNavigationItemTitle.vue with link.
Add style changes for link menu.
Add documentation for menu with link for AppNavigationItem.vue.
