### PR TITLE
Fix docs of NcAppNavigationItem with actions menu

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -46,17 +46,19 @@ Wrap the children in a template. If you have more than 2 actions, a popover menu
 button will be automatically created.
 
 ```
-<NcAppNavigationItem title="Item with actions" icon="icon-category-enabled">
-	<template #actions>
-		<NcActionButton icon="icon-edit" @click="alert('Edit')">
-			Edit
-		</NcActionButton>
-		<NcActionButton icon="icon-delete" @click="alert('Delete')">
-			Delete
-		</NcActionButton>
-		<NcActionLink icon="icon-external" title="Link" href="https://nextcloud.com" />
-	</template>
-</NcAppNavigationItem>
+<div id="app-navigation-vue"><!-- Just a wrapper necessary in the docs. Not needed when NcAppNavigation is correctly used as parent. -->
+	<NcAppNavigationItem title="Item with actions" icon="icon-category-enabled">
+		<template #actions>
+			<NcActionButton icon="icon-edit" @click="alert('Edit')">
+				Edit
+			</NcActionButton>
+			<NcActionButton icon="icon-delete" @click="alert('Delete')">
+				Delete
+			</NcActionButton>
+			<NcActionLink icon="icon-external" title="Link" href="https://nextcloud.com" />
+		</template>
+	</NcAppNavigationItem>
+</div>
 ```
 
 ### Element with counter


### PR DESCRIPTION
This fixes the docs of the `AppNavigationItem` with actions menu. Since we now (after #3157) attach the actions menu for the `AppNavigationItem` component to `#app-navigation-vue`, the menu would not open anymore in the docs, as the component is used there without the correct parent component, i.e. `AppNavigation`. This fixes the issue and allows the actions menu to also open in the docs.
For a real life app, no adjustment is necessary, of course.