### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/Highlight/Highlight.vue
+++ b/src/components/Highlight/Highlight.vue
@@ -176,7 +176,7 @@ export default {
 					chunks.push({
 						...range,
 						highlight: true,
-						text: this.text.substr(range.start, range.end - range.start),
+						text: this.text.slice(range.start, range.end),
 					})
 					currentRange++
 					currentIndex = range.end
@@ -187,7 +187,7 @@ export default {
 							start: currentIndex,
 							end: this.text.length,
 							highlight: false,
-							text: this.text.substr(currentIndex, this.text.length - currentIndex),
+							text: this.text.slice(currentIndex),
 						})
 						// Set the current index so the while loop ends.
 						currentIndex = this.text.length
@@ -200,7 +200,7 @@ export default {
 					start: currentIndex,
 					end: range.start,
 					highlight: false,
-					text: this.text.substr(currentIndex, range.start - currentIndex),
+					text: this.text.slice(currentIndex, range.start),
 				})
 				currentIndex = range.start
 			}

--- a/src/components/Multiselect/EllipsisedOption.vue
+++ b/src/components/Multiselect/EllipsisedOption.vue
@@ -81,13 +81,13 @@ export default {
 		},
 		part1() {
 			if (this.needsTruncate) {
-				return this.name.substr(0, this.split)
+				return this.name.slice(0, this.split)
 			}
 			return this.name
 		},
 		part2() {
 			if (this.needsTruncate) {
-				return this.name.substr(this.split)
+				return this.name.slice(this.split)
 			}
 			return ''
 		},

--- a/src/utils/GenRandomId.js
+++ b/src/utils/GenRandomId.js
@@ -25,7 +25,7 @@ const GenRandomId = (length) => {
 	return Math.random()
 		.toString(36)
 		.replace(/[^a-z]+/g, '')
-		.substr(0, length || 5)
+		.slice(0, length || 5)
 }
 
 export default GenRandomId

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,7 +13,7 @@ const StyleLintPlugin = require('stylelint-webpack-plugin')
 // scope variable
 // fallback for cypress testing
 const appVersion = JSON.stringify(process.env.npm_package_version || 'nextcloud-vue')
-const versionHash = md5(appVersion).substr(0, 7)
+const versionHash = md5(appVersion).slice(0, 7)
 const SCOPE_VERSION = JSON.stringify(versionHash)
 
 console.info('This build version hash is', versionHash, '\n')
@@ -25,7 +25,7 @@ const translations = fs
 	.filter(name => name !== 'messages.pot' && name.endsWith('.pot'))
 	.map(file => {
 		const path = './l10n/' + file
-		const locale = file.substr(0, file.length - '.pot'.length)
+		const locale = file.slice(0, -'.pot'.length)
 
 		const po = fs.readFileSync(path)
 		const json = gettextParser.po.parse(po)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.