### PR TITLE
Disable focus-trap for Popover by default

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -114,7 +114,7 @@ export default {
 		},
 		focusTrap: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 	},
 


### PR DESCRIPTION
This PR disabled the focus trap for Popovers by default for the moment. Reason is, that focusing other elements from within an Actions menu does not work anymore. E.g. here: https://github.com/nextcloud/tasks/blob/master/src/components/TaskBody.vue#L583-L588 the call to `focus()` has no effect.

Also see this example (copy into docs):
```vue
<template>
    <div>
        <input ref="input" />
        <Actions>
            <ActionButton @click="focusInput" :close-after-click="true">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Focus input
            </ActionButton>
            <ActionButton @click="actionDelete">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Delete
            </ActionButton>
        </Actions>
    </div>
</template>
<script>
import Delete from 'vue-material-design-icons/Delete'

export default {
	components: {
		Delete,
	},
	methods: {
		actionDelete() {
			alert('Delete')
		},
		async focusInput() {
			await this.$nextTick()
            this.$refs.input.focus()
		},
	},
}
</script>
```
The input should be focused when clicking on "Focus input" in the menu.
