### PR TITLE
Add ref=inputField to NcPasswordField

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -94,6 +94,7 @@ export default {
 
 <template>
 	<NcInputField v-bind="$props"
+		ref="inputField"
 		:type="isPasswordHidden ? 'password' : 'text'"
 		:show-trailing-button="true"
 		:helper-text="computedHelperText"


### PR DESCRIPTION
Use case: 

LoginForm.vue set focus to password field when username is already given via url. 