### PR TITLE
Migrate to use `:deep` selector instead of deprecated `::v-deep`

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -91,7 +91,7 @@
 			background-repeat: no-repeat;
 		}
 
-		&::v-deep .material-design-icon {
+		&:deep(.material-design-icon) {
 			width: $clickable-area;
 			height: $clickable-area;
 			opacity: $opacity_full;


### PR DESCRIPTION
`::v-deep` is deprecated as vue moved to `:deep` selector for vue-3 which is also available and recommended for vue 2.7.