### PR TITLE
Fix border radius for small progress bar

### DIFF
--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -43,7 +43,7 @@ This is a simple progress bar component.
 <template>
 	<progress class="progress-bar vue"
 		:class="{ 'progress-bar--error': error }"
-		:style="progressBarStyle"
+		:style="{'--progress-bar-height': height }"
 		:value="value"
 		max="100" />
 </template>
@@ -87,21 +87,11 @@ export default {
 		},
 	},
 	computed: {
-
-		progressBarStyle() {
-			let height = 0
-			let borderRadius = 0
+		height() {
 			if (this.size === 'small') {
-				height = '4px'
-				borderRadius = '2px'
-			} else if (this.size === 'medium') {
-				height = '6px'
-				borderRadius = '3px'
+				return '4px'
 			}
-			return {
-				height,
-				'border-radius': borderRadius,
-			}
+			return '6px'
 		},
 	},
 }
@@ -116,16 +106,18 @@ export default {
 	background: var(--color-background-dark);
 	border: 0;
 	padding: 0;
-	border-radius: var(--border-radius);
+	height: var(--progress-bar-height);
+	border-radius: calc(var(--progress-bar-height) / 2);
 	&::-webkit-progress-bar {
-		height: calc(var(--border-radius) * 2);
+		height: var(--progress-bar-height);
 	}
 	&::-webkit-progress-value {
 		background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
-		border-radius: var(--border-radius);
+		border-radius: calc(var(--progress-bar-height) / 2);
 	}
 	&::-moz-progress-bar {
 		background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
+		border-radius: calc(var(--progress-bar-height) / 2);
 	}
 	&--error {
 		// Override previous values


### PR DESCRIPTION
This fixes the `border-radius` of the `ProgressBar` component. I introduced a CSS variable to dynamically set the height. Since the variable is scoped to the respective element, it does not pollute the global scope and multiple progress bars can exist with different heights / border radii on the same page.

See this screenshot from the docs in Firefox (I temporarily increased the height with the dev tools to make it obvious):
![Screenshot 2022-04-08 at 09-56-55 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/162391600-7d14e3b3-6ceb-4aa3-8143-18c01fe19baf.png)

And in Chrome:
![Unbenannt](https://user-images.githubusercontent.com/2496460/162391989-3c7b81bd-2dbd-4f60-8e68-3ea1d8846fbc.png)


Closes #2569.
