### PR TITLE
Cleanup tooltip and popover CSS

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -132,7 +132,8 @@ $arrow-width: 10px;
 		height: 0;
 		margin: $arrow-width;
 		border-style: solid;
-		border-color: var(--color-main-background);
+		border-color: transparent;
+		border-width: $arrow-width;
 	}
 
 	&[x-placement^='top'] {
@@ -143,10 +144,8 @@ $arrow-width: 10px;
 			left: calc(50% - $arrow-width);
 			margin-top: 0;
 			margin-bottom: 0;
-			border-width: $arrow-width $arrow-width 0 $arrow-width;
-			border-right-color: transparent !important;
-			border-bottom-color: transparent !important;
-			border-left-color: transparent !important;
+			border-bottom-width: 0;
+			border-top-color: var(--color-main-background);
 		}
 	}
 
@@ -158,10 +157,8 @@ $arrow-width: 10px;
 			left: calc(50% - $arrow-width);
 			margin-top: 0;
 			margin-bottom: 0;
-			border-width: 0 $arrow-width $arrow-width $arrow-width;
-			border-top-color: transparent !important;
-			border-right-color: transparent !important;
-			border-left-color: transparent !important;
+			border-top-width: 0;
+			border-bottom-color: var(--color-main-background);
 		}
 	}
 
@@ -173,10 +170,8 @@ $arrow-width: 10px;
 			left: -$arrow-width;
 			margin-right: 0;
 			margin-left: 0;
-			border-width: $arrow-width $arrow-width $arrow-width 0;
-			border-top-color: transparent !important;
-			border-bottom-color: transparent !important;
-			border-left-color: transparent !important;
+			border-left-width: 0;
+			border-right-color: var(--color-main-background);
 		}
 	}
 
@@ -188,10 +183,8 @@ $arrow-width: 10px;
 			right: -$arrow-width;
 			margin-right: 0;
 			margin-left: 0;
-			border-width: $arrow-width 0 $arrow-width $arrow-width;
-			border-top-color: transparent !important;
-			border-right-color: transparent !important;
-			border-bottom-color: transparent !important;
+			border-right-width: 0;
+			border-left-color: var(--color-main-background);
 		}
 	}
 

--- a/src/directives/Tooltip/index.scss
+++ b/src/directives/Tooltip/index.scss
@@ -31,55 +31,31 @@ $arrow-width: 10px;
 	filter: drop-shadow(0 1px 10px var(--color-box-shadow));
 
 	// TOP
-	&[x-placement^='top'] {
-		.tooltip-arrow {
-			bottom: 0;
-			margin-top: 0;
-			margin-bottom: 0;
-			border-width: $arrow-width $arrow-width 0 $arrow-width;
-			border-right-color: transparent;
-			border-bottom-color: transparent;
-			border-left-color: transparent;
-		}
+	&[x-placement^='top'] .tooltip-arrow {
+		bottom: 0;
+		border-bottom-width: 0;
+		border-top-color: var(--color-main-background);
 	}
 
 	// BOTTOM
-	&[x-placement^='bottom'] {
-		.tooltip-arrow {
-			top: 0;
-			margin-top: 0;
-			margin-bottom: 0;
-			border-width: 0 $arrow-width $arrow-width $arrow-width;
-			border-top-color: transparent;
-			border-right-color: transparent;
-			border-left-color: transparent;
-		}
+	&[x-placement^='bottom'] .tooltip-arrow {
+		top: 0;
+		border-top-width: 0;
+		border-bottom-color: var(--color-main-background);
 	}
 
 	// RIGHT
-	&[x-placement^='right'] {
-		.tooltip-arrow {
-			right: 100%;
-			margin-right: 0;
-			margin-left: 0;
-			border-width: $arrow-width $arrow-width $arrow-width 0;
-			border-top-color: transparent;
-			border-bottom-color: transparent;
-			border-left-color: transparent;
-		}
+	&[x-placement^='right'] .tooltip-arrow {
+		right: 100%;
+		border-left-width: 0;
+		border-right-color: var(--color-main-background);
 	}
 
 	// LEFT
-	&[x-placement^='left'] {
-		.tooltip-arrow {
-			left: 100%;
-			margin-right: 0;
-			margin-left: 0;
-			border-width: $arrow-width 0 $arrow-width $arrow-width;
-			border-top-color: transparent;
-			border-right-color: transparent;
-			border-bottom-color: transparent;
-		}
+	&[x-placement^='left'] .tooltip-arrow {
+		left: 100%;
+		border-right-width: 0;
+		border-left-color: var(--color-main-background);
 	}
 
 	// HIDDEN / SHOWN
@@ -112,6 +88,7 @@ $arrow-width: 10px;
 		height: 0;
 		margin: 0;
 		border-style: solid;
-		border-color: var(--color-main-background);
+		border-color: transparent;
+		border-width: $arrow-width;
 	}
 }


### PR DESCRIPTION
This cleans up the CSS code for the popover and tooltip. Before the CSS code was a bit illogical. Before e.g. the `border-color` was set to a color on all sides in the general rule, and then overwritten to be transparent on three sides. Now it's the other way around, transparent everywhere and only one side is overwritten. This reduces complexity.

Since it does not visually change anything, I didn't attach any screenshot here. Just have a look at the docs and check that tooltip and popover (i.e. Actions) look the same.