### PR TITLE
Fix initials color of new non-user avatars

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -129,7 +129,7 @@ export default {
 			:class="'avatardiv__user-status--' + userStatus.status" />
 
 		<!-- Show the letter if no avatar nor icon class -->
-		<div v-if="userDoesNotExist && !(iconClass || $slots.icon)" class="unknown">
+		<div v-if="userDoesNotExist && !(iconClass || $slots.icon)" :style="initialsStyle" class="unknown">
 			{{ initials }}
 		</div>
 	</div>
@@ -404,6 +404,12 @@ export default {
 				style.backgroundColor = 'rgba(' + rgb.r + ', ' + rgb.g + ', ' + rgb.b + ', 0.1)'
 			}
 			return style
+		},
+		initialsStyle() {
+			const { r, g, b } = usernameToColor(this.getUserIdentifier)
+			return {
+				color: `rgb(${r}, ${g}, ${b})`,
+			}
 		},
 		tooltip() {
 			if (this.disableTooltip) {
@@ -711,7 +717,6 @@ export default {
 		width: 100%;
 		text-align: center;
 		font-weight: normal;
-		color: var(--color-main-background);
 	}
 
 	img {


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/issues/7294
Ref https://github.com/nextcloud/server/pull/33752

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-20 08-48-29](https://user-images.githubusercontent.com/1374172/191189809-995b9440-e516-40da-83ef-7ab8d86546a0.png) | ![Bildschirmfoto vom 2022-09-20 09-00-32](https://user-images.githubusercontent.com/1374172/191189444-1f7d5947-011b-4021-b91c-fd4d95700899.png) |

(Demo requires https://github.com/nextcloud/nextcloud-vue/pull/3270)