### PR TITLE
Fix invalid tabindex and role

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -197,7 +197,7 @@ include a standard-header like it's used by the files app.
 									v-linkify="{text: title, linkify: linkifyTitle}"
 									v-tooltip.auto="titleTooltip"
 									class="app-sidebar-header__maintitle"
-									:tabindex="titleEditable ? 0 : -1"
+									:tabindex="titleEditable ? 0 : undefined"
 									@click.self="editTitle">
 									{{ title }}
 								</h2>

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -42,7 +42,7 @@
 						:class="{ active: activeTab === tab.id }"
 						:data-id="tab.id"
 						:href="`#tab-${tab.id}`"
-						:tabindex="activeTab === tab.id ? null : -1"
+						:tabindex="activeTab === tab.id ? undefined : -1"
 						role="tab"
 						@click.prevent="setActive(tab.id)">
 						<span class="app-sidebar-tabs__tab-icon">

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -66,9 +66,9 @@
 		}"
 		:style="avatarStyle"
 		class="avatardiv popovermenu-wrapper"
-		:tabindex="disableMenu ? '-1' : '0'"
+		:tabindex="disableMenu ? undefined : '0'"
 		:aria-label="avatarAriaLabel"
-		:role="disableMenu ? '' : 'button'"
+		:role="disableMenu ? undefined : 'button'"
 		v-on="!disableMenu ? { click: toggleMenu } : {}"
 		@keydown.enter="toggleMenu">
 		<!-- @slot Icon slot -->


### PR DESCRIPTION
Bad value "" for attribute role on element div.

An element with the attribute tabindex must not appear as a descendant
of an element with the attribute role=button.

Signed-off-by: Joas Schilling <coding@schilljs.com>