### PR TITLE
Allow more than text on EmptyContent description

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -103,7 +103,6 @@ export default {
 
 		hasDescription() {
 			return this.slots?.desc !== undefined
-				&& this.slots?.desc[0]?.text
 		},
 	},
 }


### PR DESCRIPTION
Adding a slot to NcEmptyContent to put a button below.

There is however still a problem with reactivity, when using multiple NcEmptyContent 'after' each other.
If i first show an EmptyContent with LoadingIcon only, and after finished loading i want to show an EmptyContent with icon and text, then the text is not shown. Same applies to Icon (Action, Desc), if a slot is not used on the first usage, but should be shown on the second. (Example in https://github.com/nextcloud/forms/pull/1308)
@raimund-schluessler @skjnldsv @Pytal Any idea, how to fix the emptyContent reactivity here? Seems like there was some attempt to fix reactivity in https://github.com/nextcloud/nextcloud-vue/pull/2867, but did this maybe introduce the problem? :see_no_evil: 

![Screenshot from 2022-08-21 21-26-58](https://user-images.githubusercontent.com/47433654/185810828-e47e4b5a-f603-4042-8207-c12d44d14745.png)
