### PR TITLE
Revert "Use large corner radius for the Popover component"

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -120,8 +120,7 @@ $arrow-width: 10px;
 	&__inner {
 		padding: 0;
 		color: var(--color-main-text);
-		border-radius: var(--border-radius-large);
-		overflow: hidden;
+		border-radius: var(--border-radius);
 		background: var(--color-main-background);
 	}
 


### PR DESCRIPTION
Reverts nextcloud/nextcloud-vue#2566

Unfortunately the impact of "overflow: hidden" https://github.com/nextcloud/nextcloud-vue/pull/2566/files#diff-6227be297736de3cfd95255a1009cea60ca35ef0086ce9477c6357c88ee5b3acR124 is too large, that cause a popover in half usable state =(

I have discussed it with @skjnldsv and it seems to be ok to revert this PR as a quick fix.

![Screenshot from 2022-04-06 19-11-37](https://user-images.githubusercontent.com/6078378/162030326-4af21b51-4e4c-4738-a900-d21b84fb90d6.png)

