### PR TITLE
Fix a word puzzle in NcDashboardWidget component

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -83,13 +83,10 @@ msgstr ""
 msgid "Hide password"
 msgstr ""
 
-msgid "items"
-msgstr ""
-
 msgid "Message limit of {count} characters reached"
 msgstr ""
 
-msgid "More {dashboardItemType} …"
+msgid "More items …"
 msgstr ""
 
 msgid "Next"

--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -230,11 +230,13 @@ export default {
 			default: '',
 		},
 		/**
-		 * The type of elements to show more.
+		 * The text of show more button.
+		 *
+		 * Expected to be in the form "More {itemName} …"
 		 */
-		showMoreText: {
+		showMoreLabel: {
 			type: String,
-			default: t('items'),
+			default: t('More items …'),
 		},
 		/**
 		 * A boolean to put the widget in a loading state.
@@ -306,10 +308,6 @@ export default {
 
 		showMore() {
 			return this.showMoreUrl && this.items.length >= this.maxItemNumber
-		},
-
-		showMoreLabel() {
-			return t('More {dashboardItemType} …', { dashboardItemType: this.showMoreText })
 		},
 	},
 }


### PR DESCRIPTION
Instead of having a prop that allows customizing one part of a sentence, use a prop to allow changing the full sentences.

Part of the fix for https://github.com/nextcloud/activity/issues/919

This an API break so only for nc-7