### PR TITLE
Fix single button action icon attribute

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -69,9 +69,6 @@ If you're using a long text you can specify a title
 	<template>
 		<Actions>
 			<ActionButton icon="icon-add" @click="showMessage('Add')">
-				<template #icon>
-					<Plus :size="20" />
-				</template>
 				Add new
 			</ActionButton>
 			<ActionButton title="Long button" @click="showMessage('Delete')">
@@ -84,13 +81,33 @@ If you're using a long text you can specify a title
 	</template>
 	<script>
 	import Delete from 'vue-material-design-icons/Delete'
-	import Plus from 'vue-material-design-icons/Plus'
 
 	export default {
 		components: {
 			Delete,
-			Plus,
 		},
+		methods: {
+			showMessage(msg) {
+				alert(msg)
+			},
+		},
+	}
+	</script>
+
+```
+
+Action icon attribute with a single action
+
+```vue
+	<template>
+		<Actions>
+			<ActionButton icon="icon-add" @click="showMessage('Add')">
+				Add new
+			</ActionButton>
+		</Actions>
+	</template>
+	<script>
+	export default {
 		methods: {
 			showMessage(msg) {
 				alert(msg)

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -739,6 +739,8 @@ export default {
 						'action-item action-item--single',
 						firstAction?.data?.staticClass,
 						firstAction?.data?.class,
+						// use icon attribute as class if icon slot is not used
+						icon ? undefined : firstAction?.componentOptions?.propsData?.icon,
 					],
 					attrs: {
 						'aria-label': firstAction?.componentOptions?.propsData?.ariaLabel || firstAction?.componentOptions?.children?.[0]?.text,


### PR DESCRIPTION
Actual:
<img width="541" alt="image" src="https://user-images.githubusercontent.com/277525/184219897-f77486ba-bb24-42ec-8222-c04c43345202.png">

Expected:

The icon should appear.

It already works with this format when inside the popover, it's only when there's only a single action that it doesn't.

The component is used that way in many places in the server, see https://github.com/nextcloud/server/pull/33508#issuecomment-1212357494