### PR TITLE
Add emits option to components emitting events

### DIFF
--- a/src/components/ActionCheckbox/ActionCheckbox.vue
+++ b/src/components/ActionCheckbox/ActionCheckbox.vue
@@ -99,6 +99,13 @@ export default {
 		},
 	},
 
+	emits: [
+		'change',
+		'check',
+		'uncheck',
+		'update:checked',
+	],
+
 	computed: {
 		/**
 		 * determines if the action is focusable

--- a/src/components/ActionInput/ActionInput.vue
+++ b/src/components/ActionInput/ActionInput.vue
@@ -170,6 +170,13 @@ export default {
 		},
 	},
 
+	emits: [
+		'input',
+		'submit',
+		'change',
+		'update:value',
+	],
+
 	computed: {
 		isIconUrl() {
 			try {

--- a/src/components/ActionRadio/ActionRadio.vue
+++ b/src/components/ActionRadio/ActionRadio.vue
@@ -112,6 +112,11 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:checked',
+		'change',
+	],
+
 	computed: {
 		/**
 		 * determines if the action is focusable

--- a/src/components/ActionTextEditable/ActionTextEditable.vue
+++ b/src/components/ActionTextEditable/ActionTextEditable.vue
@@ -136,6 +136,12 @@ export default {
 		},
 	},
 
+	emits: [
+		'input',
+		'update:value',
+		'submit',
+	],
+
 	computed: {
 		/**
 		 * determines if the action is focusable

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -476,6 +476,15 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:open',
+		'open',
+		'update:open',
+		'close',
+		'focus',
+		'blur',
+	],
+
 	data() {
 		return {
 			opened: this.open,

--- a/src/components/AppContent/AppContent.vue
+++ b/src/components/AppContent/AppContent.vue
@@ -194,6 +194,8 @@ export default {
 		},
 	},
 
+	emits: ['update:showDetails'],
+
 	data() {
 		return {
 			contentHeight: 0,

--- a/src/components/AppNavigationIconBullet/AppNavigationIconBullet.vue
+++ b/src/components/AppNavigationIconBullet/AppNavigationIconBullet.vue
@@ -65,6 +65,8 @@ export default {
 		},
 	},
 
+	emits: ['click'],
+
 	computed: {
 		formattedColor() {
 			if (this.color.startsWith('#')) {

--- a/src/components/AppNavigationItem/AppNavigationIconCollapsible.vue
+++ b/src/components/AppNavigationItem/AppNavigationIconCollapsible.vue
@@ -59,6 +59,8 @@ export default {
 		},
 	},
 
+	emits: ['click'],
+
 	computed: {
 		labelButton() {
 			return open ? t('Close') : t('Open')

--- a/src/components/AppNavigationItem/AppNavigationItem.vue
+++ b/src/components/AppNavigationItem/AppNavigationItem.vue
@@ -367,6 +367,14 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:menuOpen',
+		'update:open',
+		'update:title',
+		'click',
+		'undo',
+	],
+
 	data() {
 		return {
 			editingValue: '',

--- a/src/components/AppNavigationItem/InputConfirmCancel.vue
+++ b/src/components/AppNavigationItem/InputConfirmCancel.vue
@@ -85,6 +85,12 @@ export default {
 		},
 	},
 
+	emits: [
+		'input',
+		'confirm',
+		'cancel',
+	],
+
 	data() {
 		return {
 			labelConfirm: t('Confirm changes'),

--- a/src/components/AppNavigationNew/AppNavigationNew.vue
+++ b/src/components/AppNavigationNew/AppNavigationNew.vue
@@ -79,6 +79,8 @@ export default {
 			required: true,
 		},
 	},
+
+	emits: ['click'],
 }
 </script>
 

--- a/src/components/AppNavigationNewItem/AppNavigationNewItem.vue
+++ b/src/components/AppNavigationNewItem/AppNavigationNewItem.vue
@@ -120,6 +120,8 @@ export default {
 		},
 	},
 
+	emits: ['new-item'],
+
 	data() {
 		return {
 			newItemValue: '',

--- a/src/components/AppNavigationToggle/AppNavigationToggle.vue
+++ b/src/components/AppNavigationToggle/AppNavigationToggle.vue
@@ -61,6 +61,8 @@ export default {
 		},
 	},
 
+	emits: ['update:open'],
+
 	computed: {
 		label() {
 			return this.open ? t('Close navigation') : t('Open navigation')

--- a/src/components/AppSettingsDialog/AppSettingsDialog.vue
+++ b/src/components/AppSettingsDialog/AppSettingsDialog.vue
@@ -125,6 +125,8 @@ export default {
 		},
 	},
 
+	emits: ['update:open'],
+
 	data() {
 		return {
 			selectedSection: '',

--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -417,6 +417,21 @@ export default {
 		},
 	},
 
+	emits: [
+		'close',
+		'closing',
+		'closed',
+		'opening',
+		'opened',
+		'figure-click',
+		'update:starred',
+		'update:titleEditable',
+		'update:title',
+		'update:active',
+		'submit-title',
+		'dismiss-editing',
+	],
+
 	data() {
 		return {
 			changeTitleTranslated: t('Change title'),

--- a/src/components/AppSidebar/AppSidebarTabs.vue
+++ b/src/components/AppSidebar/AppSidebarTabs.vue
@@ -95,6 +95,8 @@ export default {
 		},
 	},
 
+	emits: ['update:active'],
+
 	data() {
 		return {
 			/**

--- a/src/components/AppSidebarTab/AppSidebarTab.vue
+++ b/src/components/AppSidebarTab/AppSidebarTab.vue
@@ -62,6 +62,11 @@ export default {
 		},
 	},
 
+	emits: [
+		'bottom-reached',
+		'scroll',
+	],
+
 	computed: {
 		// TODO: implement a better way to force pass a prop fromm Sidebar
 		isActive() {

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -132,6 +132,10 @@ export default {
 			default: false,
 		},
 	},
+	emits: [
+		'update:open',
+		'dropped',
+	],
 	data() {
 		return {
 			/**

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -156,6 +156,7 @@ export default {
 			default: 'icon-home',
 		},
 	},
+	emits: ['dropped'],
 	data() {
 		return {
 			/**

--- a/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
+++ b/src/components/CheckboxRadioSwitch/CheckboxRadioSwitch.vue
@@ -304,6 +304,8 @@ export default {
 		},
 	},
 
+	emits: ['update:checked'],
+
 	computed: {
 		/**
 		 * Icon size

--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -192,6 +192,14 @@ export default {
 		},
 	},
 
+	emits: [
+		'submit',
+		'close',
+		'update:open',
+		'update:value',
+		'input',
+	],
+
 	data() {
 		return {
 			currentColor: this.value,

--- a/src/components/DatetimePicker/DatetimePicker.vue
+++ b/src/components/DatetimePicker/DatetimePicker.vue
@@ -268,6 +268,11 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:value',
+		'update:timezone-id',
+	],
+
 	data() {
 		return {
 			showTimezonePopover: false,

--- a/src/components/EmojiPicker/EmojiPicker.vue
+++ b/src/components/EmojiPicker/EmojiPicker.vue
@@ -172,6 +172,10 @@ export default {
 			default: 'body',
 		},
 	},
+	emits: [
+		'select',
+		'select-data',
+	],
 	data() {
 		return {
 			emojiIndex: new EmojiIndex(data),

--- a/src/components/InputField/InputField.vue
+++ b/src/components/InputField/InputField.vue
@@ -172,6 +172,11 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:value',
+		'trailing-button-click',
+	],
+
 	computed: {
 		inputName() {
 			return 'input' + GenRandomId()

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -396,6 +396,8 @@ export default {
 		},
 	},
 
+	emits: ['click'],
+
 	data() {
 		return {
 			hovered: false,

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -447,6 +447,12 @@ export default {
 		},
 	},
 
+	emits: [
+		'previous',
+		'next',
+		'close',
+	],
+
 	data() {
 		return {
 			mc: null,

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -343,6 +343,11 @@ export default {
 		},
 	},
 
+	emits: [
+		'change',
+		'update:value',
+	],
+
 	data() {
 		return {
 			elWidth: 0,

--- a/src/components/MultiselectTags/MultiselectTags.vue
+++ b/src/components/MultiselectTags/MultiselectTags.vue
@@ -117,6 +117,7 @@ export default {
 			default: (element, index) => index < 5,
 		},
 	},
+	emits: ['input'],
 	data() {
 		return {
 			tags: [],

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -118,6 +118,11 @@ export default {
 		},
 	},
 
+	emits: [
+		'after-show',
+		'after-hide',
+	],
+
 	mounted() {
 		this.$watch(
 			() => {

--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -224,6 +224,12 @@ export default {
 		},
 	},
 
+	emits: [
+		'submit',
+		'paste',
+		'update:value',
+	],
+
 	data() {
 		return {
 			tribute: null,

--- a/src/components/SettingsInputText/SettingsInputText.vue
+++ b/src/components/SettingsInputText/SettingsInputText.vue
@@ -101,6 +101,13 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:value',
+		'input',
+		'submit',
+		'change',
+	],
+
 	data() {
 		return {
 			submitTranslated: t('Submit'),

--- a/src/components/SettingsSelectGroup/SettingsSelectGroup.vue
+++ b/src/components/SettingsSelectGroup/SettingsSelectGroup.vue
@@ -99,6 +99,10 @@ export default {
 			default: false,
 		},
 	},
+	emits: [
+		'input',
+		'error',
+	],
 	data() {
 		return {
 			groups: {},

--- a/src/components/TextField/TextField.vue
+++ b/src/components/TextField/TextField.vue
@@ -246,6 +246,10 @@ export default {
 		},
 	},
 
+	emits: [
+		'update:value',
+	],
+
 	methods: {
 		handleInput(event) {
 			this.$emit('update:value', event.target.value)

--- a/src/components/TimezonePicker/TimezonePicker.vue
+++ b/src/components/TimezonePicker/TimezonePicker.vue
@@ -84,6 +84,7 @@ export default {
 			default: 'floating',
 		},
 	},
+	emits: ['input'],
 	computed: {
 		placeholder() {
 			return t('Type to search time zone')

--- a/src/components/UserBubble/UserBubble.vue
+++ b/src/components/UserBubble/UserBubble.vue
@@ -196,6 +196,10 @@ export default {
 			default: 2,
 		},
 	},
+	emits: [
+		'click',
+		'update:open',
+	],
 	computed: {
 		/**
 		 * If userbubble is empty, let's NOT

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -56,6 +56,10 @@ export default {
 		},
 	},
 
+	emits: [
+		'click',
+	],
+
 	computed: {
 		isIconUrl() {
 			try {


### PR DESCRIPTION
This PR lists the events emitted by the components under the `emits` option new in Vue 2.7, see https://blog.vuejs.org/posts/vue-2-7-naruto.html

Listing them does not affect runtime behavior (different to vue 3), but helps with the vue 3 migration in #2637 and might help with type-checking.