### PR TITLE
Fix alignment of NcAppNavigationCaption

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -88,7 +88,7 @@ export default {
 .app-navigation-caption {
 	display: flex;
 	justify-content: space-between;
-	padding: 0 8px 0 math.div($clickable-area, 2);
+	padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 3);
 
 	&__title {
 		font-weight: bold;


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/4536

This was discussed in the design chat and we agreed to left align the headers.

## Screenshots from Calendar

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1479486/192498704-396ced20-bddf-4216-8fd0-116397930e60.png) | ![after](https://user-images.githubusercontent.com/1479486/192498320-264ff6ea-c0c5-4905-b1cc-15fa17a1c166.png) |
