### PR TITLE
Fix overwriting placeholder property in NcDatetimePicker

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -122,6 +122,24 @@ msgstr ""
 msgid "People & Body"
 msgstr ""
 
+msgid "Pick a date"
+msgstr ""
+
+msgid "Pick a date and a time"
+msgstr ""
+
+msgid "Pick a month"
+msgstr ""
+
+msgid "Pick a time"
+msgstr ""
+
+msgid "Pick a week"
+msgstr ""
+
+msgid "Pick a year"
+msgstr ""
+
 msgid "Pick an emoji"
 msgstr ""
 

--- a/src/components/NcDatetimePicker/NcDatetimePicker.vue
+++ b/src/components/NcDatetimePicker/NcDatetimePicker.vue
@@ -130,7 +130,7 @@ export default {
 		:formatter="formatter"
 		:lang="lang"
 		:minute-step="minuteStep"
-		:placeholder="placeholder"
+		:placeholder="placeholder ? placeholder : defaultPlaceholder"
 		:popup-class="{ 'show-week-number': showWeekNumber }"
 		:show-week-number="showWeekNumber"
 		:type="type"
@@ -168,7 +168,7 @@ export default {
 <script>
 import NcTimezonePicker from '../NcTimezonePicker/index.js'
 import NcPopover from '../NcPopover/index.js'
-import l10n from '../../mixins/l10n.js'
+import { t } from '../../l10n.js'
 
 import {
 	getFirstDay,
@@ -198,8 +198,6 @@ export default {
 		NcPopover,
 		NcTimezonePicker,
 	},
-
-	mixins: [l10n],
 
 	inheritAttrs: false,
 
@@ -266,6 +264,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		placeholder: {
+			type: String,
+			default: null,
+		},
 	},
 
 	emits: [
@@ -307,23 +310,23 @@ export default {
 		 *
 		 * @return {string}
 		 */
-		placeholder() {
+		defaultPlaceholder() {
 			if (this.type === 'time') {
-				return this.t('Pick a time')
+				return t('Pick a time')
 			}
 			if (this.type === 'month') {
-				return this.t('Pick a month')
+				return t('Pick a month')
 			}
 			if (this.type === 'year') {
-				return this.t('Pick a year')
+				return t('Pick a year')
 			}
 			if (this.type === 'week') {
-				return this.t('Pick a week')
+				return t('Pick a week')
 			}
 			if (this.type === 'date') {
-				return this.t('Pick a date')
+				return t('Pick a date')
 			}
-			return this.t('Pick a date and a time')
+			return t('Pick a date and a time')
 		},
 
 		/**


### PR DESCRIPTION
This fixes an issue in Forms where the placeholder for NcDatetimePicker cannot be overwritten by passing some text to the property: https://github.com/nextcloud/forms/issues/1296 

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>