### PR TITLE
Fix the ProgressBar display in the documentation

### DIFF
--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -24,13 +24,19 @@ This is a simple progress bar component.
 ## Usage:
 
 ### Small
+```vue
 <ProgressBar :value="60" />
+```
 
 ### Medium
+```vue
 <ProgressBar :value="60" size="medium" />
+```
 
 ### error
+```vue
 <ProgressBar :value="60" :error="true" />
+```
 
 </docs>
 


### PR DESCRIPTION
The ProgressBar component was not shown in the documentation.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/12123721/159475549-c2d0d289-8614-49b2-a0f4-33431b5842f4.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/12123721/159475461-a268e9a6-9ee6-4d85-b844-37ec451406f9.png)

</details>
