### PR TITLE
Adjust loading icon style, replace `fillColor` prop

### DIFF
--- a/src/components/LoadingIcon/LoadingIcon.vue
+++ b/src/components/LoadingIcon/LoadingIcon.vue
@@ -43,8 +43,8 @@
 		<svg :width="size"
 			:height="size"
 			viewBox="0 0 24 24">
-			<path :fill="colorCircle" d="M12,4V2A10,10 0 1,0 22,12H20A8,8 0 1,1 12,4Z" />
-			<path :fill="colorSpinner" d="M12,4V2A10,10 0 0,1 22,12H20A8,8 0 0,0 12,4Z">
+			<path :fill="colors[0]" d="M12,4V2A10,10 0 1,0 22,12H20A8,8 0 1,1 12,4Z" />
+			<path :fill="colors[1]" d="M12,4V2A10,10 0 0,1 22,12H20A8,8 0 0,0 12,4Z">
 				<title v-if="title">{{ title }}</title>
 			</path>
 		</svg>
@@ -83,21 +83,14 @@ export default {
 		},
 	},
 	computed: {
-		colorCircle() {
+		colors() {
+			const colors = ['#777', '#CCC']
 			if (this.appearance === 'light') {
-				return '#777'
+				return colors
 			} else if (this.appearance === 'dark') {
-				return '#CCC'
+				return colors.reverse()
 			}
-			return 'var(--color-loading-light)'
-		},
-		colorSpinner() {
-			if (this.appearance === 'light') {
-				return '#CCC'
-			} else if (this.appearance === 'dark') {
-				return '#777'
-			}
-			return 'var(--color-loading-dark)'
+			return ['var(--color-loading-light)', 'var(--color-loading-dark)']
 		},
 	},
 }

--- a/src/components/LoadingIcon/LoadingIcon.vue
+++ b/src/components/LoadingIcon/LoadingIcon.vue
@@ -24,23 +24,36 @@
 # Usage
 
 ```
-<LoadingIcon />
-<LoadingIcon :size="64" fill-color="var(--color-primary-element)" title="Loading with primary color" />
+<div>
+	<LoadingIcon />
+</div>
+<div style="background-color: #171717;">
+	<LoadingIcon :size="64" appearance="light" title="Loading on dark background" />
+</div>
+<div style="background-color: #fff;">
+	<LoadingIcon :size="64" appearance="dark" title="Loading on light background" />
+</div>
 ```
 </docs>
 
 <template>
-	<Loading :size="size" :fill-color="fillColor" :title="title" />
+	<span :aria-label="title"
+		role="img"
+		class="material-design-icon loading-icon">
+		<svg :width="size"
+			:height="size"
+			viewBox="0 0 24 24">
+			<path :fill="colorCircle" d="M12,4V2A10,10 0 1,0 22,12H20A8,8 0 1,1 12,4Z" />
+			<path :fill="colorSpinner" d="M12,4V2A10,10 0 0,1 22,12H20A8,8 0 0,0 12,4Z">
+				<title v-if="title">{{ title }}</title>
+			</path>
+		</svg>
+	</span>
 </template>
 
 <script>
-import Loading from 'vue-material-design-icons/Loading'
-
 export default {
 	name: 'LoadingIcon',
-	components: {
-		Loading,
-	},
 	props: {
 		/**
 		 * Specify the size of the loading icon.
@@ -50,11 +63,16 @@ export default {
 			default: 20,
 		},
 		/**
-		 * Overwrites the default color. Necessary for dark backgrounds.
+		 * The appearance of the loading icon.
+		 * 'auto' adjusts to the Nextcloud color scheme,
+		 * 'light' and 'dark' are static.
 		 */
-		fillColor: {
+		appearance: {
 			type: String,
-			default: 'var(--color-loading-dark)',
+			validator(value) {
+				return ['auto', 'light', 'dark'].includes(value)
+			},
+			default: 'auto',
 		},
 		/**
 		 * Specify what is loading.
@@ -64,11 +82,29 @@ export default {
 			default: '',
 		},
 	},
+	computed: {
+		colorCircle() {
+			if (this.appearance === 'light') {
+				return '#777'
+			} else if (this.appearance === 'dark') {
+				return '#CCC'
+			}
+			return 'var(--color-loading-light)'
+		},
+		colorSpinner() {
+			if (this.appearance === 'light') {
+				return '#CCC'
+			} else if (this.appearance === 'dark') {
+				return '#777'
+			}
+			return 'var(--color-loading-dark)'
+		},
+	},
 }
 </script>
 
 <style lang="scss" scoped>
-.material-design-icon::v-deep svg {
+.loading-icon svg{
 	animation: rotate var(--animation-duration, 0.8s) linear infinite;
 }
 </style>


### PR DESCRIPTION
This PR adjusts the style of the vue loading icon to the old style of the loading icon:
![Screenshot 2022-07-22 at 22-13-17 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/180520062-3a63f42b-de70-4c14-a3d1-a57d5467c11a.png)

It also replaces the `fillColor` with an `appearance` prop. This prevents the usage of arbitrary colors, and allows to select whether the icon adjusts its color to the Nextcloud color scheme, or always shows as `light` or `dark`, independent of the color scheme.

At the moment, the colors for the `light` and `dark` mode are hard-coded, since I didn't find any color variables that don't change with the color scheme. Any hints here are welcome.

Follow-up to #2727.