### PR TITLE
Update the css for the datepicker

### DIFF
--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -49,6 +49,28 @@ export default {
 </script>
 ```
 
+### Example with confirm button
+```vue
+<template>
+	<span>
+		<DatetimePicker
+			v-model="time"
+			type="datetime"
+			confirm />
+		{{ time }}
+	</span>
+</template>
+<script>
+	export default {
+		data() {
+			return {
+				time: null,
+			}
+		},
+	}
+</script>
+```
+
 ### Range picker
 ```vue
 <template>

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -55,7 +55,7 @@ $cell_height: 32px;
 	}
 	
 	&.show-week-number .mx-calendar {
-		width: $cell_height * 8 + 2 * 5px; // week number + 7 days + padding
+		width: $cell_height * 8 + 2 * 5px + 30px; // week number + 7 days + padding + 30px padding to fit the buttons
 	}
 
 	.mx-datepicker-header {
@@ -68,10 +68,10 @@ $cell_height: 32px;
 
 	// default popup styles
 	.mx-calendar {
-		width: $cell_height * 7 + 2 * 5px; // 7 days + padding
+		width: $cell_height * 7 + 2 * 5px + 30px; // 7 days + padding + 30px padding to fit the buttons
 		padding: 5px;
 		&.mx-calendar-week-mode {
-			width: $cell_height * 8 + 2 * 5px; // week number + 7 days + padding
+			width: $cell_height * 8 + 2 * 5px + 30px; // week number + 7 days + padding + 30px padding to fit the buttons
 		}
 	}
 

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -66,6 +66,18 @@ $cell_height: 32px;
 		border-top: 1px solid var(--color-border);
 	}
 
+	.mx-datepicker-btn-confirm {
+		background-color: var(--color-primary-element);
+		border-color: var(--color-primary-element);
+		color: var(--color-primary-text) !important;
+		opacity: 1 !important;
+	}
+
+	.mx-datepicker-btn-confirm:hover {
+		background-color: var(--color-primary-element-light) !important;
+		border-color: var(--color-primary-element-light) !important;
+	}
+
 	// default popup styles
 	.mx-calendar {
 		width: $cell_height * 7 + 2 * 5px + 30px; // 7 days + padding + 30px padding to fit the buttons
@@ -344,7 +356,6 @@ $cell_height: 32px;
 			order: 3;
 		}
 	}
-
 	// Week panel
 	.mx-calendar-week-mode {
 		// move focus on row and not on cell

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -235,7 +235,7 @@ $cell_height: 32px;
 	.mx-btn {
 		min-width: $cell_height;
 		height: $cell_height;
-		margin: 0 auto; // center also single element
+		margin: 0 2px !important; // center also single element. Definitively use margin so that buttons are not touching
 		padding: 7px 10px;
 		cursor: pointer;
 		text-decoration: none;

--- a/src/components/DatetimePicker/index.scss
+++ b/src/components/DatetimePicker/index.scss
@@ -299,6 +299,9 @@ $cell_height: 32px;
 					display: none;
 				}
 			}
+			&.mx-btn-text {
+				line-height: initial;
+			}
 		}
 
 		.mx-calendar-header-label {


### PR DESCRIPTION
Also see nextcloud/calendar/pull/4105 for the discussion.


In this pr i fixed the missing margin on the buttons. I also widened the popup to fit all the controls aswell as made the text in those buttons centered.
Also i added color to the confirm button to match the 'primary' style of nextcloud. 


Here is an example of the fixes:
![grafik](https://user-images.githubusercontent.com/25279821/164016036-232515b8-f402-4fcc-a375-585cb8b86ae8.png)
