### PR TITLE
Add minlength and maxlength to text field

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -95,7 +95,6 @@ export default {
 <template>
 	<NcInputField v-bind="$props"
 		ref="inputField"
-		:autofocus="$attrs.autofocus"
 		:type="isPasswordHidden ? 'password' : 'text'"
 		:show-trailing-button="true"
 		:helper-text="computedHelperText"
@@ -215,6 +214,15 @@ export default {
 		helperText: {
 			type: String,
 			default: '',
+		},
+
+		/**
+		 * The autofocus property defines whether the input should
+		 * automatically receive focus on page load
+		 */
+		autofocus: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -121,7 +121,6 @@ export default {
 <template>
 	<NcInputField v-bind="$props"
 		ref="inputField"
-		:autofocus="$attrs.autofocus"
 		:trailing-button-label="clearTextLabel"
 		v-on="$listeners"
 		@input="handleInput">
@@ -360,6 +359,15 @@ export default {
 				'words',
 				'characters',
 			].includes(value),
+		},
+
+		/**
+		 * The autofocus property defines whether the input should
+		 * automatically receive focus on page load
+		 */
+		autofocus: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -371,6 +371,24 @@ export default {
 		},
 
 		/**
+		 * The minlength property defines the minimum number of characters
+		 * (as UTF-16 code units) the user can enter
+		 */
+		minlength: {
+			type: Number,
+			default: 0,
+		},
+
+		/**
+		 * The maxlength property defines the maximum number of characters
+		 * (as UTF-16 code units) the user can enter
+		 */
+		maxlength: {
+			type: Number,
+			default: null,
+		},
+
+		/**
 		 * Allow to disable spellchecking
 		 */
 		spellcheck: {


### PR DESCRIPTION
Add `minlength` and `maxlength` to be forwarded to the input by `v-bind="$props"`

The part which adds the `autofocus` prop definition is an addendum to https://github.com/nextcloud/nextcloud-vue/pull/3245

Before this change `autofocus` wasn't contained in `$props` so it wasn't automatically forwarded by `v-bind="$props"`, adding the explicit definition now makes it get forwarded by the `v-bind` and also makes the prop show up in the docs