### PR TITLE
Update design of related resources panel

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -17,6 +17,9 @@ msgstr ""
 msgid "Animals & Nature"
 msgstr ""
 
+msgid "Anything shared with the same group of people will show up here"
+msgstr ""
+
 msgid "Avatar of {displayName}"
 msgstr ""
 

--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -47,11 +47,13 @@ export default {
 	<div v-if="appEnabled && isVisible" class="related-resources">
 		<div class="related-resources__header">
 			<h5>{{ headerTranslated }}</h5>
+			<p>{{ descriptionTranslated }}</p>
 		</div>
 
 		<NcResource v-for="resource in resources"
 			:key="resource.itemId"
 			class="related-resources__entry"
+			:icon="resource.icon"
 			:title="resource.title"
 			:subtitle="resource.subtitle"
 			:tooltip="resource.tooltip"
@@ -108,6 +110,7 @@ export default {
 		return {
 			appEnabled: OC?.appswebroots?.related_resources !== undefined,
 			headerTranslated: t('Related resources'),
+			descriptionTranslated: t('Anything shared with the same group of people will show up here'),
 			loading: false,
 			resources: [],
 		}
@@ -188,13 +191,15 @@ export default {
 <style lang="scss" scoped>
 .related-resources {
 	&__header {
-		display: flex;
-		height: 44px;
-		align-items: center;
-	}
+		margin: 0 0 10px 46px;
 
-	&__entry {
-		padding-left: 36px;
+		h5 {
+			font-weight: bold;
+		}
+
+		p {
+			color: var(--color-text-maxcontrast);
+		}
 	}
 }
 </style>

--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -63,6 +63,7 @@ export default {
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
+import { t } from '../../l10n.js'
 
 import NcResource from './NcResource.vue'
 

--- a/src/components/NcRelatedResourcesPanel/NcResource.vue
+++ b/src/components/NcRelatedResourcesPanel/NcResource.vue
@@ -22,18 +22,16 @@
 
 <template>
 	<li class="resource">
-		<div v-tooltip="tooltip" class="resource__desc">
-			<h5>{{ title }}</h5>
-			<p v-if="subtitle">
-				{{ subtitle }}
-			</p>
-		</div>
-		<NcButton :aria-label="labelTranslated"
+		<NcButton class="resource__button"
+			:aria-label="labelTranslated"
 			type="tertiary"
 			:href="url">
 			<template #icon>
-				<ArrowRight :size="20" />
+				<div class="resource__icon">
+					<img :src="icon">
+				</div>
 			</template>
+			{{ title }}
 		</NcButton>
 	</li>
 </template>
@@ -43,13 +41,10 @@ import NcButton from '../NcButton/index.js'
 import Tooltip from '../../directives/Tooltip/index.js'
 import { t } from '../../l10n.js'
 
-import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
-
 export default {
 	name: 'NcResource',
 
 	components: {
-		ArrowRight,
 		NcButton,
 	},
 
@@ -58,6 +53,10 @@ export default {
 	},
 
 	props: {
+		icon: {
+			type: String,
+			required: true,
+		},
 		title: {
 			type: String,
 			required: true,
@@ -90,22 +89,31 @@ export default {
 	align-items: center;
 	height: 44px;
 
-	&__desc {
-		padding: 8px;
-		line-height: 1.2em;
-		position: relative;
-		flex: 1 1;
-		min-width: 0;
+	// Override default NcButton styles
+	&__button {
+		width: 100%;
+		justify-content: flex-start;
+		padding: 0;
 
-		h5 {
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			overflow: hidden;
-			max-width: inherit;
+		&:deep(.button-vue__text) {
+			font-weight: normal;
+			margin-left: 2px;
 		}
+	}
 
-		p {
-			color: var(--color-text-maxcontrast);
+	&__icon {
+		width: 32px;
+		height: 32px;
+		background-color: var(--color-text-maxcontrast);
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		img {
+			width: 16px;
+			height: 16px;
+			filter: var(--background-invert-if-dark);
 		}
 	}
 }

--- a/src/components/NcRelatedResourcesPanel/NcResource.vue
+++ b/src/components/NcRelatedResourcesPanel/NcResource.vue
@@ -41,6 +41,7 @@
 <script>
 import NcButton from '../NcButton/index.js'
 import Tooltip from '../../directives/Tooltip/index.js'
+import { t } from '../../l10n.js'
 
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 

--- a/styleguide/global.requires.js
+++ b/styleguide/global.requires.js
@@ -88,6 +88,20 @@ window.OC = {
 			return aa.length - bb.length
 		},
 	},
+	coreApps: [
+		'',
+		'admin',
+		'log',
+		'core/search',
+		'core',
+		'3rdparty',
+	],
+	appswebroots: {
+		calendar: '/apps/calendar',
+		deck: '/apps/deck',
+		files: '/apps/files',
+		spreed: '/apps/spreed',
+	},
 	webroot: '',
 }
 window.OCA = {}

--- a/tests/OC.js
+++ b/tests/OC.js
@@ -16,5 +16,21 @@ export default {
 		naturalSortCompare(a, b) {
 			return 0
 		}
-	}
+	},
+
+	coreApps: [
+		'',
+		'admin',
+		'log',
+		'core/search',
+		'core',
+		'3rdparty',
+	],
+
+	appswebroots: {
+		calendar: '/apps/calendar',
+		deck: '/apps/deck',
+		files: '/apps/files',
+		spreed: '/apps/spreed',
+	},
 }


### PR DESCRIPTION
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/24800714/189790863-3e59241e-3d69-4eef-8ee1-1f66d9ec57f6.png) | ![image](https://user-images.githubusercontent.com/24800714/190041364-6131ea94-1ae9-43f6-a56a-39e10ffb5d1b.png)

- [x] Using icons instead of repeated subline
- [x] Have a short explanatory text below the heading as per mockup
- [x] Whole entry should be clickable

`coreApps` and `appswebroots` data was added to resolve some console errors in the styleguide