### PR TITLE
Debug iOS breadcrumbs issue

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -235,6 +235,7 @@ export default {
 
 .vue-crumb {
 	background-image: none;
+	background-color: blue;
 	display: inline-flex;
 	height: $clickable-area;
 	padding: 0;
@@ -278,6 +279,7 @@ export default {
 	}
 
 	> a {
+		background-color: red;
 		overflow: hidden;
 		color: var(--color-text-maxcontrast);
 		padding: 12px;
@@ -287,6 +289,7 @@ export default {
 		display: inline-flex;
 
 		> span {
+			background-color: green;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -590,8 +590,6 @@ export default {
 	}
 
 	& #{&}__crumbs {
-		flex-shrink: 1;
-		max-width: 100%;
 		/**
 		 * This value is given by the min-width of the last crumb (100px) plus
 		 * two times the width of a crumb with an icon (first crumb and hidden crumbs actions).


### PR DESCRIPTION
Do not merge this. :wink: 

This is just a debug PR to figure out why the breadcrumb on the right of the hidden breadcrumbs dropdown moves to the very right when opening the dropdown for the first time on iOS. Since I don't own a mac, I cannot debug this nicely with the webinspector and have to mess around like this :see_no_evil:

This is how it looks on iOS when opened:
![22-03-20 22-02-49 4146](https://user-images.githubusercontent.com/2496460/159185838-55c2bab0-472e-4d08-b85a-e8593ac5c93a.png)

If anyone can figure this out faster, please help :sweat_smile: 