### PR TITLE
Fix styleguide serve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
 				"jest-serializer-vue": "^2.0.2",
 				"jest-transform-stub": "^2.0.0",
 				"node-sass": "^7.0.1",
+				"process": "^0.11.10",
 				"raw-loader": "^4.0.1",
 				"resolve-url-loader": "^5.0.0",
 				"sanitize-filename": "^1.6.3",
@@ -21504,6 +21505,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/process-nextick-args": {
@@ -45771,6 +45781,12 @@
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
 			"dev": true
 		},
 		"process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
 		"jest-serializer-vue": "^2.0.2",
 		"jest-transform-stub": "^2.0.0",
 		"node-sass": "^7.0.1",
+		"process": "^0.11.10",
 		"raw-loader": "^4.0.1",
 		"resolve-url-loader": "^5.0.0",
 		"sanitize-filename": "^1.6.3",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const { merge } = require('webpack-merge')
+const webpack = require('webpack')
 const webpackConfig = require('./webpack.dev.js')
 
 const newConfig = Object.assign({}, webpackConfig, {
@@ -10,6 +11,15 @@ const newConfig = Object.assign({}, webpackConfig, {
 			rule => rule.use !== 'eslint-loader'
 		),
 	},
+	plugins: [
+		...webpackConfig.plugins,
+		new webpack.HotModuleReplacementPlugin(),
+		new webpack.ProvidePlugin({
+			// Webpack 5 does no longer include a polyfill for this Node.js variable.
+			// https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice
+			process: 'process/browser'
+		})
+	],
 })
 
 module.exports = {


### PR DESCRIPTION
Due to a problem of vue-styleguidist with webpack 5, we have to manually work around if for now. Fix is from https://github.com/vue-styleguidist/vue-styleguidist/pull/1308 and can be removed once the upstream fix is merged and released.