### PR TITLE
Actions - small a11y adjusts

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -75,10 +75,11 @@ export default {
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }">
+	<li class="action" role="presentation" :class="{ 'action--disabled': disabled }">
 		<button class="action-button"
 			:class="{ focusable: isFocusable }"
 			:aria-label="ariaLabel"
+			role="menuitem"
 			type="button"
 			@click="onClick">
 			<!-- @slot Manually provide icon -->

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -162,6 +162,7 @@ export default {
 	<div v-else
 		v-show="hasMultipleActions || forceMenu"
 		:class="{'action-item--open': opened}"
+
 		class="action-item">
 		<!-- If more than one action, create a popovermenu -->
 		<Popover :delay="0"
@@ -186,7 +187,7 @@ export default {
 						'action-item__menutoggle--default-icon': !iconSlotIsPopulated && defaultIcon === '',
 						'action-item__menutoggle--primary': primary
 					}"
-					aria-haspopup="true"
+					aria-haspopup="menu"
 					:aria-label="ariaLabel"
 					:aria-controls="randomId"
 					:aria-expanded="opened ? 'true' : 'false'"
@@ -213,7 +214,7 @@ export default {
 				@keydown.esc.exact.prevent="closeMenu"
 				@mousemove="onMouseFocusAction">
 				<!-- menu content -->
-				<ul :id="randomId" tabindex="-1">
+				<ul :id="randomId" tabindex="-1" role="menu">
 					<template v-if="opened">
 						<slot />
 					</template>


### PR DESCRIPTION
- add `role=menu` to `Actions`
- add `role="presentation"` and `role="menuitem"` to `ActionButton`

Related: 
- #2502 
- https://github.com/nextcloud/text/pull/2715

Refs: 
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role
