### PR TITLE
Use large corner radius for the Popover component

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -120,7 +120,8 @@ $arrow-width: 10px;
 	&__inner {
 		padding: 0;
 		color: var(--color-main-text);
-		border-radius: var(--border-radius);
+		border-radius: var(--border-radius-large);
+		overflow: hidden;
 		background: var(--color-main-background);
 	}
 


### PR DESCRIPTION
This PR *tries* to takes a further step towards the standardization of border radii. Currently, border radii are not uniform. Among other things, buttons have a very high border-radius, while Popovers are only allowed a 3px border-radius, and lists have none.

In the current state of this PR, here are some examples:

| Before | After |
| --- | --- |
| ![check-1](https://user-images.githubusercontent.com/12123721/159508163-76da304c-cf1d-4282-b604-a33478683ca1.png) | ![check-2](https://user-images.githubusercontent.com/12123721/159508210-29b3747f-21a9-42e1-a124-05ba3ee7ffed.png) |
| ![menu-1](https://user-images.githubusercontent.com/12123721/159508280-2b7558d9-26d0-4df9-bce3-b58de3d3681a.png) | ![menu-2](https://user-images.githubusercontent.com/12123721/159508292-62382943-39a0-4213-8a81-e3ff5e1fecbe.png) |
| ![large-1](https://user-images.githubusercontent.com/12123721/159508343-397d0f8a-9208-4762-bfdb-a3dd41d4d6e7.png) | ![large-2](https://user-images.githubusercontent.com/12123721/159508367-566f3f04-1f5d-4d9b-ad61-fe72e6ba1215.png) |

Another example (done with devtools) of what it looks like in-app:

![Capture d’écran 2022-03-22 à 15 49 50](https://user-images.githubusercontent.com/12123721/159510142-f759a331-0ae1-4971-a488-536874053845.png)

In my opinion, it gives a more modern look to NextCloud.

To improve this PR, we *could* add some vertical padding, but this is open to discussion.