### PR TITLE
Fix focusing last action with page-down

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -187,13 +187,13 @@ export default {
 ```
 <template>
 	<Actions :primary="true">
-		<ActionButton icon="icon-edit">
+		<ActionButton>
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
 			Edit
 		</ActionButton>
-		<ActionButton icon="icon-delete">
+		<ActionButton>
 			<template #icon>
 				<Delete :size="20" />
 			</template>

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -846,7 +846,7 @@ export default {
 		focusLastAction(event) {
 			if (this.opened) {
 				this.preventIfEvent(event)
-				this.focusIndex = this.$el.querySelectorAll(focusableSelector).length - 1
+				this.focusIndex = this.$refs.menu.querySelectorAll(focusableSelector).length - 1
 				this.focusAction()
 			}
 		},


### PR DESCRIPTION
This PR fixes focusing the last action with page-down, which is currently broken. Closes #2958.

I also cleaned up two unused icon classes that I missed to remove in #2927.