### PR TITLE
Fix Actions styling in Breadcrumbs

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -436,6 +436,19 @@ export default {
 		},
 
 		/**
+		 * Specifies the button type used for trigger and single actions buttons
+		 * Accepted values: primary, secondary, tertiary, tertiary-no-background, tertiary-on-primary, error, warning, success. If left empty,
+		 * the default button style will be applied.
+		 */
+		type: {
+			type: String,
+			validator(value) {
+				return ['primary', 'secondary', 'tertiary', 'tertiary-no-background', 'tertiary-on-primary', 'error', 'warning', 'success'].indexOf(value) !== -1
+			},
+			default: null,
+		},
+
+		/**
 		 * Aria label for the actions menu
 		 */
 		ariaLabel: {
@@ -723,7 +736,7 @@ export default {
 					},
 					props: {
 						 // If it has a title, we use a secondary button
-						type: title ? 'secondary' : 'tertiary',
+						type: this.type || (title ? 'secondary' : 'tertiary'),
 						disabled: this.disabled || firstAction?.componentOptions?.propsData?.disabled,
 						...firstAction?.componentOptions?.propsData,
 					},
@@ -807,10 +820,10 @@ export default {
 								class: 'action-item__menutoggle',
 								props: {
 									// If requested, we use a primary button
-									type: this.primary
+									type: this.type || (this.primary
 										? 'primary'
 										// If it has a title, we use a secondary button
-										: this.menuTitle ? 'secondary' : 'tertiary',
+										: this.menuTitle ? 'secondary' : 'tertiary'),
 									disabled: this.disabled,
 								},
 								slot: 'trigger',

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -51,6 +51,7 @@ This component is meant to be used inside a Breadcrumbs component.
 		</element>
 		<Actions v-if="$slots.default"
 			ref="actions"
+			type="tertiary"
 			:force-menu="forceMenu"
 			:open="open"
 			:menu-title="title"
@@ -300,40 +301,17 @@ export default {
 	&::v-deep .action-item {
 		// Adjustments necessary to correctly shrink on small screens
 		max-width: 100%;
-		.trigger {
-			max-width: 100%;
-		}
 
-		&__menutoggle--with-title,
-		&--single--with-title {
-			// Adjustments necessary to correctly shrink on small screens
-			max-width: 100%;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
-			width: 100%;
-			display: inline-block;
+		.button-vue {
+			padding: 0 4px 0 16px;
 
-			background-color: unset;
-			border: none;
-
-			&:hover,
-			&:focus,
-			&:active {
-				background-color: var(--color-background-dark) !important;
-				color: var(--color-main-text);
-			}
-
-			// Show the icon on the right
-			padding-right: 44px;
-			padding-left: 14px;
-			& > span.material-design-icon {
-				right: 0;
-				left: unset;
+			&__wrapper {
+				flex-direction: row-reverse;
 			}
 		}
+
 		// Adjust the background of the last crumb when the action is open
-		&.action-item--open .action-item__menutoggle--with-title {
+		&.action-item--open .action-item__menutoggle {
 			background-color: var(--color-background-dark);
 			color: var(--color-main-text);
 		}


### PR DESCRIPTION
This fixes (and simplifies) the styling of the `Actions` component in the `Breadcrumbs` component, which is broken due to #2911. To allow to re-use the `ButtonVue` styling, I allowed to forward the `type` prop from the `Actions` to the `ButtonVue` component.

Closes #2988.

Before:
![Screenshot 2022-08-09 at 23-06-16 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/183761583-62324b69-5168-4f6e-a1a0-74e56c58a0cf.png)

After:
![Screenshot 2022-08-09 at 23-10-35 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/183762151-0b168d84-4294-455e-8652-8a98c948d663.png)
