### PR TITLE
Add md icon slot to Avatar component

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -34,6 +34,27 @@
 	<avatar url="https://nextcloud.com/wp-content/themes/next/assets/img/common/nextcloud-square-logo.png" />
 ```
 
+### Avatar with material design icon
+
+```
+ <template>
+	<avatar>
+		<template #icon>
+			<AccountMultiple :size="20" decorative />
+		</template>
+	</AppNavigationNew>
+ </template>
+ <script>
+ import AccountMultiple from 'vue-material-design-icons/AccountMultiple'
+
+ export default {
+	components: {
+		AccountMultiple,
+	},
+ }
+ </script>
+```
+
 </docs>
 <template>
 	<div ref="main"

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -50,12 +50,15 @@
 		:role="disableMenu ? '' : 'button'"
 		v-on="!disableMenu ? { click: toggleMenu } : {}"
 		@keydown.enter="toggleMenu">
-		<!-- Avatar icon or image -->
-		<div v-if="iconClass" :class="iconClass" class="avatar-class-icon" />
-		<img v-else-if="isAvatarLoaded && !userDoesNotExist"
-			:src="avatarUrlLoaded"
-			:srcset="avatarSrcSetLoaded"
-			alt="">
+		<!-- @slot Icon slot -->
+		<slot name="icon">
+			<!-- Avatar icon or image -->
+			<div v-if="iconClass" :class="iconClass" class="avatar-class-icon" />
+			<img v-else-if="isAvatarLoaded && !userDoesNotExist"
+				:src="avatarUrlLoaded"
+				:srcset="avatarSrcSetLoaded"
+				alt="">
+		</slot>
 
 		<!-- Contact menu -->
 		<Popover v-if="hasMenu"
@@ -84,7 +87,7 @@
 			:class="'avatardiv__user-status--' + userStatus.status" />
 
 		<!-- Show the letter if no avatar nor icon class -->
-		<div v-if="userDoesNotExist && !iconClass" class="unknown">
+		<div v-if="userDoesNotExist && !(iconClass || $slots.icon)" class="unknown">
 			{{ initials }}
 		</div>
 	</div>
@@ -679,6 +682,11 @@ export default {
 		height: 100%;
 		// Keep ratio
 		object-fit: cover;
+	}
+
+	.material-design-icon {
+		width: var(--size);
+		height: var(--size);
 	}
 
 	.avatardiv__user-status {


### PR DESCRIPTION
This PR adds a material design icon slot to the avatar component. Implements the second part of and closes #2707.
I also added an example for an avatar with a md icon.

![Screenshot 2022-06-03 at 21-05-53 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/171931904-5204b3ed-85ff-432a-a814-57c85f8c97d0.png)
