### PR TITLE
7.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.1.0-beta.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.1.0-beta.1) (2022-11-18)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.1.0-beta.0...v7.1.0-beta.1)
+
+### :rocket: Enhancements
+
+- Extend NcInputField props and forward $attrs to NcPasswordField and NcTextField [\#3485](https://github.com/nextcloud/nextcloud-vue/pull/3485) ([skjnldsv](https://github.com/skjnldsv))
+- Move loadState to data for better mockability [\#3502](https://github.com/nextcloud/nextcloud-vue/pull/3502) ([skjnldsv](https://github.com/skjnldsv))
+
+### :bug: Fixed bugs
+
+- Fix value type for DateTimePickerNative [\#3491](https://github.com/nextcloud/nextcloud-vue/pull/3491) ([skjnldsv](https://github.com/skjnldsv))
+
 ## [v7.1.0-beta.0](https://github.com/nextcloud/nextcloud-vue/tree/v7.0.2-beta.0) (2022-11-15)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.0.1...v7.0.2-beta.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.1.0-beta.0",
+	"version": "7.1.0-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.1.0-beta.0",
+			"version": "7.1.0-beta.1",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.1.0-beta.0",
+	"version": "7.1.0-beta.1",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
## [v7.1.0-beta.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.1.0-beta.1) (2022-11-18)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.1.0-beta.0...v7.1.0-beta.1)

### :rocket: Enhancements

- Extend NcInputField props and forward $attrs to NcPasswordField and NcTextField [\#3485](https://github.com/nextcloud/nextcloud-vue/pull/3485) ([skjnldsv](https://github.com/skjnldsv))
- Move loadState to data for better mockability [\#3502](https://github.com/nextcloud/nextcloud-vue/pull/3502) ([skjnldsv](https://github.com/skjnldsv))

### :bug: Fixed bugs

- Fix value type for DateTimePickerNative [\#3491](https://github.com/nextcloud/nextcloud-vue/pull/3491) ([skjnldsv](https://github.com/skjnldsv))
