### PR TITLE
Focus first action after opening actions menu

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1003,6 +1003,7 @@ export default {
 						boundary: this.boundariesElement,
 						container: this.container,
 						popoverBaseClass: 'action-item__popper',
+						noAutoFocus: true,
 					},
 					// For some reason the popover component
 					// does not react to props given under the 'props' key,
@@ -1015,6 +1016,7 @@ export default {
 						boundary: this.boundariesElement,
 						container: this.container,
 						popoverBaseClass: 'action-item__popper',
+						noAutoFocus: true,
 					},
 					on: {
 						show: this.openMenu,


### PR DESCRIPTION
This is a dirty hack to solve #3053 and get keyboard navigation in the Actions menu to work without pressing tab once.

I have honestly no idea why a timeout is necessary here. All my attempts of using nextTick or listening for floating-vue events (even with #3149 included) did not succeed. The menu is open, and the button is there and defined, but still `focus()` does nothing when called without a timeout directly after the menu was open. The timeout duration is chosen arbitrarily, a timeout of 1 ms works for me as well (0 does not).

Maybe this inspires someone to find the correct solution, if not, I think the PR at least does not make it worse :see_no_evil: 