### PR TITLE
Add more explicit title to the sidebar close button

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -41,6 +41,9 @@ msgstr ""
 msgid "Close navigation"
 msgstr ""
 
+msgid "Close sidebar"
+msgstr ""
+
 msgid "Confirm changes"
 msgstr ""
 

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -420,7 +420,7 @@ export default {
 	data() {
 		return {
 			changeTitleTranslated: t('Change title'),
-			closeTranslated: t('Close'),
+			closeTranslated: t('Close sidebar'),
 			favoriteTranslated: t('Favorite'),
 			isStarred: this.starred,
 		}


### PR DESCRIPTION
To make sure that a screen reader user has some context on what the button actually does
