### PR TITLE
Fix EmptyContent Reactivity

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -73,15 +73,14 @@ export default {
 
 <template>
 	<div class="empty-content" role="note">
-		<div v-if="hasIcon" class="empty-content__icon">
+		<div v-if="$slots.icon" class="empty-content__icon">
 			<!-- @slot Optional material design icon -->
 			<slot name="icon" />
 		</div>
 		<h2 v-if="hasTitle" class="empty-content__title">
-			<!-- @slot Optional title -->
-			<slot />
+			{{ title }}
 		</h2>
-		<p v-if="hasDescription">
+		<p v-if="$slots.desc">
 			<!-- @slot Optional description -->
 			<slot name="desc" />
 		</p>
@@ -92,27 +91,16 @@ export default {
 export default {
 	name: 'NcEmptyContent',
 
-	data() {
-		return {
-			/**
-			 * Making sure the slots are reactive
-			 */
-			slots: this.$slots,
-		}
+	props: {
+		title: {
+			type: String,
+			default: '',
+		},
 	},
 
 	computed: {
-		hasIcon() {
-			return this.slots.icon !== undefined
-		},
-
 		hasTitle() {
-			return this.slots?.default !== undefined
-				&& this.slots?.default[0]?.text
-		},
-
-		hasDescription() {
-			return this.slots?.desc !== undefined
+			return this.title !== ''
 		},
 	},
 }


### PR DESCRIPTION
So - this fixes Reactivity for me.

|Before|After|
|:---:|:---:|
|<video autoplay src="https://user-images.githubusercontent.com/14975046/186139154-c80a6692-f09f-4ff3-9e24-c9fd30990b75.mp4" />|<video autoplay src="https://user-images.githubusercontent.com/14975046/186138687-09c17a52-1b52-4600-887f-19bd2b4c9ffa.mp4" />|



(With this code: https://github.com/nextcloud/forms/pull/1308/files)


@Pytal can you remember, why you introduced that reactivity stuff in #2867 ? Any place, where i can/need to test it?

@raimund-schluessler As you mentioned https://github.com/nextcloud/tasks/blob/0611f1b897c4681035b7e6541247dd4dcc9cea44/src/components/TaskCreateDialog.vue#L77-L85 - Does this work for you on current master? Do you see similar issues as me above (Not seeing the description on second EmptyContent)?