### PR TITLE
Improve SettingsInputText component

### DIFF
--- a/src/components/SettingsInputText/SettingsInputText.vue
+++ b/src/components/SettingsInputText/SettingsInputText.vue
@@ -20,6 +20,15 @@
   -
   -->
 
+<docs>
+
+```vue
+<SettingsInputText label="Label" hint="Hint" />
+<SettingsInputText label="Label" value="Value" hint="Hint" disabled />
+```
+
+</docs>
+
 <template>
 	<form ref="form"
 		:disabled="disabled"

--- a/src/components/SettingsInputText/SettingsInputText.vue
+++ b/src/components/SettingsInputText/SettingsInputText.vue
@@ -45,7 +45,6 @@
 				:value="submitTranslated"
 				type="submit"
 				class="action-input__submit">
-			<label v-show="!disabled" :for="idSubmit" class="action-input__label" />
 			<p v-if="hint" class="hint">
 				{{ hint }}
 			</p>
@@ -147,60 +146,15 @@ export default {
 
 <style lang="scss" scoped>
 
-	$input-margin: 4px;
-
 	.input-wrapper {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		flex-wrap: wrap;
 		width: 100%;
 		max-width: 400px;
-		&__form {
-			display: flex;
-			align-items: center;
-			flex: 1 1 auto;
 
-			margin: $input-margin 0;
-			padding-right: $icon-margin;
-		}
-
-		&__submit {
-			position: absolute;
-			left: -10000px;
-			top: auto;
-			width: 1px;
-			height: 1px;
-			overflow: hidden;
-		}
-
-		&__label {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-
-			width: #{$clickable-area - $input-margin * 2};
-			height: #{$clickable-area - $input-margin * 2};
-
-			cursor: pointer;
-
-			opacity: $opacity_full;
-			color: var(--color-text-lighter);
-			border: 1px solid var(--color-border-dark);
-			border-left-color: transparent;
-			border-radius: 0 var(--border-radius) var(--border-radius) 0;
-			/* Avoid background under border */
-			background-color: var(--color-main-background);
-			background-clip: padding-box;
-
-			font-size: $icon-size;
-		}
-
-		&__input[type=text] {
-			flex-grow: 1;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			overflow: hidden;
-			cursor: text;
+		& .action-input__label {
+			margin-right: 12px;
 		}
 
 		// if disabled, change cursor
@@ -210,6 +164,7 @@ export default {
 
 		.hint {
 			color: var(--color-text-lighter);
+			margin-left: 8px;
 		}
 	}
 


### PR DESCRIPTION
This PR improves the style of the `SettingsInputText` component (and to see what I'm doing, add examples to the documentation).

### Screenshots

#### Examples before

![Capture d’écran 2022-03-22 à 14 20 53](https://user-images.githubusercontent.com/12123721/159497798-cbc467ab-f091-4f68-b41b-3b7bacec5ad4.png)

#### Examples after

![Capture d’écran 2022-03-22 à 14 41 43](https://user-images.githubusercontent.com/12123721/159497811-ba45d93d-f49d-4574-a428-6a874e9dad0c.png)

### Note

While fixing the style, I removed some SCSS that seems unused (?)