### PR TITLE
Migrate to @fontsource/roboto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
 			},
 			"devDependencies": {
 				"@cypress/webpack-preprocessor": "5.11.1",
+				"@fontsource/roboto": "^4.5.5",
 				"@nextcloud/babel-config": "^1.0.0",
 				"@nextcloud/browserslist-config": "^2.1.0",
 				"@nextcloud/eslint-config": "^5.1.0",
@@ -59,7 +60,6 @@
 				"eslint-plugin-cypress": "^2.11.1",
 				"eslint-plugin-import": "^2.23.4",
 				"file-loader": "^6.0.0",
-				"fontsource-roboto": "^4.0.0",
 				"gettext-extractor": "^3.5.2",
 				"gettext-parser": "^5.0.0",
 				"glob": "^7.1.6",
@@ -5894,6 +5894,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/@fontsource/roboto": {
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.5.tgz",
+			"integrity": "sha512-Pe1p+gAO6K0aLxBXlLoJRHVx352tVc/v/7DOnvM3t+FYXb+KUga9aCD1NpnDfd0kKnWXqrZyAXguyyFWDDuphw==",
+			"dev": true
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.5.0",
@@ -16477,13 +16483,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/fontsource-roboto": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fontsource-roboto/-/fontsource-roboto-4.0.0.tgz",
-			"integrity": "sha512-zD6L8nvdWRcwSgp4ojxFchG+MPj8kXXQKDEAH9bfhbxy+lkpvpC1WgAK0lCa4dwobv+hvAe0uyHaawcgH7WH/g==",
-			"deprecated": "Package relocated. Please install and migrate to @fontsource/roboto.",
-			"dev": true
 		},
 		"node_modules/for-in": {
 			"version": "1.0.2",
@@ -39183,6 +39182,12 @@
 				}
 			}
 		},
+		"@fontsource/roboto": {
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.5.tgz",
+			"integrity": "sha512-Pe1p+gAO6K0aLxBXlLoJRHVx352tVc/v/7DOnvM3t+FYXb+KUga9aCD1NpnDfd0kKnWXqrZyAXguyyFWDDuphw==",
+			"dev": true
+		},
 		"@humanwhocodes/config-array": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -47664,12 +47669,6 @@
 			"version": "1.14.8",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
 			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
-		},
-		"fontsource-roboto": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fontsource-roboto/-/fontsource-roboto-4.0.0.tgz",
-			"integrity": "sha512-zD6L8nvdWRcwSgp4ojxFchG+MPj8kXXQKDEAH9bfhbxy+lkpvpC1WgAK0lCa4dwobv+hvAe0uyHaawcgH7WH/g==",
-			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 	},
 	"devDependencies": {
 		"@cypress/webpack-preprocessor": "5.11.1",
+		"@fontsource/roboto": "^4.5.5",
 		"@nextcloud/babel-config": "^1.0.0",
 		"@nextcloud/browserslist-config": "^2.1.0",
 		"@nextcloud/eslint-config": "^5.1.0",
@@ -90,7 +91,6 @@
 		"eslint-plugin-cypress": "^2.11.1",
 		"eslint-plugin-import": "^2.23.4",
 		"file-loader": "^6.0.0",
-		"fontsource-roboto": "^4.0.0",
 		"gettext-extractor": "^3.5.2",
 		"gettext-parser": "^5.0.0",
 		"glob": "^7.1.6",

--- a/tests/visual/components/AppSidebar/AppSidebarMixin.js
+++ b/tests/visual/components/AppSidebar/AppSidebarMixin.js
@@ -33,7 +33,7 @@ import icons from '../../../../styleguide/assets/icons.css'
 import variables from '../../../../styleguide/assets/variables.css'
 
 // Import font so CI has the same
-import font from 'fontsource-roboto'
+import font from '@fontsource/roboto'
 
 /**
  * Split the Appsidebar test in two for performances


### PR DESCRIPTION
This migrates to `@fontsource/roboto`. This does not bring any visual or functional changes, just updated the dependency to its new home.