### PR TITLE
show the action buttons on top of the modal always by default

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -107,17 +107,10 @@
 		<div ref="mask"
 			class="modal-mask"
 			:class="{ 'modal-mask--dark': dark }"
-			:style="cssVariables"
-			@click="handleMouseMove"
-			@mousemove="handleMouseMove"
-			@touchmove="handleMouseMove">
+			:style="cssVariables">
 			<!-- Header -->
 			<transition name="fade-visibility">
-				<div v-show="!clearView"
-					:class="{
-						invisible: clearView
-					}"
-					class="modal-header">
+				<div class="modal-header">
 					<div v-if="title.trim() !== ''" class="modal-title">
 						{{ title }}
 					</div>
@@ -189,11 +182,11 @@
 					@mousedown.self="close">
 					<!-- Navigation button -->
 					<transition name="fade-visibility">
-						<a v-show="hasPrevious && !clearView"
+						<a v-show="hasPrevious"
 							class="prev"
 							href="#"
 							:class="{
-								invisible: clearView || !hasPrevious
+								invisible: !hasPrevious
 							}"
 							@click.prevent.stop="previous">
 							<span class="icon-previous">
@@ -213,11 +206,11 @@
 
 					<!-- Navigation button -->
 					<transition name="fade-visibility">
-						<a v-show="hasNext && !clearView"
+						<a v-show="hasNext"
 							class="next"
 							href="#"
 							:class="{
-								invisible: clearView || !hasNext
+								invisible: !hasNext
 							}"
 							@click.prevent.stop="next">
 							<span class="icon-next">
@@ -305,10 +298,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		clearViewDelay: {
-			type: Number,
-			default: 5000,
-		},
 		/**
 		 * Declare the slide interval
 		 */
@@ -373,8 +362,6 @@ export default {
 		return {
 			mc: null,
 			showModal: false,
-			clearView: false,
-			clearViewTimeout: null,
 			playing: false,
 			slideshowTimeout: null,
 			iconSize: 24,
@@ -426,7 +413,6 @@ export default {
 		this.showModal = true
 
 		// init clear view
-		this.handleMouseMove()
 		this.useFocusTrap()
 		this.mc = new Hammer(this.$refs.mask)
 		this.mc.on('swipeleft swiperight', e => {
@@ -512,15 +498,6 @@ export default {
 					// swiping to right to go back to the previous item
 					this.previous(e)
 				}
-			}
-		},
-		handleMouseMove() {
-			if (this.clearViewDelay > 0) {
-				this.clearView = false
-				clearTimeout(this.clearViewTimeout)
-				this.clearViewTimeout = setTimeout(() => {
-					this.clearView = true
-				}, this.clearViewDelay)
 			}
 		},
 


### PR DESCRIPTION
reason behind this: as noticed in the accessibility workshop, the action buttons of the modal should always visible. Changing the default to -1 will allow to opt-in into the hiding of the action buttons which is in my opinion the better way to do this.

Signed-off-by: szaimen <szaimen@e.mail.de>