### PR TITLE
Fix lifecycle hook name in Avatar

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -441,7 +441,7 @@ export default {
 		}
 	},
 
-	beforeDestroyed() {
+	beforeDestroy() {
 		if (this.showUserStatus && this.user && !this.isNoUser) {
 			unsubscribe('user_status:status.updated', this.handleUserStatusUpdated)
 		}


### PR DESCRIPTION
The life cycle hook `beforeDestroyed` is actually called `beforeDestroy`.