### PR TITLE
Fix margin for Modal inline actions

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -805,17 +805,20 @@ export default {
 		}
 
 		.header-actions {
-			margin: math.div($header-height - $clickable-area, 2);
 			color: white;
 		}
 
-		.action-item--single {
-			box-sizing: border-box;
-			width: $clickable-area;
-			height: $clickable-area;
-			cursor: pointer;
-			background-position: center;
-			background-size: 22px;
+		&:deep() .action-item {
+			margin: math.div($header-height - $clickable-area, 2);
+
+			&--single {
+				box-sizing: border-box;
+				width: $clickable-area;
+				height: $clickable-area;
+				cursor: pointer;
+				background-position: center;
+				background-size: 22px;
+			}
 		}
 
 		:deep(button) {


### PR DESCRIPTION
All the other actions (slideshow, close...) have a proper margin

| Before | After |
|:---------:|:------:|
|![Peek 18-08-2022 19-35](https://user-images.githubusercontent.com/14975046/185458818-a9cf18db-f9fb-4cc8-9462-ca501cc48718.gif)|![Peek 18-08-2022 19-34](https://user-images.githubusercontent.com/14975046/185458820-bd7fba1d-4356-4f5c-a72a-556ed2f22236.gif)|