### PR TITLE
Don't return focus after close-after-click

### DIFF
--- a/src/components/ActionButton/ActionButton.vue
+++ b/src/components/ActionButton/ActionButton.vue
@@ -26,37 +26,51 @@ This component is made to be used inside of the [Actions](#Actions) component sl
 
 ```vue
 	<template>
-		<Actions>
-			<ActionButton @click="showMessage('Delete')">
-				<template #icon>
-					<Delete :size="20" />
-				</template>
-				Delete
-			</ActionButton>
-			<ActionButton :close-after-click="true" @click="showMessage('Delete and close menu')">
-				<template #icon>
-					<Delete :size="20" />
-				</template>
-				Delete and close
-			</ActionButton>
-			<ActionButton :disabled="true" @click="showMessage('Disabled')">
-				<template #icon>
-					<Delete :size="20" />
-				</template>
-				Disabled button
-			</ActionButton>
-		</Actions>
+		<div style="display: flex; align-items: center;">
+			<Actions>
+				<ActionButton @click="showMessage('Delete')">
+					<template #icon>
+						<Delete :size="20" />
+					</template>
+					Delete
+				</ActionButton>
+				<ActionButton :close-after-click="true" @click="showMessage('Delete and close menu')">
+					<template #icon>
+						<Delete :size="20" />
+					</template>
+					Delete and close
+				</ActionButton>
+				<ActionButton :close-after-click="true" @click="focusInput">
+					<template #icon>
+						<Plus :size="20" />
+					</template>
+					Create
+				</ActionButton>
+				<ActionButton :disabled="true" @click="showMessage('Disabled')">
+					<template #icon>
+						<Delete :size="20" />
+					</template>
+					Disabled button
+				</ActionButton>
+			</Actions>
+			<input ref="input" />
+		</div>
 	</template>
 	<script>
 	import Delete from 'vue-material-design-icons/Delete'
+	import Plus from 'vue-material-design-icons/Plus'
 
 	export default {
 		components: {
 			Delete,
+			Plus,
 		},
 		methods: {
 			showMessage(msg) {
 				alert(msg)
+			},
+			focusInput() {
+				this.$nextTick(() => this.$refs.input.focus())
 			},
 		},
 	}

--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -559,12 +559,14 @@ export default {
 			 */
 			this.$emit('open')
 		},
-		closeMenu(e) {
+		closeMenu(returnFocus = true) {
 			if (!this.opened) {
 				return
 			}
 
 			this.opened = false
+
+			this.$refs.popover.clearFocusTrap({ returnFocus })
 
 			/**
 			 * Event emitted when the popover menu open state is changed
@@ -639,7 +641,7 @@ export default {
 			}
 			// Esc
 			if (event.keyCode === 27) {
-				this.closeMenu(event)
+				this.closeMenu()
 				event.preventDefault()
 			}
 		},
@@ -811,6 +813,7 @@ export default {
 				[
 					h('Popover',
 						{
+							ref: 'popover',
 							props: {
 								delay: 0,
 								handleResize: true,

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -82,7 +82,7 @@ export default {
 			if (this.closeAfterClick) {
 				const parent = GetParent(this, 'Actions')
 				if (parent && parent.closeMenu) {
-					parent.closeMenu()
+					parent.closeMenu(false)
 				}
 			}
 		},


### PR DESCRIPTION
As alternative to #3028, I would like to propose a less complex solution for the `Actions` component focus-trap problem in #3021. When an `Action` has the `close-after-click` prop set, the focus is not returned to the initial element after closing. This enables programmatically focusing another element (e.g. an input element)  after the `Actions` menu is closed. Checkout the example added. 

In difference to #3028 it does not introduce a scoped slot, hence is not a breaking change, but just keeps the current behaviour intact, without changes to the app.
On the other hand, It is a bit less flexible, since the dev cannot configure whether the focus is returned or not at the moment. But if one really needs this option, it could be implemented by simply adding a prop for it.