### PR TITLE
Allow click outside for Popover focus trap

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -170,6 +170,7 @@ export default {
 					// Prevents to lose focus using esc key
 					// Focus will be release when popover be hide
 					escapeDeactivates: false,
+					allowOutsideClick: true,
 				})
 				this.$focusTrap.activate()
 			})


### PR DESCRIPTION
Similar to #3020 this fixes an issue with the Popver/Actions focus-trap which was added in https://github.com/nextcloud/nextcloud-vue/pull/2941 and prevented directly opening another Actions menu, when one was already open. Before, you would need two clicks on the second Actions menu trigger to open the other Actions menu, one for closing the first one, one for actually opening the second one.

Try this example code by copying into the docs:
```vue
<template>
    <div>
        <Actions>
            <ActionButton @click="actionDelete">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Delete
            </ActionButton>
            <ActionButton @click="actionDelete">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Delete
            </ActionButton>
        </Actions>
        <Actions>
            <ActionButton @click="actionDelete">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Delete
            </ActionButton>
            <ActionButton @click="actionDelete">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Delete
            </ActionButton>
        </Actions>
    </div>
</template>
<script>
import Delete from 'vue-material-design-icons/Delete'

export default {
	components: {
		Delete,
	},
	methods: {
		actionDelete() {
			alert('Delete')
		},
	},
}
</script>
```

With this PR, each Actions menu opens after one click, no matter if the other is open or not.

There is still an issue open, preventing focusing any other element from within the Actions menu, see #3021.