### PR TITLE
Add actions slot to dashboard widget item

### DIFF
--- a/src/components/DashboardWidgetItem/DashboardWidgetItem.vue
+++ b/src/components/DashboardWidgetItem/DashboardWidgetItem.vue
@@ -57,13 +57,16 @@ This component is meant to be used inside a DashboardWidget component.
 				</p>
 			</div>
 			<Actions v-if="gotMenu" :force-menu="forceMenu" menu-align="right">
-				<ActionButton v-for="(m, menuItemId) in itemMenu"
-					:key="menuItemId"
-					:icon="m.icon"
-					:close-after-click="true"
-					@click.prevent.stop="$emit(menuItemId, item)">
-					{{ m.text }}
-				</ActionButton>
+				<!-- @slot This slot can be used to provide actions for each dashboard widget item. -->
+				<slot name="actions">
+					<ActionButton v-for="(m, menuItemId) in itemMenu"
+						:key="menuItemId"
+						:icon="m.icon"
+						:close-after-click="true"
+						@click.prevent.stop="$emit(menuItemId, item)">
+						{{ m.text }}
+					</ActionButton>
+				</slot>
 			</Actions>
 		</component>
 	</div>
@@ -175,7 +178,7 @@ export default {
 			}
 		},
 		gotMenu() {
-			return Object.keys(this.itemMenu).length !== 0
+			return Object.keys(this.itemMenu).length !== 0 || !!this.$slots.actions
 		},
 		gotOverlayIcon() {
 			return this.overlayIconUrl && this.overlayIconUrl !== ''


### PR DESCRIPTION
This PR adds an `action` slot to the `DashboardWidgetItem` so that it's possible to provide different actions for each dashboard widget item. This also allows to provide material design icons for each action, which was not possible before. Closes #2685.

See https://github.com/nextcloud/tasks/pull/2017 for an example how this works.

In Tasks, we can now prevent showing actions for read-only tasks:

Before:
![Screenshot 2022-06-01 at 22-46-13 Dashboard - Nextcloud](https://user-images.githubusercontent.com/2496460/171499618-e0d317e1-5d83-429b-8349-490db357aa0a.png)

After:
![Screenshot 2022-06-01 at 22-54-37 Dashboard - Nextcloud](https://user-images.githubusercontent.com/2496460/171499777-c778e216-f203-4723-b374-22c65335a913.png)