### PR TITLE
Fix password_policy fallback handling

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -127,7 +127,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { t } from '../../l10n.js'
 import logger from '../../utils/logger.js'
 
-const defaultPasswordPolicy = loadState('core', 'capabilities', { passwordPolicy: null }).password_policy
+const defaultPasswordPolicy = loadState('core', 'capabilities', {}).password_policy || null
 
 export default {
 	name: 'NcPasswordField',


### PR DESCRIPTION
The defined fallback is only affecting when no core=>capabilities is there. But that is pretty unlikely while the password_policy entry can be missing often (app not installed, unit tests, ...)

Also null vs. undefined gives different results:
https://github.com/nextcloud/nextcloud-vue/blob/0204f6dd86ad16e9b57d8c5915ee15672d4a5e5a/src/components/NcPasswordField/NcPasswordField.vue#L354-L359

Fixes the failing JS unit test in: https://github.com/nextcloud/spreed/pull/8213