### PR TITLE
Accessible EmptyContent component

### DIFF
--- a/src/components/EmptyContent/EmptyContent.vue
+++ b/src/components/EmptyContent/EmptyContent.vue
@@ -24,12 +24,14 @@
 ### Basic use
 
 Use this component to display a message about an empty content.
-An icon and a title are mandatory.
-Providing an additional description is strongly advised.
+Providing an icon, title, and a description is strongly advised.
 
 ```
-<EmptyContent icon="icon-comment">
+<EmptyContent>
 	No comments
+	<template #icon>
+		<Comment />
+	</template>
 	<template #desc>No comments in here</template>
 </EmptyContent>
 ```
@@ -37,17 +39,21 @@ Providing an additional description is strongly advised.
 <template>
 	<EmptyContent>
 		Network error
-		<template #icon><Airplane /></template>
+		<template #icon>
+			<Airplane />
+		</template>
 		<template #desc>Unable to load the list</template>
 	</EmptyContent>
 </template>
 
 <script>
 import Airplane from 'vue-material-design-icons/Airplane'
+import Comment from 'vue-material-design-icons/Comment'
 
 export default {
 	components: {
-		Airplane
+		Airplane,
+		Comment,
 	}
 }
 </script>
@@ -57,15 +63,15 @@ export default {
 
 <template>
 	<div class="empty-content" role="note">
-		<div class="empty-content__icon" :class="icon" role="img">
-			<!-- @slot Optional icon slot -->
+		<div v-if="hasIcon" class="empty-content__icon">
+			<!-- @slot Optional material design icon -->
 			<slot name="icon" />
 		</div>
-		<h2 class="empty-content__title">
-			<!-- @slot Mandatory title -->
+		<h2 v-if="hasTitle" class="empty-content__title">
+			<!-- @slot Optional title -->
 			<slot />
 		</h2>
-		<p v-show="$slots.desc">
+		<p v-if="hasDescription">
 			<!-- @slot Optional description -->
 			<slot name="desc" />
 		</p>
@@ -75,13 +81,29 @@ export default {
 <script>
 export default {
 	name: 'EmptyContent',
-	props: {
-		/**
-		 * The main icon illustration
-		 */
-		icon: {
-			type: String,
-			default: '',
+
+	data() {
+		return {
+			/**
+			 * Making sure the slots are reactive
+			 */
+			slots: this.$slots,
+		}
+	},
+
+	computed: {
+		hasIcon() {
+			return this.slots.icon !== undefined
+		},
+
+		hasTitle() {
+			return this.slots?.default !== undefined
+				&& this.slots?.default[0]?.text
+		},
+
+		hasDescription() {
+			return this.slots?.desc !== undefined
+				&& this.slots?.desc[0]?.text
 		},
 	},
 }
@@ -117,5 +139,4 @@ export default {
 		text-align: center;
 	}
 }
-
 </style>


### PR DESCRIPTION
Close https://github.com/nextcloud/nextcloud-vue/issues/2500

### To Do

- [x] Require accessible https://github.com/robcresswell/vue-material-design-icons exclusively with the icon slot and drop class based icons
	- Icons use inline `svg` markup https://github.com/robcresswell/vue-material-design-icons/blob/5.1.2/build.ts#L20-L28
	- Icons have `role="img"` https://github.com/robcresswell/vue-material-design-icons/blob/5.1.2/build.ts#L18
	- Icons are [decorative](https://www.w3.org/WAI/tutorials/images/decorative/) so they have the `aria-hidden` attribute https://github.com/robcresswell/vue-material-design-icons/blob/5.1.2/build.ts#L15
- [x] Remove mandatory title requirement
	- Allow more flexibility in component usage without a title e.g https://github.com/nextcloud/nextcloud-vue/blob/498364d197c5257d758a48853abf87f71ba1d8d2/src/components/DashboardWidget/DashboardWidget.vue#L143-L149