### PR TITLE
Forward the autofocus attribute to input field component

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -95,6 +95,7 @@ export default {
 <template>
 	<NcInputField v-bind="$props"
 		ref="inputField"
+		:autofocus="$attrs.autofocus"
 		:type="isPasswordHidden ? 'password' : 'text'"
 		:show-trailing-button="true"
 		:helper-text="computedHelperText"

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -121,6 +121,7 @@ export default {
 <template>
 	<NcInputField v-bind="$props"
 		ref="inputField"
+		:autofocus="$attrs.autofocus"
 		:trailing-button-label="clearTextLabel"
 		v-on="$listeners"
 		@input="handleInput">


### PR DESCRIPTION
Make it possible to set the `autofocus` attribute on on TextField and PasswordField