### PR TITLE
Fix contrast of next/prev modal buttons

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -852,14 +852,17 @@ export default {
 		z-index: 10000;
 		// ignore display: none
 		display: flex !important;
-		align-items: center;
-		justify-content: center;
-		width: 8%;
-		min-width: $clickable-area;
 		height: 35vw;
 		position: absolute;
 		transition: opacity 250ms,
-			visibility 250ms;
+		visibility 250ms;
+		color: var(--color-primary-text);
+
+		&:focus-visible {
+			// Override NcButton focus styles
+			box-shadow: 0 0 0 2px var(--color-primary-text);
+			background-color: var(--color-box-shadow);
+		}
 
 		// we want to keep the elements on page
 		// even if hidden to avoid having a unbalanced
@@ -871,10 +874,10 @@ export default {
 		}
 	}
 	.prev {
-		left: 0;
+		left: 2px;
 	}
 	.next {
-		right: 0;
+		right: 2px;
 	}
 
 	/* Content */


### PR DESCRIPTION
Fix https://github.com/nextcloud/nextcloud-vue/issues/2954

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/24800714/185724374-881b964c-f373-4063-985e-54f7746ad05c.png) | ![image](https://user-images.githubusercontent.com/24800714/185724263-1ce381f2-0c81-4127-b15b-9fde2e4023ab.png)
![image](https://user-images.githubusercontent.com/24800714/185724377-d74b2a13-2dd2-4829-bb50-926a128415ab.png) | ![image](https://user-images.githubusercontent.com/24800714/186743038-c76462ab-fcdf-42ac-9b88-a942ab29b8c9.png)