### PR TITLE
Ensure l10n check uses right node and npm version

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -9,10 +9,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v1
+      - name: Read package.json node and npm engines version
+        uses: skjnldsv/read-package-engines-version-actions@v1.2
+        id: versions
         with:
-          node-version: 14
+          fallbackNode: '^12'
+          fallbackNpm: '^6'
+
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Before the l10n check would run with npm 6 which is not what is specified in `package.json`.