### PR TITLE
Fix missing icon in actions custom icon slot

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -124,10 +124,21 @@ export default {
 
 ### Custom icon slot in child elements
 ```
-<Actions :primary="true">
-	<ActionButton><template #icon><MagnifyIcon /></template>Search</ActionButton>
-	<ActionButton icon="icon-delete">Delete</ActionButton>
-</Actions>
+<template>
+	<Actions :primary="true">
+		<ActionButton><template #icon><Magnify :size="20" /></template>Search</ActionButton>
+		<ActionButton icon="icon-delete">Delete</ActionButton>
+	</Actions>
+</template>
+<script>
+import Magnify from 'vue-material-design-icons/Magnify'
+
+export default {
+	components: {
+		Magnify,
+	},
+}
+</script>
 ```
 
 </docs>


### PR DESCRIPTION
Fixes a missing icon in the actions component docs.

Before:
![Screenshot 2022-08-02 at 21-51-45 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/182461448-d6adafa2-8532-4ad6-bb2a-cae03954c4de.png)

After:
![Screenshot 2022-08-02 at 21-55-54 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/182461968-924cc308-1a03-4197-a517-8e1a13c2cd01.png)
