### PR TITLE
Use ButtonVue everywhere in the docs

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -287,7 +287,7 @@ It can be used with one or multiple actions.
 ```
 <template>
 	<div style="display: flex;align-items: center;">
-		<button @click="toggled = !toggled">Toggle multiple action</button>
+		<ButtonVue @click="toggled = !toggled">Toggle multiple action</ButtonVue>
 		<Actions>
 			<template #icon>
 				<DotsHorizontalCircleOutline :size="20" />

--- a/src/components/AppSettingsDialog/AppSettingsDialog.vue
+++ b/src/components/AppSettingsDialog/AppSettingsDialog.vue
@@ -27,7 +27,7 @@ providing the section's title prop. You can put your settings within each
 ```vue
 <template>
 	<div>
-		<button @click="settingsOpen = true">Show Settings</button>
+		<ButtonVue @click="settingsOpen = true">Show Settings</ButtonVue>
 		<AppSettingsDialog :open.sync="settingsOpen" :show-navigation="true" title="Application settings">
 			<AppSettingsSection id="asci-title-1" title="Example title 1">
 				Some example content

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -62,12 +62,12 @@ is dropped on a creadcrumb.
 					</ActionButton>
 				</Breadcrumb>
 				<template #actions>
-					<Button>
+					<ButtonVue>
 						<template #icon>
 							<Plus :size="20" />
 						</template>
 						New
-					</Button>
+					</ButtonVue>
 				</template>
 			</Breadcrumbs>
 		</div>

--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -38,7 +38,7 @@ actual pickers:
 <template>
 	<div class="container0">
 		<ColorPicker v-model="color">
-			<button> Click Me </button>
+			<ButtonVue> Click Me </ButtonVue>
 		</ColorPicker>
 		<div :style="{'background-color': color}" class="color0" />
 	</div>
@@ -71,7 +71,7 @@ export default {
 ```vue
 <template>
 	<div class="container1">
-		<button @click="open = !open"> Click Me </button>
+		<ButtonVue @click="open = !open"> Click Me </ButtonVue>
 		<ColorPicker :value="color" @input="updateColor" :shown.sync="open">
 			<div :style="{'background-color': color}" class="color1" />
 		</ColorPicker>

--- a/src/components/Content/Content.vue
+++ b/src/components/Content/Content.vue
@@ -41,7 +41,7 @@ It includes the Navigation, the App content and the Sidebar.
 		</AppNavigation>
 		<AppContent>
 			<h2>Your main app content here</h2>
-			<button @click="opened = !opened">Toggle sidebar</button>
+			<ButtonVue @click="opened = !opened">Toggle sidebar</ButtonVue>
 		</AppContent>
 		<AppSidebar v-if="opened" title="cat-picture.jpg" @close="opened=false"></AppSidebar>
 	</Content>

--- a/src/components/EmojiPicker/EmojiPicker.vue
+++ b/src/components/EmojiPicker/EmojiPicker.vue
@@ -33,7 +33,7 @@
 	<template>
 		<div>
 			<EmojiPicker @select="select" style="display: inline-block">
-				<button> Click Me </button>
+				<ButtonVue> Click Me </ButtonVue>
 			</EmojiPicker>
 			<span>selected emoji: {{ emoji }}</span>
 		</div>
@@ -64,7 +64,7 @@
 				:show-preview="true"
 				@select="select"
 				style="display: inline-block">
-				<button> Click Me </button>
+				<ButtonVue> Click Me </ButtonVue>
 			</EmojiPicker>
 			<span>selected emoji: {{ emoji }}</span>
 		</div>

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -25,7 +25,7 @@
 	```vue
 	<template>
 		<div>
-			<button @click="showModal">Show Modal</button>
+			<ButtonVue @click="showModal">Show Modal</ButtonVue>
 			<modal
 				v-if="modal"
 				@close="closeModal"
@@ -69,7 +69,7 @@
 	```vue
 	<template>
 		<div>
-			<button @click="showModal">Show Modal with fields</button>
+			<ButtonVue @click="showModal">Show Modal with fields</ButtonVue>
 			<modal
 				v-if="modal"
 				@close="closeModal"
@@ -136,10 +136,10 @@
 	```vue
 	<template>
 		<div>
-			<button @click="showModal">Show Modal</button>
+			<ButtonVue @click="showModal">Show Modal</ButtonVue>
 			<modal v-if="modal" @close="closeModal" size="small">
 				<EmojiPicker container=".modal-mask" @select="select">
-					<button>Select emoji {{ emoji }}</button>
+					<ButtonVue>Select emoji {{ emoji }}</ButtonVue>
 				</EmojiPicker>
 			</modal>
 		</div>

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -42,7 +42,7 @@ open prop on this component;
 <template>
 	<Popover>
 		<template #trigger>
-			<button> I am the trigger </button>
+			<ButtonVue> I am the trigger </ButtonVue>
 		</template>
 		<template>
 			<form tabindex="0" @submit.prevent>
@@ -71,7 +71,7 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 <template>
 	<Popover :focus-trap="false">
 		<template #trigger>
-			<button> Click me! </button>
+			<ButtonVue> Click me! </ButtonVue>
 		</template>
 		<template>
 			Hi! 🚀


### PR DESCRIPTION
This PR replaces all usages of the normal HTML `button` with the `ButtonVue` from nextcloud/vue. Fixes half of #2988.

Before:
![Screenshot 2022-08-09 at 21-57-15 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/183749482-86d45fd8-0b88-4591-ade2-02a131ba737f.png)

After:
![Screenshot 2022-08-09 at 22-24-35 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/183753894-02ac7a21-a555-4471-aa41-041ff0f67786.png)
