### PR TITLE
Fix InputField focus state

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -262,8 +262,13 @@ export default {
 		&:hover {
 			border-color: var(--color-primary-element);
 		}
+
 		&:focus {
 			cursor: text;
+		}
+
+		&:focus-visible {
+			box-shadow: unset !important; // Override server rules
 		}
 
 		&--success {


### PR DESCRIPTION
overrides a box shadow rule that effectively makes the border of
the input field 4px thick instead of 2.

Signed-off-by: Marco Ambrosini <marcoambrosini@icloud.com>