### PR TITLE
NcAppNavigationItem: always display actions menu on mobile

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -169,7 +169,7 @@ Just set the `pinned` prop.
 			<!-- Counter and Actions -->
 			<div v-if="hasUtils && !editingActive"
 				class="app-navigation-entry__utils"
-				:class="{'app-navigation-entry__utils--display-actions': forceDisplayActions || menuOpenLocalValue}">
+				:class="{'app-navigation-entry__utils--display-actions': isMobile || forceDisplayActions || menuOpenLocalValue}">
 				<div v-if="$slots.counter"
 					class="app-navigation-entry__counter-wrapper">
 					<slot name="counter" />


### PR DESCRIPTION
Fixes: #3233

Signed-off-by: Jonas <jonas@freesources.org>