### PR TITLE
Live refresh image and displayname based avatar on update

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -476,6 +476,8 @@ export default {
 
 	mounted() {
 		this.loadAvatarUrl()
+		subscribe('settings:avatar:updated', this.loadAvatarUrl)
+		subscribe('settings:display-name:updated', this.loadAvatarUrl)
 		if (this.showUserStatus && this.user && !this.isNoUser) {
 			if (!this.preloadedUserStatus) {
 				this.fetchUserStatus(this.user)
@@ -490,6 +492,8 @@ export default {
 	},
 
 	beforeDestroy() {
+		unsubscribe('settings:avatar:updated', this.loadAvatarUrl)
+		unsubscribe('settings:display-name:updated', this.loadAvatarUrl)
 		if (this.showUserStatus && this.user && !this.isNoUser) {
 			unsubscribe('user_status:status.updated', this.handleUserStatusUpdated)
 		}


### PR DESCRIPTION
Close https://github.com/nextcloud/nextcloud-vue/issues/2975

Listen to avatar https://github.com/nextcloud/server/blob/b9c002df0a3ab80c1612206cfb1f724d90e0da3a/apps/settings/src/components/PersonalInfo/AvatarSection.vue#L268 and displayname https://github.com/nextcloud/server/blob/b9c002df0a3ab80c1612206cfb1f724d90e0da3a/apps/settings/src/components/PersonalInfo/DisplayNameSection.vue#L66 update events to automatically refresh the image or displayname based avatar