### PR TITLE
Add styleguide example for non-user avatar

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -78,6 +78,13 @@ export default {
  }
  </script>
 ```
+
+### Avatar for non-users
+
+```vue
+	<NcAvatar display-name="Robbie Hyeon-Jeong" :is-no-user="true" />
+```
+
 </docs>
 <template>
 	<div ref="main"


### PR DESCRIPTION
![Bildschirmfoto vom 2022-09-20 08-48-29](https://user-images.githubusercontent.com/1374172/191186958-e74dde71-dae8-41bc-bf42-4ca4f12da836.png)

My sneaky demo that the `NvAvatar` renders letters different than Nextcloud 25 server-side generated avatars :smiling_imp: 