### PR TITLE
Widen container prop type passed to NcPopover

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -639,7 +639,7 @@ export default {
 		 * Selector for the actions' popover container
 		 */
 		container: {
-			type: String,
+			type: [String, Object, Element, Boolean],
 			default: 'body',
 		},
 

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -348,7 +348,7 @@ export default {
 		 * Selector for the popover menu container
 		 */
 		menuContainer: {
-			type: String,
+			type: [String, Object, Element, Boolean],
 			default: 'body',
 		},
 

--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -169,7 +169,7 @@ export default {
 		 * Selector for the popover container
 		 */
 		container: {
-			type: String,
+			type: [String, Object, Element, Boolean],
 			default: 'body',
 		},
 	},


### PR DESCRIPTION
Fixes type validation errors in the console

From https://github.com/Akryum/floating-vue/blob/v1.0.0-beta.18/packages/floating-vue/src/components/Popper.ts#L146-L147