### PR TITLE
Fix emoji picker and Popover no-Auto-Focus

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -91,6 +91,7 @@
 	<NcPopover :shown.sync="open"
 		:container="container"
 		v-bind="$attrs"
+		:no-auto-focus="true"
 		v-on="$listeners"
 		@after-show="afterShow"
 		@after-hide="afterHide">
@@ -98,7 +99,7 @@
 			<slot />
 		</template>
 		<Picker ref="picker"
-			:auto-focus="true"
+			:auto-focus="false"
 			color="var(--color-primary)"
 			:data="emojiIndex"
 			:emoji="previewFallbackEmoji"
@@ -221,21 +222,25 @@ export default {
 				this.open = false
 			}
 		},
+
 		afterShow() {
 			// add focus trap in modal
 			const picker = this.$refs.picker
 			picker.$el.addEventListener('keydown', this.checkKeyEvent)
+
 			// set focus on input search field
 			const input = picker.$refs.search.$el.querySelector('input')
 			if (input) {
 				input.focus()
 			}
 		},
+
 		afterHide() {
 			// remove keydown listner if popover is hidden
 			const picker = this.$refs.picker
 			picker.$el.removeEventListener('keydown', this.checkKeyEvent)
 		},
+
 		checkKeyEvent(event) {
 			if (event.key !== 'Tab') {
 				return

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -88,6 +88,7 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 		v-bind="$attrs"
 		:popper-class="popoverBaseClass"
 		v-on="$listeners"
+		@show="onShow"
 		@apply-show="afterShow"
 		@apply-hide="afterHide">
 		<!-- This will be the popover target (for the events and position) -->
@@ -120,6 +121,11 @@ export default {
 		focusTrap: {
 			type: Boolean,
 			default: true,
+		},
+
+		noAutoFocus: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -170,6 +176,20 @@ export default {
 				console.warn(err)
 			}
 		},
+		/**
+		 * Prevent the floating-vue popover to override the focus
+		 * TODO: remove once disabling auto-focus is released
+		 *
+		 * @see https://github.com/Akryum/floating-vue/pull/894
+		 */
+		onShow() {
+			/** @type {HTMLElement} */
+			const popperNode = this.$refs?.popover?.$refs?.popper?.$_popperNode
+			if (this.noAutoFocus && popperNode) {
+				popperNode.focus = () => {}
+			}
+		},
+
 		afterShow() {
 			/**
 			 * Triggered after the tooltip was visually displayed.
@@ -178,8 +198,10 @@ export default {
 			 * run earlier than this where there is no guarantee that the
 			 * tooltip is already visible and in the DOM.
 			 */
-			this.$emit('after-show')
-			this.useFocusTrap()
+			this.$nextTick(() => {
+				this.$emit('after-show')
+				this.useFocusTrap()
+			})
 		},
 		afterHide() {
 			/**


### PR DESCRIPTION
See https://github.com/Akryum/floating-vue/pull/894

Because the Popover always focuses after the event is emitted, we need to make sure to wait after the render (nextTick) to properly focus on another element.
Also implementing a way around the library to mitigate the focus priority until the new PR above is merged

fix https://github.com/nextcloud/nextcloud-vue/issues/3332
