### PR TITLE
Fix for border-radius being too large for 3-line entries like in Mail

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -570,7 +570,9 @@ export default {
 	flex: 0 0 auto;
 	justify-content: flex-start;
 	padding: 8px;
-	border-radius: var(--border-radius-pill);
+	// Fix for border-radius being too large for 3-line entries like in Mail
+	// 44px avatar size / 2 + 8px padding, and 2px for better visual quality
+	border-radius: 32px;
 	margin: 2px 0;
 	width: 100%;
 	cursor: pointer;


### PR DESCRIPTION
Fix what @marcoambrosini mentioned at https://github.com/nextcloud/nextcloud-vue/pull/3055#issuecomment-1225273555

44px avatar size / 2 + 8px padding, and 2px for better visual quality

The avatar size and padding should ideally be taken from variables but I couldn’t see the relevant ones in the variables file. `--default-grid-baseline: 4px;` is added by @juliushaertl in another pull request.

Unfortunately can’t do screenshots as I can’t see how to add the third line to the component in the docs.