### PR TITLE
Add ref to NcInputField in NcTextField

### DIFF
--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -113,6 +113,7 @@ export default {
 
 <template>
 	<NcInputField v-bind="$props"
+		ref="inputField"
 		v-on="$listeners"
 		@input="handleInput">
 		<!-- Default slot for the leading icon -->


### PR DESCRIPTION
The added `ref` simplifies programmatically focusing the `input` field of `NcInputField` when using `NcTextField`.
This will be used e.g. here:
https://github.com/nextcloud/tasks/pull/2086/files#diff-c8bcf2830b5032bb1455ee25738dd6fa8cdb38b7c4e00ea59e69e577aaac973fR402