### PR TITLE
Dismis focus trap when component gets destroyed

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -141,6 +141,10 @@ export default {
 		)
 	},
 
+	beforeDestroy() {
+		this.afterHide()
+	},
+
 	methods: {
 		afterShow() {
 			/**


### PR DESCRIPTION
Otherwise the trap is kept active while the component is being destroyed e.g. on unshare of a link