### PR TITLE
fix the size of the popper element

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1179,7 +1179,7 @@ export default {
 .v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__inner {
 	border-radius: var(--border-radius-large);
 	padding: 4px;
-	max-height: calc(100vh - 16px);
+	max-height: calc(50vh - 16px);
 	overflow: auto;
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/33839

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/200556494-e1627a0b-300a-4aec-838d-85323dc9cdd7.png) | ![image](https://user-images.githubusercontent.com/42591237/200556425-d9119181-7f8f-421a-80bf-83b79ab0fd09.png) |

Signed-off-by: Simon L <szaimen@e.mail.de>