### PR TITLE
Prevent tabbing into closed navigation

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -57,6 +57,7 @@ emit('toggle-navigation', {
 	<div id="app-navigation-vue"
 		class="app-navigation"
 		role="navigation"
+		:inert="!open || null"
 		:class="{'app-navigation--close':!open }">
 		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
 		<slot />


### PR DESCRIPTION
When the navigation is closed, add "inert" attribute to prevent tabbing
into the sidebar.

- [x] FIXME: `inert="false"` does NOT disable inert, need to remove the attribute completely :unamused: 


Note: I didn't test this but tied the attribute to the `open` value. I verified in the Talk app that the `open` attribute is properly updated when swiping, resizing the window, etc. So setting `inert` under the same conditions should work.