### PR TITLE
Add aria-label to single action button

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -719,7 +719,7 @@ export default {
 						firstAction?.data?.class,
 					],
 					attrs: {
-						'aria-label': firstAction?.componentOptions?.propsData?.ariaLabel,
+						'aria-label': firstAction?.componentOptions?.propsData?.ariaLabel || firstAction?.componentOptions?.children?.[0]?.text,
 					},
 					props: {
 						 // If it has a title, we use a secondary button


### PR DESCRIPTION
This adds a default `aria-label` with the value of the tooltip to the single action button, fixing the `You need to fill either the text or the ariaLabel props in the button component.` warning that currently occurs in the docs for single actions if the `ActionButton` has no `aria-label` set. Follow-up of #2911.