### PR TITLE
Always show NcAppSettingsDialog title

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -323,13 +323,11 @@ export default {
 					},
 				}, [
 					// app-settings title
-					this.title
-						? h('h2', {
-							attrs: {
-								class: 'app-settings__title',
-							},
-						}, this.title)
-						: undefined,
+					h('h2', {
+						attrs: {
+							class: 'app-settings__title',
+						},
+					}, this.title),
 
 					// app-settings navigation + content
 					h(

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -370,7 +370,10 @@ export default {
 	flex-direction: column;
 	min-width: 0;
 	&__title {
-		padding-top: 12px;
+		min-height: $clickable-area;
+		height: $clickable-area;
+		line-height: $clickable-area;
+		padding-top: 4px; // Same as the close button top spacing
 		text-align: center;
 	}
 	&__wrapper {


### PR DESCRIPTION
This changes the `NcAppSettingsDialog` to always show the title element, independent of whether a title is set or not.
This allows to click the modal close button even if no title is given. Before it was visible, but not clickable, since it was hidden behind the dialogs content. Closes #3029.

Check by removing the `title` prop of `NcAppSettingsDialog`.