### PR TITLE
Fix contrast of maxcontrast text on blurred background

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -137,8 +137,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
 .app-navigation {
+	// Set scoped variable override
+	// Using --color-text-maxcontrast as a fallback evaluates to an invalid value as it references itself in this scope instead of the variable defined higher up
+	--color-text-maxcontrast: var(--color-text-maxcontrast-background-blur, var(--color-text-maxcontrast-default));
+
 	transition: transform var(--animation-quick), margin var(--animation-quick);
 	width: $navigation-width;
 	position: relative;

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -676,7 +676,7 @@ export default {
 	}
 
 	&__details {
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 		margin: 0 8px;
 		font-weight: normal;
 	}
@@ -697,7 +697,7 @@ export default {
 		cursor: pointer;
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 	}
 
 	&__additional_elements {


### PR DESCRIPTION
Fix https://github.com/nextcloud/nextcloud-vue/issues/3198

Light theme before/after in https://github.com/nextcloud/nextcloud-vue/issues/3198

### Dark theme

Before (`#8C8C8C`) | After (`#919191`)
--- | ---
![image](https://user-images.githubusercontent.com/24800714/194682590-1e37dbce-7d9e-4c1e-bfe6-aebb9ba03f92.png) | ![image](https://user-images.githubusercontent.com/24800714/194682596-5326e095-d6ee-4b2d-b15e-6503b078121d.png)
![image](https://user-images.githubusercontent.com/24800714/194682603-81372460-a2e0-49a3-90e2-b4c025f9db85.png) | ![image](https://user-images.githubusercontent.com/24800714/194682609-8a4206c3-3ff6-4782-91d3-c9a0e2cebce3.png)

> Minimum 4.5 contrast ratio

Requires variables added in https://github.com/nextcloud/server/pull/34299