### PR TITLE
Fix outdated variables

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -404,7 +404,7 @@ $input-margin: 4px;
 		padding: 7px 6px;
 
 		opacity: $opacity_full;
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 		border: 1px solid var(--color-border-dark);
 		border-left-color: transparent;
 		border-radius: 0 var(--border-radius) var(--border-radius) 0;

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -284,7 +284,7 @@ $input-margin: 4px;
 		padding: 7px 6px;
 
 		opacity: $opacity_full;
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 		border: 0;
 		border-radius: 50%;
 		/* Avoid background under border */

--- a/src/components/NcAppNavigationItem/NcInputConfirmCancel.vue
+++ b/src/components/NcAppNavigationItem/NcInputConfirmCancel.vue
@@ -147,7 +147,7 @@ $input-margin: 5px;
 		&:hover {
 			outline: none;
 			background-color: var(--color-main-background);
-			color: var(--color-text-light);
+			color: var(--color-main-text);
 			border-color: var(--color-primary-element);
 		}
 	}

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -325,9 +325,9 @@ export default {
 				box-shadow: inset 0 -1px 0 var(--color-background-darker);
 			}
 			&.active {
-				color: var(--color-text-light);
-				border-bottom-color: var(--color-text-light);
-				box-shadow: inset 0 -1px 0 var(--color-text-light);
+				color: var(--color-main-text);
+				border-bottom-color: var(--color-main-text);
+				box-shadow: inset 0 -1px 0 var(--color-main-text);
 				font-weight: bold;
 			}
 			// differentiate the two for accessibility purpose

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -187,7 +187,7 @@ h5 {
 p {
 	text-align: center;
 	margin: 4px 0 12px 0;
-	color: var(--color-text-lighter)
+	color: var(--color-text-maxcontrast)
 }
 
 button {

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -439,7 +439,7 @@ export default {
 	}
 
 	// Default button type
-	background-color: var(--color-primary-element-lighter);
+	background-color: var(--color-primary-element-lighter), var(--color-primary-element-light);
 	color: var(--color-primary-light-text);
 	&:hover:not(:disabled) {
 		background-color: var(--color-primary-light-hover);
@@ -448,7 +448,7 @@ export default {
 	// Back to the default color for this button when active
 	// TODO: add ripple effect
 	&:active {
-		background-color: var(--color-primary-element-lighter);
+		background-color: var(--color-primary-element-lighter), var(--color-primary-element-light);
 	}
 
 	&__wrapper {

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -504,7 +504,7 @@ $spacing: 4px;
 
 	// Switch specific rules
 	&-switch:not(&--checked) &__icon {
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 	}
 
 	// If switch is checked AND disabled, use the fade primary colour

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -493,7 +493,7 @@ $spacing: 4px;
 	&--disabled &__label {
 		opacity: $opacity_disabled;
 		.checkbox-radio-switch__icon {
-			color: var(--color-text-light)
+			color: var(--color-main-text)
 		}
 	}
 

--- a/src/components/NcListItemIcon/NcListItemIcon.vue
+++ b/src/components/NcListItemIcon/NcListItemIcon.vue
@@ -245,7 +245,7 @@ export default {
 	}
 
 	&__lineone {
-		color: var(--color-text-light);
+		color: var(--color-main-text);
 	}
 	&__linetwo {
 		opacity: $opacity_normal;

--- a/src/components/NcNoteCard/NcNoteCard.vue
+++ b/src/components/NcNoteCard/NcNoteCard.vue
@@ -122,7 +122,7 @@ export default {
 
 <style lang="scss" scoped>
 .notecard {
-	color: var(--color-text-light) !important;
+	color: var(--color-main-text) !important;
 	background-color: var(--note-background) !important;
 	border-inline-start: 4px solid var(--note-theme);
 	border-radius: var(--border-radius);

--- a/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
+++ b/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
@@ -180,7 +180,7 @@ $autocomplete-padding: 10px;
 	}
 
 	&__subline {
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 	}
 }
 

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -598,7 +598,7 @@ export default {
 
 	&--disabled {
 		opacity: $opacity_disabled;
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 		border: 1px solid var(--color-background-darker);
 		border-radius: var(--border-radius);
 		background-color: var(--color-background-dark);

--- a/src/components/NcSettingsInputText/NcSettingsInputText.vue
+++ b/src/components/NcSettingsInputText/NcSettingsInputText.vue
@@ -173,7 +173,7 @@ export default {
 		}
 
 		.hint {
-			color: var(--color-text-lighter);
+			color: var(--color-text-maxcontrast);
 			margin-left: 8px;
 		}
 	}


### PR DESCRIPTION
**Replace deprecated --color-text-lighter with --color-text-maxcontrast** & **Replace deprecated --color-text-light with --color-main-text**
We should never ever use `--color-text-lighter` (or "light") anymore.
- `color-text-light` → `color-main-text`
- `color-text-lighter` → `color-text-maxcontrast`

Could we fully deprecate the old variables?

---

**Progressive enhancement for outdated --color-primary-element-lighter**
The --lighter does not exist in new versions anymore, so currently a button with `type=""` (empty, as opposed to no type property or `type="secondary"` actually does not show any background. This fixes that.