### PR TITLE
Cleanup styleguide config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
 				"jest-environment-jsdom": "27.5.1",
 				"jest-serializer-vue": "^2.0.2",
 				"jest-transform-stub": "^2.0.0",
-				"process": "^0.11.10",
 				"raw-loader": "^4.0.1",
 				"resolve-url-loader": "^5.0.0",
 				"sanitize-filename": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
 		"jest-environment-jsdom": "27.5.1",
 		"jest-serializer-vue": "^2.0.2",
 		"jest-transform-stub": "^2.0.0",
-		"process": "^0.11.10",
 		"raw-loader": "^4.0.1",
 		"resolve-url-loader": "^5.0.0",
 		"sanitize-filename": "^1.6.3",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const { merge } = require('webpack-merge')
-const webpack = require('webpack')
 const webpackConfig = require('./webpack.dev.js')
 
 const newConfig = Object.assign({}, webpackConfig, {
@@ -11,15 +10,6 @@ const newConfig = Object.assign({}, webpackConfig, {
 			rule => rule.use !== 'eslint-loader'
 		),
 	},
-	plugins: [
-		...webpackConfig.plugins,
-		new webpack.HotModuleReplacementPlugin(),
-		new webpack.ProvidePlugin({
-			// Webpack 5 does no longer include a polyfill for this Node.js variable.
-			// https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice
-			process: 'process/browser'
-		})
-	],
 })
 
 module.exports = {


### PR DESCRIPTION
With the really quickly released new version of vue-styleguidist merged in https://github.com/nextcloud/nextcloud-vue/pull/2632 our adjustments from #2628 to make `npm run styleguide` work again are not necessary anymore. This PR removes them.