### PR TITLE
Fix empty content height in NcDashboardWidget in N in N in N

### DIFF
--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -314,10 +314,10 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.dashboard-widget .empty-content {
+.dashboard-widget :deep(.empty-content) {
 	text-align: center;
-	margin-top: 5vh;
-
+	margin-top: 0;
+	padding-top: 5vh;
 	&.half-screen {
 		margin-top: 0;
 		margin-bottom: 1vh;


### PR DESCRIPTION
Use padding instead of margin

Fix https://github.com/nextcloud/server/issues/34582