### PR TITLE
Fix EmptyContent svg size

### DIFF
--- a/src/components/EmptyContent/EmptyContent.vue
+++ b/src/components/EmptyContent/EmptyContent.vue
@@ -106,7 +106,7 @@ export default {
 		background-position: center;
 		background-size: 64px;
 
-		svg {
+		::v-deep svg {
 			width: 64px;
 			height: 64px;
 		}


### PR DESCRIPTION
Used to work in 4.x.x, seems like the css scoping changed and/or got fixed.

| Before | After |
|:---------:|:------:|
|![Capture d’écran_2022-04-01_09-39-02](https://user-images.githubusercontent.com/14975046/161217763-08d8487f-1ae8-43d3-b5f9-66052c3bf004.png)|![Capture d’écran_2022-04-01_09-38-43](https://user-images.githubusercontent.com/14975046/161217748-e7d9d72c-33d4-4859-8014-4bf965969907.png)|