### PR TITLE
Better readability of long file and event names

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -839,8 +839,11 @@ $top-buttons-spacing: 6px;
 					overflow: hidden;
 					width: 100%;
 					margin: 0;
-					white-space: nowrap;
+					white-space: normal;
 					text-overflow: ellipsis;
+					display: -webkit-box;
+					-webkit-line-clamp: 3;
+					-webkit-box-orient: vertical;
 				}
 
 				// subtitle


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Currently, in the right side panel, the labels end too easily with ellipsis dots. This is, from my personal and professional experience, too restrictive because we often cannot see the continuation of the file or event name (potentially also in any other similar case using this "vue"). It's a pain especially in Nextcloud Calendar but in Nextcloud Files too and probably in other apps.

I propose, with this change, to allow 3 lines to be displayed before the ellipsis.

**Nextcloud Calendar test :** 
![2022-09-26_16-01](https://user-images.githubusercontent.com/33763786/192299295-763d6964-dfb9-4a67-b7a6-acb0d56a2ba7.png)
![2022-09-26_16-00_1](https://user-images.githubusercontent.com/33763786/192299330-04bd0b64-afeb-471b-a916-1ecbb49acbdc.png)
![2022-09-26_16-00](https://user-images.githubusercontent.com/33763786/192299339-8af43890-df95-4e97-9431-47daaac9bed5.png)
![2022-09-26_16-15](https://user-images.githubusercontent.com/33763786/192299611-e3e4f200-7ae9-4e80-be2a-07ff36ba96e1.png)

**Nextcloud Files test :** 
![2022-09-26_15-58](https://user-images.githubusercontent.com/33763786/192299787-0f213cb5-4124-4db5-af62-aa293fc1a2df.png)
![2022-09-26_15-57_1](https://user-images.githubusercontent.com/33763786/192299804-64455a8c-6907-4cdf-97ad-87ae7e12932b.png)
![2022-09-26_15-57](https://user-images.githubusercontent.com/33763786/192299822-300979a5-e90e-4700-930b-17ef57236a69.png)
![2022-09-26_15-56](https://user-images.githubusercontent.com/33763786/192299847-18a15fbc-76c5-4b8a-a3fe-3760a7910d03.png)

**Note :** 
My only point of hesitation concerns the management of long (or even very long) unbreakable words with the "hyphens" CSS property, which sometimes causes a hyphen to appear just above the suspension points.