### PR TITLE
Emit click event from checkboxradioswitch component

### DIFF
--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -159,7 +159,8 @@ export default {
 			'checkbox-radio-switch--button-variant-h-grouped': buttonVariant && buttonVariantGrouped === 'horizontal',
 		}"
 		:style="cssVars"
-		class="checkbox-radio-switch">
+		class="checkbox-radio-switch"
+		@click="$emit('click')">
 		<label :for="id" class="checkbox-radio-switch__label">
 			<input :id="id"
 				:checked="isChecked"


### PR DESCRIPTION
For some reason a click event is not emitted when clicking on the
checkboxradioswitch component. This commit brings this functionality to
the component.

Signed-off-by: Marco Ambrosini <marcoambrosini@icloud.com>