### PR TITLE
Fix missing half-empty dashboard empty content view

### DIFF
--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -56,6 +56,41 @@ export default {
 </script>
 ```
 
+### Showing items and a half empty content message
+```vue
+<template>
+	<NcDashboardWidget :items="items"
+		:show-items-and-empty-content="true"
+		:half-empty-content-message="'No unread items'">
+		<template #default="{ item }">
+			{{ item.title }}
+		</template>
+	</NcDashboardWidget>
+</template>
+
+<script>
+const myItems = [
+	{
+		title: 'first',
+		content: 'blabla',
+	},
+	{
+		title: 'second',
+		content: 'fuzzfuzz',
+	},
+]
+export default {
+	name: 'MyDashboardWidget',
+	props: [],
+	data() {
+		return {
+			items: myItems
+		}
+	},
+}
+</script>
+```
+
 ### Complete example using NcDashboardWidgetItem
 
 ```vue

--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -140,7 +140,7 @@ export default {
 	<div class="dashboard-widget">
 		<!-- This element is shown if we have items, but want to show a general message as well.
 		Can be used e.g. to show "No mentions" on top of the item list. -->
-		<NcEmptyContent v-if="showHalfNcArea"
+		<NcEmptyContent v-if="showHalfEmptyContentArea"
 			:description="halfEmptyContentString"
 			class="half-screen">
 			<template #icon>


### PR DESCRIPTION
Regression from https://github.com/nextcloud/nextcloud-vue/commit/8705a051b08dce466d4ed28023f30ef25c4b44d6#diff-3d47e5014667a3933f462ef227ec4965133bf0b3fb67e26bbd164fdda46dc006

Found while working on https://github.com/nextcloud/spreed/pull/8260

Also added it to the docs:
https://deploy-preview-3407--nextcloud-vue-components.netlify.app/#/Components/NcDashboard?id=ncdashboardwidget