### PR TITLE
Alternative style for CheckboxRadioSwitch (radio type)

### DIFF
--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -81,12 +81,12 @@ export default {
 </script>
 ```
 
-### Standard radio set with alternative style
+### Standard radio set with alternative button style
 ```vue
 <template>
 	<div>
-		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio" :alternative-style="true">Default permission read</CheckboxRadioSwitch>
-		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio" :alternative-style="true">Default permission read+write</CheckboxRadioSwitch>
+		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio" :button-variant="true">Default permission read</CheckboxRadioSwitch>
+		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio" :button-variant="true">Default permission read+write</CheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
 	</div>
@@ -154,7 +154,7 @@ export default {
 			'checkbox-radio-switch--checked': isChecked,
 			'checkbox-radio-switch--disabled': disabled,
 			'checkbox-radio-switch--indeterminate': indeterminate,
-			'checkbox-radio-switch--alternate-radio': isAlternativeRadio,
+			'checkbox-radio-switch--button-variant': buttonVariant,
 		}"
 		:style="cssVars"
 		class="checkbox-radio-switch">
@@ -171,7 +171,7 @@ export default {
 		<label :for="id" class="checkbox-radio-switch__label">
 			<div v-if="loading" class="icon-loading-small checkbox-radio-switch__icon" />
 			<icon :is="checkboxRadioIconElement"
-				v-else-if="!isAlternativeRadio"
+				v-else-if="!buttonVariant"
 				:size="size"
 				class="checkbox-radio-switch__icon"
 				title=""
@@ -233,9 +233,9 @@ export default {
 		},
 
 		/**
-		 * Toggle the alternative style (for radio type only)
+		 * Toggle the alternative button style
 		 */
-		alternativeStyle: {
+		buttonVariant: {
 			type: Boolean,
 			default: false,
 		},
@@ -323,10 +323,6 @@ export default {
 				return TYPE_RADIO
 			}
 			return TYPE_CHECKBOX
-		},
-
-		isAlternativeRadio() {
-			return this.type === TYPE_RADIO && this.alternativeStyle
 		},
 
 		/**
@@ -498,7 +494,7 @@ $spacing: 4px;
 		color: var(--color-primary-element-light);
 	}
 
-	&.checkbox-radio-switch--alternate-radio.checkbox-radio-switch {
+	&--button-variant.checkbox-radio-switch {
 		border: 2px solid var(--color-border-dark);
 		border-radius: var(--border-radius);
 
@@ -524,12 +520,12 @@ $spacing: 4px;
 				background-color: var(--color-background-dark);
 			}
 		}
+	}
 
-		.checkbox-radio-switch__label {
-			border-radius: 0 !important;
-			width: 100% !important;
-			margin: 0 !important;
-		}
+	&--button-variant &__label {
+		border-radius: 0 !important;
+		width: 100% !important;
+		margin: 0 !important;
 	}
 }
 </style>

--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -71,6 +71,27 @@ export default {
 	</div>
 </template>
 <script>
+	export default {
+		data() {
+			return {
+				sharingPermission: 'r',
+			}
+		}
+	}
+</script>
+```
+
+### Standard radio set with alternative style
+```vue
+<template>
+	<div>
+		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio" :alternative-style="true">Default permission read</CheckboxRadioSwitch>
+		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio" :alternative-style="true">Default permission read+write</CheckboxRadioSwitch>
+		<br>
+		sharingPermission: {{ sharingPermission }}
+	</div>
+</template>
+<script>
 export default {
 	data() {
 		return {
@@ -133,6 +154,7 @@ export default {
 			'checkbox-radio-switch--checked': isChecked,
 			'checkbox-radio-switch--disabled': disabled,
 			'checkbox-radio-switch--indeterminate': indeterminate,
+			'checkbox-radio-switch--alternate-radio': isAlternativeRadio,
 		}"
 		:style="cssVars"
 		class="checkbox-radio-switch">
@@ -149,7 +171,7 @@ export default {
 		<label :for="id" class="checkbox-radio-switch__label">
 			<div v-if="loading" class="icon-loading-small checkbox-radio-switch__icon" />
 			<icon :is="checkboxRadioIconElement"
-				v-else
+				v-else-if="!isAlternativeRadio"
 				:size="size"
 				class="checkbox-radio-switch__icon"
 				title=""
@@ -208,6 +230,14 @@ export default {
 			type: String,
 			default: 'checkbox',
 			validator: type => type === TYPE_CHECKBOX || type === TYPE_RADIO || type === TYPE_SWITCH,
+		},
+
+		/**
+		 * Toggle the alternative style (for radio type only)
+		 */
+		alternativeStyle: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**
@@ -293,6 +323,10 @@ export default {
 				return TYPE_RADIO
 			}
 			return TYPE_CHECKBOX
+		},
+
+		isAlternativeRadio() {
+			return this.type === TYPE_RADIO && this.alternativeStyle
 		},
 
 		/**
@@ -459,10 +493,43 @@ $spacing: 4px;
 		color: var(--color-text-lighter);
 	}
 
-	// If  switch is checked AND disabled, use the fade primary colour
+	// If switch is checked AND disabled, use the fade primary colour
 	&-switch.checkbox-radio-switch--disabled.checkbox-radio-switch--checked &__icon {
 		color: var(--color-primary-element-light);
 	}
-}
 
+	&.checkbox-radio-switch--alternate-radio.checkbox-radio-switch {
+		border: 2px solid var(--color-border-dark);
+		border-radius: var(--border-radius);
+
+		// avoid double borders between elements
+		& + &:not(&--checked) {
+			border-top: 0;
+		}
+		& + &--checked {
+			// as the selected element has all borders:
+			// small trick to cover the previous bottom border (only if there is one)
+			margin-top: -2px;
+		}
+
+		&--checked {
+			font-weight: bold;
+			border: 2px solid var(--color-primary-element-light);
+
+			&:hover {
+				border: 2px solid var(--color-primary);
+			}
+
+			label {
+				background-color: var(--color-background-dark);
+			}
+		}
+
+		.checkbox-radio-switch__label {
+			border-radius: 0 !important;
+			width: 100% !important;
+			margin: 0 !important;
+		}
+	}
+}
 </style>

--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -85,8 +85,8 @@ export default {
 ```vue
 <template>
 	<div>
-		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio" :button-variant="true">Default permission read</CheckboxRadioSwitch>
-		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio" :button-variant="true">Default permission read+write</CheckboxRadioSwitch>
+		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio" :button-variant="true" button-variant-grouped="vertical">Default permission read</CheckboxRadioSwitch>
+		<CheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio" :button-variant="true" button-variant-grouped="vertical">Default permission read+write</CheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
 	</div>
@@ -155,7 +155,8 @@ export default {
 			'checkbox-radio-switch--disabled': disabled,
 			'checkbox-radio-switch--indeterminate': indeterminate,
 			'checkbox-radio-switch--button-variant': buttonVariant,
-			'checkbox-radio-switch--button-variant-grouped': buttonVariantGrouped,
+			'checkbox-radio-switch--button-variant-v-grouped': buttonVariant && buttonVariantGrouped === 'vertical',
+			'checkbox-radio-switch--button-variant-h-grouped': buttonVariant && buttonVariantGrouped === 'horizontal',
 		}"
 		:style="cssVars"
 		class="checkbox-radio-switch">
@@ -242,11 +243,14 @@ export default {
 		},
 
 		/**
-		 * If the elements are all direct successors
+		 * Are the elements are all direct siblings?
+		 * If so they will be grouped horizontally or vertically
+		 * Possible values are `no`, `horizontal`, `vertical`.
 		 */
 		buttonVariantGrouped: {
-			type: Boolean,
-			default: false,
+			type: String,
+			default: 'no',
+			validator: v => ['no', 'vertical', 'horizontal'].includes(v),
 		},
 
 		/**
@@ -509,11 +513,11 @@ $spacing: 4px;
 		margin: 0;
 	}
 
-	&--button-variant:not(&--button-variant-grouped) {
+	&--button-variant:not(&--button-variant-v-grouped):not(&--button-variant-h-grouped) {
 		border-radius: var(--border-radius-large);
 	}
 
-	&--button-variant-grouped {
+	&--button-variant-v-grouped {
 		&:first-of-type {
 			border-top-left-radius: var(--border-radius-large);
 			border-top-right-radius: var(--border-radius-large);
@@ -531,6 +535,27 @@ $spacing: 4px;
 			// as the selected element has all borders:
 			// small trick to cover the previous bottom border (only if there is one)
 			margin-top: -2px;
+		}
+	}
+
+	&--button-variant-h-grouped {
+		&:first-of-type {
+			border-top-left-radius: var(--border-radius-large);
+			border-bottom-left-radius: var(--border-radius-large);
+		}
+		&:last-of-type {
+			border-top-right-radius: var(--border-radius-large);
+			border-bottom-right-radius: var(--border-radius-large);
+		}
+
+		// avoid double borders between elements
+		& + &:not(&.checkbox-radio-switch--checked) {
+			border-left: 0;
+		}
+		& + &.checkbox-radio-switch--checked {
+			// as the selected element has all borders:
+			// small trick to cover the previous bottom border (only if there is one)
+			margin-left: -2px;
 		}
 	}
 

--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -155,6 +155,7 @@ export default {
 			'checkbox-radio-switch--disabled': disabled,
 			'checkbox-radio-switch--indeterminate': indeterminate,
 			'checkbox-radio-switch--button-variant': buttonVariant,
+			'checkbox-radio-switch--button-variant-grouped': buttonVariantGrouped,
 		}"
 		:style="cssVars"
 		class="checkbox-radio-switch">
@@ -236,6 +237,14 @@ export default {
 		 * Toggle the alternative button style
 		 */
 		buttonVariant: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * If the elements are all direct successors
+		 */
+		buttonVariantGrouped: {
 			type: Boolean,
 			default: false,
 		},
@@ -494,19 +503,41 @@ $spacing: 4px;
 		color: var(--color-primary-element-light);
 	}
 
-	&--button-variant.checkbox-radio-switch {
-		border: 2px solid var(--color-border-dark);
-		border-radius: var(--border-radius);
+	&--button-variant &__label {
+		border-radius: 0;
+		width: 100%;
+		margin: 0;
+	}
+
+	&--button-variant:not(&--button-variant-grouped) {
+		border-radius: var(--border-radius-large);
+	}
+
+	&--button-variant-grouped {
+		&:first-of-type {
+			border-top-left-radius: var(--border-radius-large);
+			border-top-right-radius: var(--border-radius-large);
+		}
+		&:last-of-type {
+			border-bottom-left-radius: var(--border-radius-large);
+			border-bottom-right-radius: var(--border-radius-large);
+		}
 
 		// avoid double borders between elements
-		& + &:not(&--checked) {
+		& + &:not(&.checkbox-radio-switch--checked) {
 			border-top: 0;
 		}
-		& + &--checked {
+		& + &.checkbox-radio-switch--checked {
 			// as the selected element has all borders:
 			// small trick to cover the previous bottom border (only if there is one)
 			margin-top: -2px;
 		}
+	}
+
+	&--button-variant.checkbox-radio-switch {
+		border: 2px solid var(--color-border-dark);
+		// better than setting border-radius on labels (producing a small gap)
+		overflow: hidden;
 
 		&--checked {
 			font-weight: bold;
@@ -520,12 +551,6 @@ $spacing: 4px;
 				background-color: var(--color-background-dark);
 			}
 		}
-	}
-
-	&--button-variant &__label {
-		border-radius: 0 !important;
-		width: 100% !important;
-		margin: 0 !important;
 	}
 }
 </style>


### PR DESCRIPTION
This was inspired by https://github.com/nextcloud/server/issues/26691

A new boolean prop `buttonVariant` toggles between the classic style and this one. It can be used with all types.

If the CheckboxRadioSwitch elements are displayed next to each other vertically, their borders are "merged".

https://user-images.githubusercontent.com/11291457/174578908-5616d945-6ad4-4c9c-89fc-5cda32732f2f.mp4
