### PR TITLE
Add jquery as depenendency for tributejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"floating-vue": "^1.0.0-beta.18",
 				"focus-trap": "^6.9.4",
 				"hammerjs": "^2.0.8",
+				"jquery": "^3.6.0",
 				"linkify-string": "^3.0.4",
 				"md5": "^2.3.0",
 				"splitpanes": "^2.4.1",
@@ -18064,6 +18065,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/jquery": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
 		},
 		"node_modules/js-base64": {
 			"version": "2.6.4",
@@ -43392,6 +43398,11 @@
 					}
 				}
 			}
+		},
+		"jquery": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
 		},
 		"js-base64": {
 			"version": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"floating-vue": "^1.0.0-beta.18",
 		"focus-trap": "^6.9.4",
 		"hammerjs": "^2.0.8",
+		"jquery": "^3.6.0",
 		"linkify-string": "^3.0.4",
 		"md5": "^2.3.0",
 		"splitpanes": "^2.4.1",


### PR DESCRIPTION
Adds jquery to the vue library as a dependency, to avoid issues during npm link with other repos, which shouldn't matter in terms of building as those are marked as external anyways.

Required for https://github.com/nextcloud/server/pull/33517