### PR TITLE
Add md icon slot to ActionTextEditable

### DIFF
--- a/src/components/ActionTextEditable/ActionTextEditable.vue
+++ b/src/components/ActionTextEditable/ActionTextEditable.vue
@@ -26,11 +26,34 @@ This component is made to be used inside of the [Actions](#Actions) component sl
 All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 
 ```
-<Actions>
-	<ActionTextEditable icon="icon-edit" value="This is a textarea" />
-	<ActionTextEditable icon="icon-edit" :disabled="true" value="This is a disabled textarea" />
-	<ActionTextEditable icon="icon-edit" title="Please edit the text" value="This is a textarea with title" />
-</Actions>
+<template>
+	<Actions>
+		<ActionTextEditable value="This is a textarea">
+			<template #icon>
+				<Pencil :size="20" />
+			</template>
+		</ActionTextEditable>
+		<ActionTextEditable :disabled="true" value="This is a disabled textarea">
+			<template #icon>
+				<Pencil :size="20" />
+			</template>
+		</ActionTextEditable>
+		<ActionTextEditable title="Please edit the text" value="This is a textarea with title">
+			<template #icon>
+				<Pencil :size="20" />
+			</template>
+		</ActionTextEditable>
+	</Actions>
+</template>
+<script>
+import Pencil from 'vue-material-design-icons/Pencil'
+
+export default {
+	components: {
+		Pencil,
+	},
+}
+</script>
 ```
 </docs>
 
@@ -38,10 +61,12 @@ All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span class="action-text-editable"
 			@click="onClick">
-			<!-- icon -->
-			<span :class="[isIconUrl ? 'action-text-editable__icon--url' : icon]"
-				:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-				class="action-text-editable__icon" />
+			<!-- @slot Manually provide icon -->
+			<slot name="icon">
+				<span :class="[isIconUrl ? 'action-text-editable__icon--url' : icon]"
+					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
+					class="action-text-editable__icon" />
+			</slot>
 
 			<!-- form and input -->
 			<form ref="form"
@@ -205,6 +230,16 @@ $input-margin: 4px;
 
 		background-position: #{$icon-margin} center;
 		background-size: $icon-size;
+	}
+
+	&::v-deep .material-design-icon {
+		width: $clickable-area;
+		height: $clickable-area;
+		opacity: $opacity_full;
+
+		.material-design-icon__svg {
+			vertical-align: middle;
+		}
 	}
 
 	// Forms & text inputs


### PR DESCRIPTION
This adds a material design icon slot to the `ActionTextEditable` component and adjusts the icons used in the docs.

Before (with icon classes):
![Screenshot 2022-08-03 at 12-36-06 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/182588183-dcd2d122-b828-4204-9bfe-4685c0477211.png)

After (with material design icons):
![Screenshot 2022-08-03 at 12-37-42 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/182588457-6492a01c-5a9b-4558-8bf1-449c48479d1f.png)
