### PR TITLE
Fix reference to closed menu in "aria-controls"

### DIFF
--- a/src/components/Actions/Actions.vue
+++ b/src/components/Actions/Actions.vue
@@ -854,7 +854,7 @@ export default {
 								attrs: {
 									'aria-haspopup': 'menu',
 									'aria-label': this.ariaLabel,
-									'aria-controls': this.randomId,
+									'aria-controls': this.opened ? this.randomId : null,
 									'aria-expanded': this.opened.toString(),
 								},
 								on: {


### PR DESCRIPTION
Fixes #2842 

The `aria-controls` attribute must point to an element in the same document. When the menu is closed it is removed from the DOM, so the `aria-controls` attribute should be set only when the menu is open.

According to MDN [_The `aria-controls` only needs to be set when the popup is visible_](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls), so I guess it is fine to remove it if the menu is not there rather than always having it in the DOM but hidden, although I do not really know.