### PR TITLE
7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## v7.0.0 - 2022-10-12
+## [v7.0.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.0.1) (2022-10-14)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.0.0...v7.0.1)
+
+### :bug: Fixed bugs
+
+- use @nextcloud/focus-trap instead of focus-trap [\#3347](https://github.com/nextcloud/nextcloud-vue/pull/3347) ([vinicius73](https://github.com/vinicius73))
+
+## [v7.0.0](https://github.com/nextcloud/nextcloud-vue/tree/v7.0.0) - 2022-10-12
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v6.0.0...v7.0.0)
 
 ### :boom: Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - use @nextcloud/focus-trap instead of focus-trap [\#3347](https://github.com/nextcloud/nextcloud-vue/pull/3347) ([vinicius73](https://github.com/vinicius73))
 
+### :rocket: Enhancements
+
+- Migrate to use `:deep` selector instead of deprecated `::v-deep` [\#3348](https://github.com/nextcloud/nextcloud-vue/pull/3348) ([susnux](https://github.com/susnux))
+
 ## [v7.0.0](https://github.com/nextcloud/nextcloud-vue/tree/v7.0.0) - 2022-10-12
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v6.0.0...v7.0.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.0.0",
+	"version": "7.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.0.0",
+			"version": "7.0.1",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.0.0",
+	"version": "7.0.1",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
Includes very important PR #3347 

## [v7.0.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.0.1) (2022-10-14)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.0.0...v7.0.1)

### :bug: Fixed bugs

- use @nextcloud/focus-trap instead of focus-trap [\#3347](https://github.com/nextcloud/nextcloud-vue/pull/3347) ([vinicius73](https://github.com/vinicius73))

### :rocket: Enhancements

- Migrate to use `:deep` selector instead of deprecated `::v-deep` [\#3348](https://github.com/nextcloud/nextcloud-vue/pull/3348) ([susnux](https://github.com/susnux))