### PR TITLE
Run eslint with webpack for vue files

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -149,7 +149,9 @@ module.exports = {
 		new StyleLintPlugin({
 			files: ['src/**/*.vue', 'src/**/*.scss', 'src/**/*.css'],
 		}),
-		new ESLintPlugin(),
+		new ESLintPlugin({
+			extensions: ['js', 'vue'],
+		}),
 		new DefinePlugin({
 			SCOPE_VERSION,
 			TRANSLATIONS: JSON.stringify(translations),


### PR DESCRIPTION
This brings back running eslint on vue files when webpack runs (dev, watch, build) which got lost with #2594.

Before:
See that eslint only reports lint problems in js files when e.g. `npm run watch' runs.

After:
See that eslint now also reports lint problems in vue files when e.g. `npm run watch' runs.