### PR TITLE
Allow 'search' as type prop for NcTextField

### DIFF
--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -173,6 +173,7 @@ export default {
 				'email',
 				'tel',
 				'url',
+				'search',
 			].includes(value),
 		},
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search
