### PR TITLE
Fix multiselect background color spilling outside the component

### DIFF
--- a/src/components/NcMultiselect/index.scss
+++ b/src/components/NcMultiselect/index.scss
@@ -8,7 +8,6 @@
 	/* override this rule with your width styling if you need */
 	min-width: 260px;
 	position: relative;
-	background-color: var(--color-main-background);
 
 	/* Force single multiselect value to be shown when not active */
 	&:not(.multiselect--active) .multiselect__single {
@@ -54,6 +53,7 @@
 		min-height: 44px;
 		height: 44px;
 		padding: 8px 12px !important;
+		background-color: var(--color-main-background);
 
 		&:focus, &:hover {
 			border-color: var(--color-primary);


### PR DESCRIPTION
If you put the multiselect somewhere other than an element with the main background color, it looked weird.

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-14 11-50-55](https://user-images.githubusercontent.com/1374172/190123460-7b398a9f-68ad-4c27-a335-7a6e0852abbf.png) | ![Bildschirmfoto vom 2022-09-14 11-53-22](https://user-images.githubusercontent.com/1374172/190123505-78c78b90-c045-4608-bfbb-e41373779763.png) |

