### PR TITLE
Add aria-expended attribute

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -190,7 +190,7 @@ export default {
 					aria-haspopup="menu"
 					:aria-label="ariaLabel"
 					:aria-controls="randomId"
-					:aria-expanded="opened ? 'true' : 'false'"
+					:aria-expanded="opened.toString()"
 					type="button"
 					@focus="onFocus"
 					@blur="onBlur">

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -130,6 +130,7 @@ Just set the `pinned` prop.
 				class="app-navigation-entry-link"
 				:aria-description="ariaDescription"
 				href="#"
+				:aria-expanded="opened.toString()"
 				@click="onClick">
 
 				<!-- icon if not collapsible -->


### PR DESCRIPTION
Add aria-expended attribute to link
Correct aria-expended attribute of button in Actions.vue

Fixes https://github.com/nextcloud/nextcloud-vue/issues/2755