### PR TITLE
Adjust appnavigation settings border radius

### DIFF
--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -101,7 +101,7 @@ export default {
 			background-color: var(--color-main-background);
 			box-shadow: none;
 			border: 0;
-			border-radius: var(--border-radius-large);
+			border-radius: var(--border-radius-pill);
 			text-align: left;
 			font-weight: normal;
 			font-size: 100%;
@@ -112,7 +112,6 @@ export default {
 			&:hover,
 			&:focus {
 				background-color: var(--color-background-hover);
-				border-radius: var(--border-radius-large);
 			}
 
 			&__icon {


### PR DESCRIPTION
This adjust the border radius of the appnavigation settings button to the look of the appnavigation items. This was fixed in master already, so this only targets stable6.