### PR TITLE
Fix ListItem css

### DIFF
--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -145,7 +145,8 @@
 
 				<!-- Main content -->
 				<div class="list-item-content">
-					<div class="list-item-content__main">
+					<div class="list-item-content__main"
+						:class="{ 'list-item-content__main--oneline': oneLine }">
 
 						<!-- First line, title and details -->
 						<div class="line-one"
@@ -360,6 +361,10 @@ export default {
 			}
 		},
 
+		oneLine() {
+			return !this.hasSubtitle && !this.showDetails
+		},
+
 		showCounter() {
 			return !this.displayActionsOnHoverFocus || this.forceDisplayActions
 		},
@@ -500,6 +505,7 @@ export default {
 	&-content__wrapper {
 		display: flex;
 		align-items: center;
+		height: 48px;
 	}
 
 	&-content {
@@ -510,16 +516,19 @@ export default {
 
 		&__main {
 			flex: 1 1 auto;
-			flex-direction: column;
 			width: 0;
 			margin: auto 0;
+
+			&--oneline {
+				display: flex;
+			}
 		}
 
 		&__actions {
 			flex: 0 0 auto;
 			align-self: center;
 			justify-content: center;
-
+			margin-left: 4px;
 		}
 	}
 
@@ -533,7 +542,8 @@ export default {
 	align-items: center;
 	justify-content: space-between;
 	white-space: nowrap;
-	margin: 0 auto;
+	margin: 0 auto 0 0;
+	overflow: hidden;
 	&--bold {
 		font-weight: bold;
 	}
@@ -565,7 +575,6 @@ export default {
 	&__subtitle {
 		overflow: hidden;
 		flex-grow: 1;
-		padding-right: 4px;
 		cursor: pointer;
 		white-space: nowrap;
 		text-overflow: ellipsis;
@@ -573,7 +582,7 @@ export default {
 	}
 
 	&__counter {
-		margin: 2px 4px 0 0;
+		margin: 2px 4px 0 4px;
 	}
 }
 

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -20,7 +20,7 @@
 -->
 <docs>
 
-# Usage
+### Default Usage
 ```
 <ul>
 	<listItem
@@ -119,6 +119,65 @@
 </ul>
 
 ```
+
+### ListItem compact mode
+```
+<ul style="width: 350px;">
+	<listItem
+		:title="'Title of the element'"
+		:counter-number=1
+		:compact="true" >
+		<template #icon>
+			<div class="icon-edit" />
+		</template>
+		<template #subtitle>
+			This one is with subtitle
+		</template>
+		<template #actions>
+			<ActionButton>
+				Button one
+			</ActionButton>
+			<ActionButton>
+				Button two
+			</ActionButton>
+		</template>
+	</listItem>
+	<listItem
+		:title="'Title of the element'"
+		:compact="true" >
+		<template #icon>
+			<div class="icon-edit" />
+		</template>
+	</listItem>
+	<listItem
+		:title="'Title of the element'"
+		:counter-number=3
+		:compact="true" >
+		<template #icon>
+			<div class="icon-edit" />
+		</template>
+		<template #subtitle>
+			This one is with subtitle
+		</template>
+		<template #actions>
+			<ActionButton>
+				Button one
+			</ActionButton>
+			<ActionButton>
+				Button two
+			</ActionButton>
+		</template>
+	</listItem>
+	<listItem
+		:title="'Title of the element'"
+		:counter-number=4
+		:compact="true" >
+		<template #icon>
+			<div class="icon-edit" />
+		</template>
+	</listItem>
+</ul>
+```
 </docs>
 
 <template>
@@ -139,7 +198,8 @@
 			@click="onClick"
 			@keydown.esc="hideActions">
 
-			<div class="list-item-content__wrapper">
+			<div class="list-item-content__wrapper"
+				:class="{ 'list-item-content__wrapper--compact': compact }">
 				<!-- @slot This slot is used for the avatar or icon -->
 				<slot name="icon" />
 
@@ -271,6 +331,14 @@ export default {
 		 * Make title and subtitle bold
 		 */
 		bold: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Show the ListItem in compact design
+		 */
+		compact: {
 			type: Boolean,
 			default: false,
 		},
@@ -506,6 +574,15 @@ export default {
 		display: flex;
 		align-items: center;
 		height: 48px;
+
+		&--compact {
+			height: 36px;
+
+			.line-one, .line-two {
+				margin-top: -4px;
+				margin-bottom: -4px;
+			}
+		}
 	}
 
 	&-content {


### PR DESCRIPTION
This fixes two things:
- The ListItem was not really usable without subtitle but with counter. Different line heights and a completely messed up design were the result. This now brings that case onto one line, when only title and counter are available and fixes the ListItem height, so all ListItems are the same height. 

| Before | After |
|--|--|
[Full odd looking gif](https://user-images.githubusercontent.com/47433654/164996305-9cd5c448-f1bd-45de-8328-f6dd66b8ab91.gif)||
|![old](https://user-images.githubusercontent.com/47433654/180499784-e387bef4-5746-4321-9d81-bf6769664443.png)|![non_compact](https://user-images.githubusercontent.com/47433654/180499906-98170bf2-fe4e-4d2d-8687-5b1edf8a1402.png)|
 
- In connection to the fixed height, it introduces a compact-mode for the list item. Once used without subtitle or in a mixed case, the default sizes are quite large. Esp. if there are multiple elements without subtitle, but a few with subtitle, there is just too much space inbetween those items without. Thus the compact mode reduces the size of the ListItem a bit, so the mixed case looks good.

| Default | Compact Mode |
|--|--|
|![non_compact](https://user-images.githubusercontent.com/47433654/180500061-2a86eb70-5d4d-40f2-b4d0-e16f16002877.png)|![compact_mode](https://user-images.githubusercontent.com/47433654/180500102-a68e252a-012e-4b78-aa12-709a2bb02ca3.png)|