### PR TITLE
Increase padding of ColorPicker

### DIFF
--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -285,7 +285,7 @@ export default {
 	justify-content: space-between;
 	box-sizing: content-box !important;
 	width: 176px;
-	padding: 4px;
+	padding: 8px;
 	border-radius: 3px;
 	height: 196px;
 


### PR DESCRIPTION
Necessary since Popover component got border-radius. Otherwise it feels a bit tight

| Before | After |
| --- | --- |
| ![cp-before-](https://user-images.githubusercontent.com/12123721/159894498-d972ad43-0e5b-4208-b389-c39204531f2d.png) | ![cp-after-](https://user-images.githubusercontent.com/12123721/159894510-b31a2750-eb12-4feb-bb37-07201715b91e.png) |
| ![cp-before](https://user-images.githubusercontent.com/12123721/159894568-33d29508-3bc6-4cca-89c5-d0b4cf0b356e.png) | ![cp-after](https://user-images.githubusercontent.com/12123721/159894585-2cf12651-9ac0-4ddc-965b-d352b419dfa2.png) |
 