### PR TITLE
Fix single action validation

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -380,7 +380,7 @@ export default {
 		 */
 		isValidSingleAction() {
 			return this.actions.length === 1
-				&& this.firstActionElement !== null
+				&& this.firstActionBinding !== null
 		},
 		/**
 		 * Return the title of the single action if forced


### PR DESCRIPTION
Since https://github.com/nextcloud/nextcloud-vue/pull/585 the first action validation does not check anymore whether it's an allowed action (`firstActionElement` is `undefined` always). We only want to allow `ActionButton`, `ActionLink` and `ActionRouter` as a standalone action.

This PR fixes this bug.