### PR TITLE
Use new slot syntax everywhere

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -62,7 +62,7 @@
 				@click="handleTrailingButtonClick">
 				<!-- Populating this slot creates a trailing button within the
 				input boundaries that emits a `trailing-button-click` event -->
-				<template slot="icon">
+				<template #icon>
 					<slot name="trailing-button-icon" />
 				</template>
 			</NcButton>

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -128,7 +128,7 @@ export default {
 		<!-- Default slot for the leading icon -->
 		<slot />
 		<!-- Trailing icon slot, except for search type input as the browser already adds a trailing close icon -->
-		<template v-if="type !== 'search'" slot="trailing-button-icon">
+		<template v-if="type !== 'search'" #trailing-button-icon>
 			<Close v-if="trailingButtonIcon === 'close'" :size="20" />
 			<ArrowRight v-else-if="trailingButtonIcon === 'arrowRight'" :size="20" />
 		</template>


### PR DESCRIPTION
Necessary for vue3 as the old syntax is removed.