### PR TITLE
Fix tertiary buttons hover feedback

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -560,11 +560,12 @@ export default {
 
 	// Tertiary
 	&--vue-tertiary {
-		color: var(--color-text-lighter);
+		color: var(--color-main-text);
 		background-color: transparent;
+		opacity: .7;
 		&:hover {
-			color: var(--color-main-text);
 			background-color: transparent;
+			opacity: 1;
 		}
 	}
 


### PR DESCRIPTION
Add proper hover feedback to tertiary buttons whose icon aren't affected by the color css rule. e.g. emojis

https://user-images.githubusercontent.com/26852655/160430239-a1436f2d-9059-4b5d-821c-371f4d9bea41.mov


