### PR TITLE
Make the app content list 300px min

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -367,7 +367,7 @@ export default {
 		transition: none;
 
 		&-list {
-			min-width: 200px;
+			min-width: 300px;
 			position: sticky;
 			top: var(--header-height);
 


### PR DESCRIPTION
200px is very narrow. Too narrow for the apps that use the resizeable column.

Tagging as enhancement. Not breaking. And no backports.

Ref https://github.com/nextcloud/mail/issues/6973