### PR TITLE
fix NcAppNavigationItem, pass boundaries-element NcActions's prop as …

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -178,7 +178,7 @@ Just set the `pinned` prop.
 					ref="actions"
 					class="app-navigation-entry__actions"
 					container="#app-navigation-vue"
-					boundaries-element="#content-vue"
+					:boundaries-element="actionsBoundariesElement"
 					:placement="menuPlacement"
 					:open="menuOpen"
 					:force-menu="forceMenu"
@@ -492,6 +492,9 @@ export default {
 
 		undoButtonAriaLabel() {
 			return t('Undo changes')
+		},
+		actionsBoundariesElement() {
+			return document.querySelector('#content-vue') || undefined
 		},
 	},
 


### PR DESCRIPTION
…a dom element

Signed-off-by: Raimund Schlüßler <raimund.schluessler@mailbox.org>

Manual backport of #3197.