### PR TITLE
Allow spaces when autocompleting mentions

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -238,6 +238,8 @@ export default {
 		return {
 			tribute: null,
 			autocompleteOptions: {
+				// Allow spaces in the middle of mentions
+				allowSpaces: true,
 				fillAttr: 'id',
 				// Search against id and label (display name)
 				lookup: result => `${result.id} ${result.label}`,

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -104,6 +104,13 @@ export default {
 		 * @return {string}
 		 */
 		genSelectTemplate(value) {
+			// The value returned by this function will replace the trigger '@'
+			// and the search text, so when there is no match we simply return
+			// '@' and the text.
+			if (typeof value === 'undefined') {
+				return `${this.autocompleteTribute.current.collection.trigger}${this.autocompleteTribute.current.mentionText}`
+			}
+
 			const data = this.userData[value]
 
 			// Fallback to @mention in case no data matches


### PR DESCRIPTION
By default Tribute does not allow spaces when autocompleting mentions, so as soon as a space was pressed the autocompletion list was closed, even if some candidate mentions had a space (either in the id or in the display name of the user).

As I found no explicit mention about why spaces should not be allowed when autocompleting mentions in `NcRichContenteditable` this pull request enables them (but if there is a good reason not to enable them please shout :-) ).

Note that now the autocompletion does not end until _Enter_ is pressed (or an item is selected in the list); even if space is pressed and nothing else matches the autocomplete will still be active, even if the list is hidden.

This pull request also fixes an existing bug: if _Enter_ was pressed when the current mention did not match anything an error was shown in the console; now the current unmatched mention text is passed.

As the Comments app in Nextcloud server uses `NcRichContenteditable` these issues are also present in previous Nextcloud server releases. But I do not know how that is handled :shrug: Is this pull request backported to previous nextcloud-vue versions, a bugfix release is published for those older versions, and then the dependencies are bumped to the respective bugfix releases in _stable23_, _stable24_ and _stable25_ in server?

## How to test (scenario 1)

- Open the `NcRichContenteditable` documentation ([master](https://nextcloud-vue-components.netlify.app/#/Components/NcRichContenteditable), [pull request](https://deploy-preview-3468--nextcloud-vue-components.netlify.app/#/Components/NcRichContenteditable))
- In the example, type `@test 03`

### Result with this pull request

The autocompletion list is kept open and only `Test 03` is shown

### Result without this pull request

The autocompletion list is closed



## How to test (scenario 2)

- Open the `NcRichContenteditable` documentation ([master](https://nextcloud-vue-components.netlify.app/#/Components/NcRichContenteditable), [pull request](https://deploy-preview-3468--nextcloud-vue-components.netlify.app/#/Components/NcRichContenteditable))
- In the example, type `@unmatched`, press _Enter_ and then press _Enter_ again

### Result with this pull request

The message is sent as `@unmatched`

### Result without this pull request

An error is shown twice in the console and the message is not sent

Note that, with this pull request, if `@Test 03 and some more text` is written and _Enter_ is pressed twice then the message sent will be `@Test 03 and some more text` rather than `@"Test 03" and some more text`, given that as mentioned above the autocompletion does not end until _Enter_ is pressed, so `@Test 03 and some more text` is seen as the whole unmatched mention and therefore passed. I have not found a way to solve that, although it would be probably uncommon to type the full user id without user the autocompletion list. Or at least I hope so :-)