### PR TITLE
Make input field button style take precedence

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -316,19 +316,16 @@ export default {
 		}
 	}
 
-	&__clear-button {
+	&__clear-button.button-vue {
 		position: absolute;
 		top: 2px;
 		right: 1px;
+		min-width: unset;
+		min-height: unset;
+		height: 32px;
+		width: 32px !important;
+		border-radius: var(--border-radius-large);
 	}
-}
-
-:deep(.button-vue) {
-	min-width: unset;
-	min-height: unset;
-	height: 32px;
-	width: 32px !important;
-	border-radius: var(--border-radius-large);
 }
 
 </style>


### PR DESCRIPTION
Depending on how the bundler packs together the CSS rules of nextcloud/vue, it would happen that the style of `NcButton` takes precedence over the custom adjustment to the button in `NcInputField`, leading to a wrongly positioned button.

This PR ensures that the custom adjustment to the button in `NcInputField` always apply.