### PR TITLE
closes#2569, changed fixed 4px to .38rem height.

### DIFF
--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -122,7 +122,8 @@ export default {
 	}
 	&::-webkit-progress-value {
 		background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
-		border-radius: var(--border-radius);
+		border-radius: 2px:
+		height:.38rem
 	}
 	&::-moz-progress-bar {
 		background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);


### PR DESCRIPTION
The issue seems to be only in some browsers ( safari has it, firefox was fine) ,changed from fixed pixels to rem unit , displays the same accros the different browsers