### PR TITLE
Only show actions if actions given for breadcrumbs

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -50,7 +50,8 @@ This component is meant to be used inside a Breadcrumbs component.
 				<span v-else>{{ title }}</span>
 			</slot>
 		</element>
-		<Actions ref="actions"
+		<Actions v-if="$slots.default"
+			ref="actions"
 			:force-menu="forceMenu"
 			:open="open"
 			:menu-title="title"


### PR DESCRIPTION
This is a minor cleanup of the breadcrumbs bar. The Actions menu is now only rendered if Actions are actually present. Before, they were just hidden.

This does not change any functionality or appearance, just cleans up the HTML code and probably renders a bit faster.