### PR TITLE
Fix focus trap init function

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -580,7 +580,7 @@ export default {
 		useFocusTrap() {
 			const contentContainer = this.$refs.mask
 			// wait until all children are mounted and available in the DOM before focusTrap can be added
-			this.$nextTick(function() {
+			this.$nextTick(() => {
 				this.focusTrap = createFocusTrap(contentContainer)
 				this.focusTrap.activate()
 			})


### PR DESCRIPTION
Makes sure that "this" is the right scope so that deactivate is called
on the correct element.

Doesn't seem to affect the current behavior.

Discovered while adding a modal example in https://github.com/nextcloud/nextcloud-vue/pull/2953 to prove https://github.com/nextcloud/nextcloud-vue/issues/2816

I tested locally with the example PR that this change here doesn't affect anything, the focus still returns to the correct element.