### PR TITLE
Fix SCSS to CSS variable assignment

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -337,7 +337,7 @@ export default {
 
 	// Variables
 	// the whitespace between the topbar content and its edges
-	--topbar-margin: $topbar-margin;
+	--topbar-margin: #{$topbar-margin};
 }
 
 .app-content-wrapper {


### PR DESCRIPTION
Currently the assignment of the `topbar-margin` css variable does not work, it gets compiled to:
```css
--topbar-margin: $topbar-margin
```

See also https://sass-lang.com/documentation/breaking-changes/css-vars