### PR TITLE
Fix comments headers

### DIFF
--- a/src/components/NcAppContent/index.js
+++ b/src/components/NcAppContent/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcAppContentDetails/index.js
+++ b/src/components/NcAppContentDetails/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcAppContentList/index.js
+++ b/src/components/NcAppContentList/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcAppNavigationNew/index.js
+++ b/src/components/NcAppNavigationNew/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcAppNavigationSettings/index.js
+++ b/src/components/NcAppNavigationSettings/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcAppSidebar/index.js
+++ b/src/components/NcAppSidebar/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcContent/index.js
+++ b/src/components/NcContent/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/components/NcEmojiPicker/index.js
+++ b/src/components/NcEmojiPicker/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2020 Georg Ehrke <oc.list@georgehrke.com>
  *
  * @author 2020 Georg Ehrke <oc.list@georgehrke.com>

--- a/src/components/NcGuestContent/index.js
+++ b/src/components/NcGuestContent/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2022 Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>


### PR DESCRIPTION
Dont't ask, all the other files follow the same `**` syntax :see_no_evil: 
Sometimes this single `*` creates weird syntax highlighting bugs