### PR TITLE
Fix emptyContent once more

### DIFF
--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -141,15 +141,13 @@ export default {
 		<!-- This element is shown if we have items, but want to show a general message as well.
 		Can be used e.g. to show "No mentions" on top of the item list. -->
 		<NcEmptyContent v-if="showHalfNcArea"
+			:description="halfEmptyContentString"
 			class="half-screen">
 			<template #icon>
 				<!-- @slot The icon to show in the half empty content area. -->
 				<slot name="halfEmptyContentIcon">
 					<Check />
 				</slot>
-			</template>
-			<template #desc>
-				{{ halfEmptyContentString }}
 			</template>
 		</NcEmptyContent>
 		<!-- The list of items to show. -->
@@ -177,13 +175,11 @@ export default {
 		</div>
 		<!-- @slot Slot for showing information in case of an empty item list. -->
 		<slot v-else-if="items.length === 0" name="empty-content">
-			<NcEmptyContent v-if="emptyContentMessage">
+			<NcEmptyContent v-if="emptyContentMessage"
+				:description="emptyContentMessage">
 				<template #icon>
 					<!-- @slot The icon to show in the empty content area. -->
 					<slot name="emptyContentIcon" />
-				</template>
-				<template #desc>
-					{{ emptyContentMessage }}
 				</template>
 			</NcEmptyContent>
 		</slot>

--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -28,12 +28,11 @@ Providing an icon, title, and a description is strongly advised.
 
 ```
 <template>
-	<NcEmptyContent>
-		No comments
+	<NcEmptyContent
+		title="No comments">
 		<template #icon>
 			<Comment />
 		</template>
-		<template #desc>No comments in here</template>
 	</NcEmptyContent>
 </template>
 
@@ -47,24 +46,28 @@ export default {
 }
 </script>
 ```
-
 ```
 <template>
-	<NcEmptyContent>
-		Network error
+	<NcEmptyContent
+		title="No comments"
+		description="No comments in here">
 		<template #icon>
-			<Airplane />
+			<Comment />
 		</template>
-		<template #desc>Unable to load the list</template>
+		<template #action>
+			<NcButton type="primary">
+				Add a comment!
+			</NcButton>
+		</template>
 	</NcEmptyContent>
 </template>
 
 <script>
-import Airplane from 'vue-material-design-icons/Airplane'
+import Comment from 'vue-material-design-icons/Comment'
 
 export default {
 	components: {
-		Airplane,
+		Comment,
 	},
 }
 </script>
@@ -80,10 +83,13 @@ export default {
 		<h2 v-if="hasTitle" class="empty-content__title">
 			{{ title }}
 		</h2>
-		<p v-if="$slots.desc">
-			<!-- @slot Optional description -->
-			<slot name="desc" />
+		<p v-if="hasDescription">
+			{{ description }}
 		</p>
+		<div v-if="$slots.action" class="empty-content__action">
+			<!-- @slot Optional slot for a button or the like -->
+			<slot name="action" />
+		</div>
 	</div>
 </template>
 
@@ -96,11 +102,19 @@ export default {
 			type: String,
 			default: '',
 		},
+
+		description: {
+			type: String,
+			default: '',
+		},
 	},
 
 	computed: {
 		hasTitle() {
 			return this.title !== ''
+		},
+		hasDescription() {
+			return this.description !== ''
 		},
 	},
 }
@@ -134,6 +148,10 @@ export default {
 	&__title {
 		margin-bottom: 10px;
 		text-align: center;
+	}
+
+	&__action {
+		margin-top: 8px;
 	}
 }
 </style>


### PR DESCRIPTION
- Now went back to the action slot, so action and description can be properly formatted here on the component.
- The description also became a prop, thus beeing consistent with the title.
- Adapting resp. docs
- Adapting Usage within DashboardWidget

I considered alternatively to make the old description slot a flex-element for centering items, that however didn't allow me to put some margin between text and action here on the component. So apps would have needed to separately style the distance between.

|Before|After|
|---|---|
|![Screenshot from 2022-08-26 09-03-28](https://user-images.githubusercontent.com/47433654/186843112-0bd269c6-9d53-4466-bf09-18916cc85c3c.png)|![Screenshot from 2022-08-26 08-50-34](https://user-images.githubusercontent.com/47433654/186841095-3d28cd6d-a1d4-4886-a7e8-ae26ec1de95d.png)|