### PR TITLE
Fix spacing in app navigation and make the setting pill style

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -145,7 +145,7 @@ export default {
 	position: relative;
 	top: 0;
 	left: 0;
-	padding: 4px;
+	padding: 0px;
 	// Above appcontent
 	z-index: 1800;
 	height: 100%;
@@ -178,6 +178,7 @@ export default {
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;
+		padding: calc(var(--default-grid-baseline, 4px) * 2);
 	}
 }
 

--- a/src/components/NcAppNavigationNew/NcAppNavigationNew.vue
+++ b/src/components/NcAppNavigationNew/NcAppNavigationNew.vue
@@ -88,7 +88,7 @@ export default {
 /* 'New' button */
 .app-navigation-new {
 	display: block;
-	padding: 10px;
+	padding: calc(var(--default-grid-baseline, 4px) * 2);
 	button {
 		width: 100%;
 	}

--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -87,6 +87,7 @@ export default {
 <style lang="scss" scoped>
 #app-settings {
 	margin-top: auto;
+	padding: calc(var(--default-grid-baseline, 4px) * 2);
 
 	&__header {
 		box-sizing: border-box;
@@ -101,7 +102,7 @@ export default {
 			background-color: var(--color-main-background);
 			box-shadow: none;
 			border: 0;
-			border-radius: var(--border-radius-large);
+			border-radius: var(--border-radius-pill);
 			text-align: left;
 			font-weight: normal;
 			font-size: 100%;
@@ -112,7 +113,6 @@ export default {
 			&:hover,
 			&:focus {
 				background-color: var(--color-background-hover);
-				border-radius: var(--border-radius-large);
 			}
 
 			&__icon {
@@ -132,7 +132,6 @@ export default {
 	&__content {
 		display: block;
 		padding: 10px;
-		background-color: var(--color-main-background);
 		/* restrict height of settings and make scrollable */
 		max-height: 300px;
 		overflow-y: auto;


### PR DESCRIPTION
Adds proper spacing to the app navigation entries and moves the settings to pill style

<img width="395" alt="Screenshot 2022-09-02 at 13 03 45" src="https://user-images.githubusercontent.com/3404133/188126254-ff09e5fc-34b1-4c10-b22d-ec0d2a036131.png">

