### PR TITLE
Make app navigation settings pixel perfect-ish

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -58,3 +58,6 @@ $breakpoint-mobile: 1024px;
 
 // top-bar spacing
 $topbar-margin: 4px;
+
+// navigation spacing
+$app-navigation-settings-margin: 3px;

--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -87,10 +87,11 @@ export default {
 <style lang="scss" scoped>
 #app-settings {
 	margin-top: auto;
-	padding: calc(var(--default-grid-baseline, 4px) * 2);
+	padding: $app-navigation-settings-margin;
 
 	&__header {
 		box-sizing: border-box;
+		margin: 0 $app-navigation-settings-margin $app-navigation-settings-margin $app-navigation-settings-margin;
 
 		.settings-button {
 			display: flex;
@@ -132,6 +133,10 @@ export default {
 	&__content {
 		display: block;
 		padding: 10px;
+
+		/* prevent scrolled contents from stopping too early */
+		margin-bottom: -$app-navigation-settings-margin;
+
 		/* restrict height of settings and make scrollable */
 		max-height: 300px;
 		overflow-y: auto;


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/nextcloud-vue/issues/3184.

Follow-up to https://github.com/nextcloud/nextcloud-vue/pull/3158.

* Make settings button same with as other nav elements
* Make sure scrolled menus don't look cut at the bottom

| Description | Before | After |
|---|---|---|
| General | ![Bildschirmfoto vom 2022-09-14 14-45-35](https://user-images.githubusercontent.com/1374172/190158056-1d27437e-f528-4b70-8c2d-f239bf4fca98.png) | ![Bildschirmfoto vom 2022-09-14 14-43-38](https://user-images.githubusercontent.com/1374172/190158094-b2fb5490-af79-4ac8-952c-c897995f5a39.png) |
| Matching width | ![Bildschirmfoto vom 2022-09-14 14-45-51](https://user-images.githubusercontent.com/1374172/190158048-3a21cc66-9de4-4330-ab06-c450db3b92ad.png) | ![Bildschirmfoto vom 2022-09-14 14-43-35](https://user-images.githubusercontent.com/1374172/190158119-ec40c94d-f795-4813-a014-1f18760c558b.png) |
| Scrolling | ![Bildschirmfoto vom 2022-09-14 14-45-56](https://user-images.githubusercontent.com/1374172/190158039-1666933f-bf65-4121-a701-a1f220614482.png) | ![Bildschirmfoto vom 2022-09-14 14-43-45](https://user-images.githubusercontent.com/1374172/190158071-579051fd-a547-4ff6-ba6e-9948277271fa.png) |



