### PR TITLE
Allow querying for resources with complex item ids

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -131,13 +131,25 @@ export default {
 			return false
 		},
 
+		isFiles() {
+			return this.fileInfo?.id !== undefined
+		},
+
 		url() {
-			if (this.fileInfo?.id !== undefined) {
-				return generateOcsUrl('/apps/related_resources/related/files/{fileId}?format=json', { fileId: this.fileInfo.id })
+			let providerId = null
+			let itemId = null
+
+			if (this.isFiles) {
+				providerId = 'files'
+				itemId = this.fileInfo.id
+			} else {
+				providerId = this.providerId
+				itemId = this.itemId
 			}
-			return generateOcsUrl('/apps/related_resources/related/{providerId}/{itemId}?format=json', {
-				providerId: this.providerId,
-				itemId: this.itemId,
+
+			return generateOcsUrl('/apps/related_resources/related/{providerId}?itemId={itemId}&format=json', {
+				providerId,
+				itemId,
 			})
 		},
 	},


### PR DESCRIPTION
Query for resources with the item id as a query string parameter instead of a URL path segment to allow for complex ids

For https://github.com/nextcloud/related_resources/pull/124