### PR TITLE
Don't return focus to initial element for Actions

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -175,6 +175,7 @@ export default {
 					// Focus will be release when popover be hide
 					escapeDeactivates: false,
 					allowOutsideClick: true,
+					returnFocusOnDeactivate: false,
 				})
 				this.$focusTrap.activate()
 			})


### PR DESCRIPTION
This PR is aimed at enabling this use case:
```vue
<template>
    <div>
        <input ref="input" />
        <Actions>
            <ActionButton @click="focusInput" :close-after-click="true">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Focus input
            </ActionButton>
            <ActionButton @click="actionDelete">
                <template #icon>
                    <Delete :size="20" />
                </template>
                Delete
            </ActionButton>
        </Actions>
    </div>
</template>
<script>
import Delete from 'vue-material-design-icons/Delete'

export default {
	components: {
		Delete,
	},
	methods: {
		actionDelete() {
			alert('Delete')
		},
		async focusInput() {
			await this.$nextTick()
            this.$refs.input.focus()
		},
	},
}
</script>
```
but unfortunately, it doesn't solve the issue. Closing.