### PR TITLE
Fix NcMultiselect height

### DIFF
--- a/src/components/NcMultiselect/index.scss
+++ b/src/components/NcMultiselect/index.scss
@@ -54,6 +54,7 @@
 		height: 44px;
 		padding: 8px 12px !important;
 		background-color: var(--color-main-background);
+		box-sizing: border-box;
 
 		&:focus, &:hover {
 			border-color: var(--color-primary);


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/4550

In most cases, the correct `box-sizing` is already set on some parent and inherited down to the Multiselect (e. g. Calendar sidebar editor). In some instances it isn't and the Multiselect is too big.

| Before | After |
| --- | --- |
| ![box-sizing-before](https://user-images.githubusercontent.com/1479486/193026509-3133baf0-2146-4336-a2be-47bacf93eadc.png) | ![box-sizing-after](https://user-images.githubusercontent.com/1479486/193026518-28fe12bf-73d2-4d26-83ec-f2e547c90aaf.png) |
