### PR TITLE
Fix breadcrumbs dropdown icon alignment

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -302,7 +302,7 @@ export default {
 
 	// Adjust action item appearance for crumbs with actions
 	// to match other crumbs
-	&:deep() .action-item {
+	&:not(.dropdown) :deep(.action-item) {
 		// Adjustments necessary to correctly shrink on small screens
 		max-width: 100%;
 


### PR DESCRIPTION
This fixes the alignment of the actions menu icon in the `Breadcrumbs` component.

Before:
![Screenshot 2022-08-18 at 10-02-46 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/185342828-124b99b0-5c5d-43b3-a3af-958adc144b0f.png)

After:
![Screenshot 2022-08-18 at 10-16-41 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/185345848-2fd00cda-d23c-4c17-827c-94a05a01bbf9.png)
