### PR TITLE
Do not treat an avatar as a button if there is no menu

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -66,10 +66,10 @@
 		}"
 		:style="avatarStyle"
 		class="avatardiv popovermenu-wrapper"
-		:tabindex="disableMenu ? undefined : '0'"
+		:tabindex="!hasMenu ? undefined : '0'"
 		:aria-label="avatarAriaLabel"
-		:role="disableMenu ? undefined : 'button'"
-		v-on="!disableMenu ? { click: toggleMenu } : {}"
+		:role="!hasMenu ? undefined : 'button'"
+		v-on="hasMenu ? { click: toggleMenu } : {}"
 		@keydown.enter="toggleMenu">
 		<!-- @slot Icon slot -->
 		<slot name="icon">

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -66,9 +66,9 @@
 		}"
 		:style="avatarStyle"
 		class="avatardiv popovermenu-wrapper"
-		:tabindex="!hasMenu ? undefined : '0'"
+		:tabindex="hasMenu ? '0' : undefined"
 		:aria-label="avatarAriaLabel"
-		:role="!hasMenu ? undefined : 'button'"
+		:role="hasMenu ? 'button' : undefined"
 		v-on="hasMenu ? { click: toggleMenu } : {}"
 		@keydown.enter="toggleMenu">
 		<!-- @slot Icon slot -->


### PR DESCRIPTION
An avatar is treated as a button that toggles its contact menu, except when the menu was explicitly disabled. However, a menu may not be available even if it was not explicitly disabled (for example, if the avatar is for the current user). As no menu can be toggled in that case the avatar should not be treated as a button either.

Note that the menu is lazily loaded, so after you try to open the menu it could happen that there is actually no menu (that scenario can be tested by always returning a 404 in [ContactsMenuController](https://github.com/nextcloud/server/blob/232322fe062031d5fe5b5297ca60b22bc1da1d30/core/Controller/ContactsMenuController.php#L61)). In that case the avatar stops being a button after the user explicitly triggered it, is it needed to signal that to screen readers? Or maybe [a toast should be shown in all cases](https://github.com/nextcloud/nextcloud-vue/blob/510246b200cdb5aaf25e87f1e6287f26d6d65e43/src/components/Avatar/Avatar.vue#L515), as even if you are not using a screen reader the behaviour is a bit strange. **Opinions?**

Another problem I noticed is that after focusing on an avatar and pressing enter to show the contact menu the focus is moved to the contact menu, but if shift-tab is used to go back to the avatar to close the menu the focus would move instead to another element (as the contact menu was appended to the end of the body). Is there any easy / quick way to solve that, or should I open a new issue?

## How to test

- Create a conversation in Talk
- In the right sidebar, open the Participants tab
- Add another participant
- Click again on _Search or add participants_ to focus it again
- Press tab to focus the next element

### Result with this pull request

The avatar of the other participant is focused. The avatar of the current user was skipped, as no interaction is possible.

### Result without this pull request

The avatar of the current user is focused, even if no further interaction is possible
