### PR TITLE
Add aria-modal to Modal dialog

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -182,6 +182,7 @@ export default {
 			:class="{ 'modal-mask--dark': dark }"
 			:style="cssVariables"
 			role="dialog"
+			aria-modal="true"
 			:aria-labelledby="'modal-title-' + randId"
 			:aria-describedby="'modal-description-' + randId">
 			<!-- Header -->


### PR DESCRIPTION
Assuming that all NcModal are actually modal.

Was reported when reviewing the user status dialog: https://github.com/nextcloud/server/issues/33745