### PR TITLE
V6.0.0 beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## v6.0.0-beta.2 (2022-08-11)
+
+#### :bug: Bug Fix
+
+* [#3006](https://github.com/nextcloud/nextcloud-vue/pull/3006) Fix single button action icon attribute ([@PVince81](https://github.com/PVince81))
+
 ## v6.0.0-beta.1 (2022-08-11)
 
 #### :boom: Breaking Change
 * [#2980](https://github.com/nextcloud/nextcloud-vue/pull/2980) Bump @nextcloud/eslint-config from 8.0.0 to 8.1.2 ([@dependabot[bot]](https://github.com/apps/dependabot))
-* [#2911](https://github.com/nextcloud/nextcloud-vue/pull/2911) Use render function in Actions component ([@raimund-schluessler](https://github.com/raimund-schluessler))
+* ~~[#2911](https://github.com/nextcloud/nextcloud-vue/pull/2911) Use render function in Actions component ([@raimund-schluessler](https://github.com/raimund-schluessler))~~ No more breaking after [#3006](https://github.com/nextcloud/nextcloud-vue/pull/3006) in beta.2
 * [#2929](https://github.com/nextcloud/nextcloud-vue/pull/2929) Bump vue from 2.6.14 to 2.7.8 ([@raimund-schluessler](https://github.com/raimund-schluessler))
 * [#2923](https://github.com/nextcloud/nextcloud-vue/pull/2923) Enforce setting section ids ([@nickvergessen](https://github.com/nickvergessen))
 
 #### :rocket: Enhancement
+* [#2911](https://github.com/nextcloud/nextcloud-vue/pull/2911) Use render function in Actions component ([@raimund-schluessler](https://github.com/raimund-schluessler))
 * [#2998](https://github.com/nextcloud/nextcloud-vue/pull/2998) Import tooltip directive only locally ([@raimund-schluessler](https://github.com/raimund-schluessler))
 * [#2983](https://github.com/nextcloud/nextcloud-vue/pull/2983) Simplify webpack configuration ([@raimund-schluessler](https://github.com/raimund-schluessler))
 * [#2973](https://github.com/nextcloud/nextcloud-vue/pull/2973) Allow to filter the available tags ([@nickvergessen](https://github.com/nickvergessen))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 #### :bug: Bug Fix
 
+* [#3017](https://github.com/nextcloud/nextcloud-vue/pull/3017) Fix icon-class, re-add default-icon support for Actions ([@raimund-schluessler](https://github.com/raimund-schluessler))
 * [#3006](https://github.com/nextcloud/nextcloud-vue/pull/3006) Fix single button action icon attribute ([@PVince81](https://github.com/PVince81))
 
 ## v6.0.0-beta.1 (2022-08-11)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "6.0.0-beta.1",
+	"version": "6.0.0-beta.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "6.0.0-beta.1",
+			"version": "6.0.0-beta.2",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "6.0.0-beta.1",
+	"version": "6.0.0-beta.2",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -449,6 +449,16 @@ export default {
 		},
 
 		/**
+		 * Icon to show for the toggle menu button
+		 * when more than one action is inside the actions component.
+		 * Only replace the default three-dot icon if really necessary.
+		 */
+		defaultIcon: {
+			type: String,
+			default: '',
+		},
+
+		/**
 		 * Aria label for the actions menu
 		 */
 		ariaLabel: {
@@ -730,7 +740,7 @@ export default {
 		 */
 		if (this.isValidSingleAction(actions) && !this.forceMenu) {
 			const firstAction = actions[0]
-			const icon = firstAction?.data?.scopedSlots?.icon()?.[0]
+			const icon = firstAction?.data?.scopedSlots?.icon()?.[0] || h('span', { class: ['icon', firstAction?.componentOptions?.propsData?.icon] })
 			const title = this.forceTitle ? this.menuTitle : ''
 			const clickListener = firstAction?.componentOptions?.listeners?.click
 			return h('ButtonVue',
@@ -739,8 +749,6 @@ export default {
 						'action-item action-item--single',
 						firstAction?.data?.staticClass,
 						firstAction?.data?.class,
-						// use icon attribute as class if icon slot is not used
-						icon ? undefined : firstAction?.componentOptions?.propsData?.icon,
 					],
 					attrs: {
 						'aria-label': firstAction?.componentOptions?.propsData?.ariaLabel || firstAction?.componentOptions?.children?.[0]?.text,
@@ -782,11 +790,15 @@ export default {
 		 * Otherwise, we render the actions in a popover
 		 */
 		} else {
-			const triggerIcon = this.$slots.icon?.[0] || h('DotsHorizontal', {
-				props: {
-					size: 20,
-				},
-			})
+			const triggerIcon = this.$slots.icon?.[0] || (
+				this.defaultIcon
+					? h('span', { class: ['icon', this.defaultIcon] })
+					: h('DotsHorizontal', {
+						props: {
+							size: 20,
+						},
+					})
+			)
 			return h('div',
 				{
 					class: [


### PR DESCRIPTION
contains https://github.com/nextcloud/nextcloud-vue/pull/3006 which moves https://github.com/nextcloud/nextcloud-vue/pull/2911 from "breaking" to "enhancement".

- [x] defaultIcon for Actions regression: https://github.com/nextcloud/nextcloud-vue/pull/3006#issuecomment-1212462507
- [x] #3017 
 
note: the regressions were just a misunderstanding about whether we wanted to keep or break icon attr: https://github.com/nextcloud/nextcloud-vue/pull/3006#issuecomment-1212422191
