### PR TITLE
Fix regressions from floating-vue migration

### DIFF
--- a/src/components/RichContenteditable/RichContenteditable.vue
+++ b/src/components/RichContenteditable/RichContenteditable.vue
@@ -322,7 +322,7 @@ export default {
 			}
 			return {
 				content: t('Message limit of {count} characters reached', { count: this.maxlength }),
-				show: true,
+				shown: true,
 				trigger: 'manual',
 			}
 		},

--- a/src/directives/Tooltip/index.scss
+++ b/src/directives/Tooltip/index.scss
@@ -32,7 +32,7 @@ $arrow-width: 10px;
 
 		// TOP
 		&[data-popper-placement^='top'] .v-popper__arrow-container {
-			bottom: 0;
+			bottom: -$arrow-width;
 			border-bottom-width: 0;
 			border-top-color: var(--color-main-background);
 		}


### PR DESCRIPTION
This PR fixes two regressions from the migration to floating-vue in #2600. The `RichContenteditable` tooltip open variable name was not adjusted and the tooltip top arrow style was broken.

Before (tooltip only shown on hover):
![Bildschirmfoto vom 2022-08-10 17-08-27](https://user-images.githubusercontent.com/2496460/183939901-98659b0b-73f6-409c-a7c4-31f4a2b8a3b9.png)

After (tooltip automatically shown):
![Bildschirmfoto vom 2022-08-10 17-10-32](https://user-images.githubusercontent.com/2496460/183940398-47fc6894-1485-4562-8084-f457e4999b4f.png)
