### PR TITLE
Fix single action detection

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -708,7 +708,8 @@ export default {
 		 * @return {boolean}
 		 */
 		isValidSingleAction(action) {
-			return ['NcActionButton', 'NcActionLink', 'NcActionRouter'].includes(action?.componentOptions?.tag)
+			const componentName = action?.componentOptions?.Ctor?.extendOptions?.name ?? action?.componentOptions?.tag
+			return ['NcActionButton', 'NcActionLink', 'NcActionRouter'].includes(componentName)
 		},
 
 		// MENU STATE MANAGEMENT


### PR DESCRIPTION
The detection relies on the tag we use in our compontent instead of the "real" component name. In calendar we did not change every tag to `NcAction...` but just changed imports instead. As a result the detection is broken and the `...` menu is always shown.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/189345086-e127fa07-df67-4d68-adfe-9e118d6b1bc5.png) | ![image](https://user-images.githubusercontent.com/1479486/189344853-ff06b733-22f5-46ab-b170-d56219651c38.png) |
