### PR TITLE
Bump floating-vue to v1.0.0-beta.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"debounce": "1.2.1",
 				"emoji-mart-vue-fast": "^12.0.1",
 				"escape-html": "^1.0.3",
-				"floating-vue": "^1.0.0-beta.18",
+				"floating-vue": "^1.0.0-beta.19",
 				"focus-trap": "^7.1.0",
 				"hammerjs": "^2.0.8",
 				"linkify-string": "^4.0.0",
@@ -12433,9 +12433,9 @@
 			"peer": true
 		},
 		"node_modules/floating-vue": {
-			"version": "1.0.0-beta.18",
-			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-1.0.0-beta.18.tgz",
-			"integrity": "sha512-mRFc78szc1BTbhlCa4okb7wAGPuH/IID+yqJ+yrTMQ038H8WIAsPV/WFgWCaXqe8d1Z12LkMqiHDVorCJy8M2A==",
+			"version": "1.0.0-beta.19",
+			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-1.0.0-beta.19.tgz",
+			"integrity": "sha512-OcM7z5Ua4XAykqolmvPj3l1s+KqUKj6Xz2t66eqjgaWfNBjtuifmxO5+4rRXakIch/Crt8IH+vKdKcR3jOUaoQ==",
 			"dependencies": {
 				"@floating-ui/dom": "^0.1.10",
 				"vue-resize": "^1.0.0"
@@ -39055,9 +39055,9 @@
 			"peer": true
 		},
 		"floating-vue": {
-			"version": "1.0.0-beta.18",
-			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-1.0.0-beta.18.tgz",
-			"integrity": "sha512-mRFc78szc1BTbhlCa4okb7wAGPuH/IID+yqJ+yrTMQ038H8WIAsPV/WFgWCaXqe8d1Z12LkMqiHDVorCJy8M2A==",
+			"version": "1.0.0-beta.19",
+			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-1.0.0-beta.19.tgz",
+			"integrity": "sha512-OcM7z5Ua4XAykqolmvPj3l1s+KqUKj6Xz2t66eqjgaWfNBjtuifmxO5+4rRXakIch/Crt8IH+vKdKcR3jOUaoQ==",
 			"requires": {
 				"@floating-ui/dom": "^0.1.10",
 				"vue-resize": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"debounce": "1.2.1",
 		"emoji-mart-vue-fast": "^12.0.1",
 		"escape-html": "^1.0.3",
-		"floating-vue": "^1.0.0-beta.18",
+		"floating-vue": "^1.0.0-beta.19",
 		"focus-trap": "^7.1.0",
 		"hammerjs": "^2.0.8",
 		"linkify-string": "^4.0.0",


### PR DESCRIPTION
# [1.0.0-beta.19](https://github.com/Akryum/v-tooltip/compare/v1.0.0-beta.18...v1.0.0-beta.19) (2022-11-17)


### Bug Fixes

* remove browser outline on dropdown, fix [#848](https://github.com/Akryum/v-tooltip/issues/848) ([cb1162d](https://github.com/Akryum/v-tooltip/commit/cb1162d18cc61cd473a1b182df51f06aeb7d8515))


### Features

* noAutoFocus ([f8d4ed8](https://github.com/Akryum/v-tooltip/commit/f8d4ed85adeb60d02d79f1905cf5eac572ee70f1))

