### PR TITLE
Forward ref of actions to inline actions

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -940,6 +940,7 @@ export default {
 					attrs: {
 						'aria-label': action?.componentOptions?.propsData?.ariaLabel || action?.componentOptions?.children?.[0]?.text,
 					},
+					ref: action?.data?.ref,
 					props: {
 						// If it has a title, we use a secondary button
 						type: this.type || (title ? 'secondary' : 'tertiary'),


### PR DESCRIPTION
This forwards a ref of an action to the respective inline action.

This allows to do something like this now:
```vue
<template>
	<NcActions ref="actions">
		<NcActionButton @click="actionDelete" ref="actionbutton">
			<template #icon>
				<Delete :size="20" />
			</template>
			Delete
		</NcActionButton>
	</NcActions>
</template>
<script>
import Delete from 'vue-material-design-icons/Delete'

export default {
	components: {
		Delete,
	},
	methods: {
		actionDelete() {
			alert('Delete')
			console.debug(this.$refs.actions.$refs.actionbutton) // Not defined before this PR.
		},
	},
}
</script>
```

However, the use case in https://github.com/nextcloud/server/pull/34288 won't work anymore without adjustments, because we use a render function now, and the ref is not available in the context of the current component anymore.