### PR TITLE
Also export tooltip options

### DIFF
--- a/src/directives/Tooltip/index.js
+++ b/src/directives/Tooltip/index.js
@@ -29,3 +29,4 @@ options.themes.tooltip.distance = 10
 options.themes.tooltip['arrow-padding'] = 3
 
 export default VTooltip
+export { options }


### PR DESCRIPTION
This adds an export of the tooltip `options` object, so one can customize the tooltips if necessary.

Works like this:
```js
import { options as TooltipOptions } from '@nextcloud/vue/dist/Directives/Tooltip'
TooltipOptions.container = '#content-vue'
```

Closes #2993.