### PR TITLE
Fix issues with focus trap on modal

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -661,7 +661,9 @@ export default {
 			const contentContainer = this.$refs.mask
 			// wait until all children are mounted and available in the DOM before focusTrap can be added
 			this.$nextTick(() => {
-				this.focusTrap = createFocusTrap(contentContainer)
+				this.focusTrap = createFocusTrap(contentContainer, {
+					allowOutsideClick: true,
+				})
 				this.focusTrap.activate()
 			})
 		},

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -445,6 +445,14 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+
+		/**
+		 * Additional elements to add to the focus trap
+		 */
+		additionalTrapElements: {
+			type: Array,
+			default: () => [],
+		},
 	},
 
 	emits: [
@@ -503,6 +511,12 @@ export default {
 				} else {
 					this.slideshowTimeout.start()
 				}
+			}
+		},
+		additionalTrapElements(elements) {
+			if (this.focusTrap) {
+				const contentContainer = this.$refs.mask
+				this.focusTrap.updateContainerElements([contentContainer, ...elements])
 			}
 		},
 	},


### PR DESCRIPTION
This PR addresses two issues that are not directly visible in the components but with the way how our apps use them.

- Allow click outside even if the focus trap is set
- Allow apps (like viewer) to pass additional focus trap elements (like the sidebar) which will then be added to the trap so it can be accessed

Corresponding viewer commit: https://github.com/nextcloud/viewer/pull/1319/commits/a2fb11097d8a3a81c4f666edfc038b7b5c6aafef