### PR TITLE
Use loading icon everywhere

### DIFF
--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -134,9 +134,10 @@ Just set the `pinned` prop.
 
 				<!-- icon if not collapsible -->
 				<!-- never show the icon over the collapsible if mobile -->
-				<div :class="{ 'icon-loading-small': loading, [icon]: icon && isIconShown }"
+				<div :class="{ [icon]: icon && isIconShown }"
 					class="app-navigation-entry-icon">
-					<slot v-show="!loading && isIconShown" name="icon" />
+					<LoadingIcon v-if="loading" />
+					<slot v-else-if="isIconShown" name="icon" />
 				</div>
 				<span v-if="!editingActive" class="app-navigation-entry__title" :title="title">
 					{{ title }}
@@ -208,6 +209,7 @@ import { directive as ClickOutside } from 'v-click-outside'
 
 import Actions from '../Actions/index.js'
 import ActionButton from '../ActionButton/index.js'
+import LoadingIcon from '../LoadingIcon/index.js'
 import AppNavigationIconCollapsible from './AppNavigationIconCollapsible.vue'
 import isMobile from '../../mixins/isMobile/index.js'
 import InputConfirmCancel from './InputConfirmCancel.vue'
@@ -222,6 +224,7 @@ export default {
 	components: {
 		Actions,
 		ActionButton,
+		LoadingIcon,
 		AppNavigationIconCollapsible,
 		InputConfirmCancel,
 		Pencil,

--- a/src/components/AppNavigationNewItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationNewItem/AppNavigationNewItem.vue
@@ -40,9 +40,10 @@
 		class="app-navigation-entry">
 		<!-- New Item -->
 		<div class="app-navigation-entry-div" @click="handleNewItem">
-			<div :class="{ 'icon-loading-small': loading, [icon]: !loading }"
+			<div :class="{ [icon]: !loading }"
 				class="app-navigation-entry-icon">
-				<slot v-if="!loading" name="icon" />
+				<LoadingIcon v-if="loading" />
+				<slot v-else name="icon" />
 			</div>
 
 			<span v-if="!newItemActive" class="app-navigation-new-item__title" :title="title">
@@ -63,6 +64,7 @@
 
 <script>
 import InputConfirmCancel from '../AppNavigationItem/InputConfirmCancel.vue'
+import LoadingIcon from '../LoadingIcon/index.js'
 
 import { directive as ClickOutside } from 'v-click-outside'
 
@@ -71,6 +73,7 @@ export default {
 
 	components: {
 		InputConfirmCancel,
+		LoadingIcon,
 	},
 	directives: {
 		ClickOutside,

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -184,7 +184,7 @@ include a standard-header like it's used by the files app.
 								<a v-if="canStar"
 									class="app-sidebar-header__star"
 									@click.prevent="toggleStarred">
-									<span v-if="starLoading" class="icon-loading-small" />
+									<LoadingIcon v-if="starLoading" />
 									<Star v-else
 										:class="{
 											'star--starred': isStarred,
@@ -252,7 +252,11 @@ include a standard-header like it's used by the files app.
 				<slot />
 			</AppSidebarTabs>
 
-			<EmptyContent v-if="loading" icon="icon-loading" />
+			<EmptyContent v-if="loading">
+				<template #icon>
+					<LoadingIcon :size="64" />
+				</template>
+			</EmptyContent>
 		</aside>
 	</transition>
 </template>
@@ -260,6 +264,7 @@ include a standard-header like it's used by the files app.
 <script>
 import AppSidebarTabs from './AppSidebarTabs.vue'
 import Actions from '../Actions/index.js'
+import LoadingIcon from '../LoadingIcon/index.js'
 import EmptyContent from '../EmptyContent/index.js'
 import Focus from '../../directives/Focus/index.js'
 import Linkify from '../../directives/Linkify/index.js'
@@ -277,6 +282,7 @@ export default {
 	components: {
 		Actions,
 		AppSidebarTabs,
+		LoadingIcon,
 		EmptyContent,
 		Close,
 		Star,
@@ -811,8 +817,7 @@ $top-buttons-spacing: 6px;
 				width: $clickable-area;
 				height: $clickable-area;
 
-				.icon-loading-small {
-					display: block;
+				.loading-icon {
 					width: $clickable-area;
 					height: $clickable-area;
 				}

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -90,7 +90,7 @@
 			@after-hide="handlePopoverAfterHide">
 			<PopoverMenu ref="popoverMenu" :menu="menu" />
 			<template #trigger>
-				<div v-if="contactsMenuLoading" class="icon-loading" />
+				<LoadingIcon v-if="contactsMenuLoading" />
 				<DotsHorizontal v-else
 					:size="20"
 					class="icon-more"
@@ -117,6 +117,7 @@
 <script>
 import Popover from '../Popover/index.js'
 import PopoverMenu from '../PopoverMenu/index.js'
+import LoadingIcon from '../LoadingIcon/index.js'
 import Tooltip from '../../directives/Tooltip/index.js'
 import usernameToColor from '../../functions/usernameToColor/index.js'
 import { userStatus } from '../../mixins/index.js'
@@ -164,6 +165,7 @@ export default {
 	},
 	components: {
 		DotsHorizontal,
+		LoadingIcon,
 		Popover,
 		PopoverMenu,
 	},
@@ -659,16 +661,8 @@ export default {
 			top: 0;
 			left: 0;
 		}
-		.icon-more, .icon-loading {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			width: var(--size);
-			height: var(--size);
-			cursor: pointer;
-			background: none;
-		}
 		.icon-more {
+			cursor: pointer;
 			opacity: 0;
 		}
 		&:focus,

--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -146,7 +146,7 @@ export default {
 				:value="value"
 				class="checkbox-radio-switch__input"
 				@change="onToggle">
-			<div v-if="loading" class="icon-loading-small checkbox-radio-switch__icon" />
+			<LoadingIcon v-if="loading" class="checkbox-radio-switch__icon" />
 			<icon :is="checkboxRadioIconElement"
 				v-else
 				:size="size"
@@ -161,6 +161,7 @@ export default {
 </template>
 
 <script>
+import LoadingIcon from '../LoadingIcon/index.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 import l10n from '../../mixins/l10n.js'
 
@@ -178,6 +179,10 @@ export const TYPE_SWITCH = 'switch'
 
 export default {
 	name: 'CheckboxRadioSwitch',
+
+	components: {
+		LoadingIcon,
+	},
 
 	mixins: [l10n],
 

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -163,13 +163,11 @@ export default {
 		v-model="localValue"
 		v-bind="$attrs"
 		:class="[
-			{
-				'icon-loading-small': loading
-			},
 			multiple ? 'multiselect--multiple': 'multiselect--single'
 		]"
 		:options="options"
 		:limit="maxOptions"
+		:loading="loading"
 		:close-on-select="willCloseOnSelect"
 		:multiple="multiple"
 		:label="label"
@@ -216,12 +214,16 @@ export default {
 		<template #noResult>
 			<span>{{ t('No results') }}</span>
 		</template>
+		<template #loading>
+			<LoadingIcon v-if="loading" />
+		</template>
 	</VueMultiselect>
 </template>
 
 <script>
 import EllipsisedOption from './EllipsisedOption.vue'
 import ListItemIcon from '../ListItemIcon/index.js'
+import LoadingIcon from '../LoadingIcon/index.js'
 import Tooltip from '../../directives/Tooltip/index.js'
 import l10n from '../../mixins/l10n.js'
 
@@ -232,6 +234,7 @@ export default {
 	components: {
 		EllipsisedOption,
 		ListItemIcon,
+		LoadingIcon,
 		VueMultiselect,
 	},
 	directives: {

--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -48,9 +48,14 @@
 	}
 
 	// loading state
-	&.icon-loading-small::after {
-		left: 100%;
-		margin-left: -24px;
+	.loading-icon {
+		position: absolute;
+		right: 1px;
+		top: 1px;
+		width: 48px;
+		height: 35px;
+		background: #fff;
+		z-index: 3;
 	}
 
 	// multiple selected options display


### PR DESCRIPTION
| Component        | Before           | After  |
| ------------- |:-------------:| :-----:|
| `AppSidebar`      | ![Sidebar_before](https://user-images.githubusercontent.com/2496460/174159948-ceafb511-be96-46c6-b168-76105f8c4760.gif) | ![Sidebar_after](https://user-images.githubusercontent.com/2496460/174159984-0c33167d-f2bc-4657-9e73-55b680f48881.gif) |
| `AppNavigationItem` | ![AppNavigation_before](https://user-images.githubusercontent.com/2496460/174157474-ec5aca0d-ab7d-4a7b-a0f9-62895855887f.gif) | ![AppNavigation_after](https://user-images.githubusercontent.com/2496460/174157539-2f6964c6-7566-423f-ab60-cca4cecb37c4.gif) |
| `AppNavigationNewItem` | ![AppNavigationNew_before](https://user-images.githubusercontent.com/2496460/174157192-18216c0d-d3cf-4ef3-96a8-b035d1c45d92.gif) | ![AppNavigationNew_after](https://user-images.githubusercontent.com/2496460/174157213-f68e433b-33cc-4cbb-be94-faa4e0c204b1.gif) |
| `CheckboxRadioSwitch` | ![Checkbox_before](https://user-images.githubusercontent.com/2496460/174156789-0dad6920-cfed-4c3a-9d9a-f785ee0aaf9c.gif) | ![Checkbox_after](https://user-images.githubusercontent.com/2496460/174156809-f6d88643-23b4-49bc-bfa1-4fe670a952bb.gif) |
| `Multiselect` | ![Multiselect_before](https://user-images.githubusercontent.com/2496460/174156503-6ff9a978-7cf7-4f42-ad59-cad86e676b22.gif) | ![Multiselect_after](https://user-images.githubusercontent.com/2496460/174156525-875f105b-248d-4537-8cfa-b2a5a448b159.gif) |