### PR TITLE
Fix active and focus frame

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -309,7 +309,9 @@ export default {
 		-webkit-appearance: textfield !important;
 		-moz-appearance: textfield !important;
 
-		&:hover:not([disabled]) {
+		&:active:not([disabled]),
+		&:hover:not([disabled]),
+		&:focus:not([disabled]) {
 			border-color: var(--color-primary-element);
 		}
 


### PR DESCRIPTION
Server has the same rules but excludes with a :not() selector the vue component