### PR TITLE
Migrate to @vue/vue2-jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
 				"@nextcloud/eslint-config": "^5.1.0",
 				"@nextcloud/stylelint-config": "^1.0.0-beta.0",
 				"@vue/test-utils": "^1.0.4",
+				"@vue/vue2-jest": "^27.0.0-alpha.4",
 				"babel-core": "^7.0.0-bridge.0",
 				"babel-jest": "^27.0.1",
 				"babel-loader": "^8.1.0",
@@ -75,7 +76,6 @@
 				"stylelint-webpack-plugin": "^2.1.0",
 				"url-loader": "^4.1.0",
 				"vue-eslint-parser": "^8.0.1",
-				"vue-jest": "^3.0.5",
 				"vue-loader": "^15.9.1",
 				"vue-styleguidist": "^4.44.27",
 				"vue-template-compiler": "^2.6.14",
@@ -7696,18 +7696,6 @@
 			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 			"dev": true
 		},
-		"node_modules/@types/strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-			"dev": true
-		},
-		"node_modules/@types/strip-json-comments": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-			"integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-			"dev": true
-		},
 		"node_modules/@types/stylelint": {
 			"version": "13.13.0",
 			"resolved": "https://registry.npmjs.org/@types/stylelint/-/stylelint-13.13.0.tgz",
@@ -8056,6 +8044,41 @@
 			"peerDependencies": {
 				"vue": "2.x",
 				"vue-template-compiler": "^2.x"
+			}
+		},
+		"node_modules/@vue/vue2-jest": {
+			"version": "27.0.0-alpha.4",
+			"resolved": "https://registry.npmjs.org/@vue/vue2-jest/-/vue2-jest-27.0.0-alpha.4.tgz",
+			"integrity": "sha512-8dxGLYkHXyW1nP3EEveWx2xx5pQOEd2lEnykUYQfM+egNZOL04MLE/DnOAcwRwky8T+D8mu2hDIgUBFwUMx13g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/plugin-transform-modules-commonjs": "^7.2.0",
+				"@vue/component-compiler-utils": "^3.1.0",
+				"chalk": "^2.1.0",
+				"extract-from-css": "^0.4.4",
+				"source-map": "0.5.6"
+			},
+			"peerDependencies": {
+				"@babel/core": "7.x",
+				"babel-jest": ">= 27 < 28",
+				"jest": "27.x",
+				"ts-jest": ">= 27 < 28",
+				"vue": "^2.x",
+				"vue-template-compiler": "^2.x"
+			},
+			"peerDependenciesMeta": {
+				"ts-jest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vue/vue2-jest/node_modules/source-map": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@vxna/mini-html-webpack-template": {
@@ -9584,28 +9607,6 @@
 				"babel-template": "^6.24.1"
 			}
 		},
-		"node_modules/babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
-			"dependencies": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
-			}
-		},
-		"node_modules/babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
-			"dependencies": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
 		"node_modules/babel-preset-current-node-syntax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
@@ -9888,6 +9889,7 @@
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dev": true,
+			"optional": true,
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -13356,20 +13358,6 @@
 			"integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
 			"dev": true
 		},
-		"node_modules/deasync": {
-			"version": "0.1.20",
-			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
-			"integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"bindings": "^1.5.0",
-				"node-addon-api": "^1.7.1"
-			},
-			"engines": {
-				"node": ">=0.11.0"
-			}
-		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -16220,7 +16208,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/filesize": {
 			"version": "6.1.0",
@@ -16290,28 +16279,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
-		},
-		"node_modules/find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"dependencies": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/find-babel-config/node_modules/json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true,
-			"bin": {
-				"json5": "lib/cli.js"
-			}
 		},
 		"node_modules/find-cache-dir": {
 			"version": "2.1.0",
@@ -23664,34 +23631,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node_modules/node-addon-api": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-			"dev": true
-		},
-		"node_modules/node-cache": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-			"integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
-			"dev": true,
-			"dependencies": {
-				"clone": "2.x",
-				"lodash": "^4.17.15"
-			},
-			"engines": {
-				"node": ">= 0.4.6"
-			}
-		},
-		"node_modules/node-cache/node_modules/clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/node-dir": {
 			"version": "0.1.17",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -29544,6 +29483,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true,
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -31153,18 +31093,6 @@
 			"integrity": "sha512-vDWbsl26LIcPGmDpoVzjEP6+hvHZkBkLW7JpvwbCv/5IYPJlsbzCVXY3wsCeAxAUeTclNOUZxnLdGh3VBD/J6w==",
 			"dev": true
 		},
-		"node_modules/tsconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-			"integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-			"dev": true,
-			"dependencies": {
-				"@types/strip-bom": "^3.0.0",
-				"@types/strip-json-comments": "0.0.30",
-				"strip-bom": "^3.0.0",
-				"strip-json-comments": "^2.0.0"
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -32147,30 +32075,6 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/vue-jest": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/vue-jest/-/vue-jest-3.0.7.tgz",
-			"integrity": "sha512-PIOxFM+wsBMry26ZpfBvUQ/DGH2hvp5khDQ1n51g3bN0TwFwTy4J85XVfxTRMukqHji/GnAoGUnlZ5Ao73K62w==",
-			"dev": true,
-			"dependencies": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-				"chalk": "^2.1.0",
-				"deasync": "^0.1.15",
-				"extract-from-css": "^0.4.4",
-				"find-babel-config": "^1.1.0",
-				"js-beautify": "^1.6.14",
-				"node-cache": "^4.1.1",
-				"object-assign": "^4.1.1",
-				"source-map": "^0.5.6",
-				"tsconfig": "^7.0.0",
-				"vue-template-es2015-compiler": "^1.6.0"
-			},
-			"peerDependencies": {
-				"babel-core": "^6.25.0 || ^7.0.0-0",
-				"vue": "^2.x",
-				"vue-template-compiler": "^2.x"
 			}
 		},
 		"node_modules/vue-loader": {
@@ -40599,18 +40503,6 @@
 			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 			"dev": true
 		},
-		"@types/strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-			"dev": true
-		},
-		"@types/strip-json-comments": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-			"integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-			"dev": true
-		},
 		"@types/stylelint": {
 			"version": "13.13.0",
 			"resolved": "https://registry.npmjs.org/@types/stylelint/-/stylelint-13.13.0.tgz",
@@ -40914,6 +40806,27 @@
 				"dom-event-types": "^1.0.0",
 				"lodash": "^4.17.15",
 				"pretty": "^2.0.0"
+			}
+		},
+		"@vue/vue2-jest": {
+			"version": "27.0.0-alpha.4",
+			"resolved": "https://registry.npmjs.org/@vue/vue2-jest/-/vue2-jest-27.0.0-alpha.4.tgz",
+			"integrity": "sha512-8dxGLYkHXyW1nP3EEveWx2xx5pQOEd2lEnykUYQfM+egNZOL04MLE/DnOAcwRwky8T+D8mu2hDIgUBFwUMx13g==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-transform-modules-commonjs": "^7.2.0",
+				"@vue/component-compiler-utils": "^3.1.0",
+				"chalk": "^2.1.0",
+				"extract-from-css": "^0.4.4",
+				"source-map": "0.5.6"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+					"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+					"dev": true
+				}
 			}
 		},
 		"@vxna/mini-html-webpack-template": {
@@ -42167,28 +42080,6 @@
 				"babel-template": "^6.24.1"
 			}
 		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
 		"babel-preset-current-node-syntax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
@@ -42430,6 +42321,7 @@
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -45213,16 +45105,6 @@
 			"integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
 			"dev": true
 		},
-		"deasync": {
-			"version": "0.1.20",
-			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
-			"integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
-			"dev": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"node-addon-api": "^1.7.1"
-			}
-		},
 		"debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -47453,7 +47335,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"filesize": {
 			"version": "6.1.0",
@@ -47512,24 +47395,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"requires": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 					"dev": true
 				}
 			}
@@ -53159,30 +53024,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-addon-api": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-			"dev": true
-		},
-		"node-cache": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-			"integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
-			"dev": true,
-			"requires": {
-				"clone": "2.x",
-				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				}
-			}
-		},
 		"node-dir": {
 			"version": "0.1.17",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -57803,7 +57644,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"striptags": {
 			"version": "3.2.0",
@@ -59042,18 +58884,6 @@
 			"integrity": "sha512-vDWbsl26LIcPGmDpoVzjEP6+hvHZkBkLW7JpvwbCv/5IYPJlsbzCVXY3wsCeAxAUeTclNOUZxnLdGh3VBD/J6w==",
 			"dev": true
 		},
-		"tsconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-			"integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-			"dev": true,
-			"requires": {
-				"@types/strip-bom": "^3.0.0",
-				"@types/strip-json-comments": "0.0.30",
-				"strip-bom": "^3.0.0",
-				"strip-json-comments": "^2.0.0"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -59828,25 +59658,6 @@
 			"requires": {
 				"camelcase": "^5.3.1",
 				"vue-inbrowser-compiler-demi": "^4.44.23"
-			}
-		},
-		"vue-jest": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/vue-jest/-/vue-jest-3.0.7.tgz",
-			"integrity": "sha512-PIOxFM+wsBMry26ZpfBvUQ/DGH2hvp5khDQ1n51g3bN0TwFwTy4J85XVfxTRMukqHji/GnAoGUnlZ5Ao73K62w==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-				"chalk": "^2.1.0",
-				"deasync": "^0.1.15",
-				"extract-from-css": "^0.4.4",
-				"find-babel-config": "^1.1.0",
-				"js-beautify": "^1.6.14",
-				"node-cache": "^4.1.1",
-				"object-assign": "^4.1.1",
-				"source-map": "^0.5.6",
-				"tsconfig": "^7.0.0",
-				"vue-template-es2015-compiler": "^1.6.0"
 			}
 		},
 		"vue-loader": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"@nextcloud/eslint-config": "^5.1.0",
 		"@nextcloud/stylelint-config": "^1.0.0-beta.0",
 		"@vue/test-utils": "^1.0.4",
+		"@vue/vue2-jest": "^27.0.0-alpha.4",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-jest": "^27.0.1",
 		"babel-loader": "^8.1.0",
@@ -106,7 +107,6 @@
 		"stylelint-webpack-plugin": "^2.1.0",
 		"url-loader": "^4.1.0",
 		"vue-eslint-parser": "^8.0.1",
-		"vue-jest": "^3.0.5",
 		"vue-loader": "^15.9.1",
 		"vue-styleguidist": "^4.44.27",
 		"vue-template-compiler": "^2.6.14",
@@ -123,7 +123,7 @@
 		"testEnvironment": "jsdom",
 		"transform": {
 			"^.+\\.js$": "babel-jest",
-			"^.+\\.vue$": "vue-jest",
+			"^.+\\.vue$": "@vue/vue2-jest",
 			".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
 		},
 		"transformIgnorePatterns": [

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -226,6 +226,7 @@ export default {
 <script>
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal'
 
+import VNodes from '../VNodes/VNodes'
 import Tooltip from '../../directives/Tooltip'
 import GenRandomId from '../../utils/GenRandomId'
 import { t } from '../../l10n'
@@ -253,10 +254,7 @@ export default {
 		Popover,
 
 		// Component to render the first action icon slot content (vnodes)
-		VNodes: {
-			functional: true,
-			render: (h, context) => context.props.vnodes,
-		},
+		VNodes,
 	},
 
 	props: {

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -66,6 +66,8 @@
 <script>
 import Vue from 'vue'
 
+import VNodes from '../VNodes/VNodes'
+
 const IsValidString = function(value) {
 	return value && typeof value === 'string' && value.trim() !== ''
 }
@@ -79,10 +81,7 @@ export default {
 
 	components: {
 		// Component to render the material design icon (vnodes)
-		VNodes: {
-			functional: true,
-			render: (h, context) => context.props.vnodes,
-		},
+		VNodes,
 	},
 
 	props: {

--- a/src/components/VNodes/VNodes.vue
+++ b/src/components/VNodes/VNodes.vue
@@ -1,0 +1,38 @@
+<!--
+ - @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -
+ -->
+
+<script>
+export default {
+	name: 'VNodes',
+	functional: true,
+	/**
+	 * The render function to display the component
+	 *
+	 * @param {Function} createElement The function to create VNodes
+	 * @param {Object} context The context object of the functional component
+	 * @returns {VNodes} The created VNodes
+	 */
+	render(createElement, context) {
+		return context.props.vnodes
+	},
+}
+</script>


### PR DESCRIPTION
For some reason `vue2-jest` does not like the functional component for rendering `VNodes` to be defined directly in the parent component. So I moved it to a separate file. The nice thing is, it reduces code duplication as well.