### PR TITLE
Fix HTML validation of AppNavigationToggle

### DIFF
--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -22,21 +22,20 @@
  -
  -->
 <template>
-	<Actions class="app-navigation-toggle">
-		<ActionButton :aria-expanded="open ? 'true' : 'false'"
-			aria-controls="app-navigation-vue"
-			@click="toggleNavigation">
-			<template #icon>
-				<Menu :size="20" />
-			</template>
-			{{ label }}
-		</ActionButton>
-	</Actions>
+	<Button class="app-navigation-toggle"
+		type="tertiary"
+		:aria-expanded="open ? 'true' : 'false'"
+		:aria-label="label"
+		aria-controls="app-navigation-vue"
+		@click="toggleNavigation">
+		<template #icon>
+			<Menu :size="20" />
+		</template>
+	</Button>
 </template>
 
 <script>
-import Actions from '../Actions/index.js'
-import ActionButton from '../ActionButton/index.js'
+import Button from '../Button/index.js'
 import { t } from '../../l10n.js'
 
 import Menu from 'vue-material-design-icons/Menu'
@@ -45,8 +44,7 @@ export default {
 	name: 'AppNavigationToggle',
 
 	components: {
-		Actions,
-		ActionButton,
+		Button,
 		Menu,
 	},
 


### PR DESCRIPTION
> Error: Attribute icon not allowed on element button at this point.
