### PR TITLE
release v7.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.1.0-beta.2](https://github.com/nextcloud/nextcloud-vue/tree/v7.1.0-beta.2) (2022-11-23)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.1.0-beta.1...v7.1.0-beta.2)
+
+### :bug: Fixed bugs
+
+- Fix multiselect checkmark and plus icon [\#3513](https://github.com/nextcloud/nextcloud-vue/pull/3513) ([skjnldsv](https://github.com/skjnldsv))
+- Make gap in NcAppNavigation consistent in nested lists [\#3506](https://github.com/nextcloud/nextcloud-vue/pull/3506) ([juliushaertl](https://github.com/juliushaertl))
+
+### Closed pull requests
+
+- Finish emoji focus cleaning [\#3504](https://github.com/nextcloud/nextcloud-vue/pull/3504) ([skjnldsv](https://github.com/skjnldsv))
+
 ## [v7.1.0-beta.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.1.0-beta.1) (2022-11-18)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.1.0-beta.0...v7.1.0-beta.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.1.0-beta.1",
+	"version": "7.1.0-beta.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.1.0-beta.1",
+			"version": "7.1.0-beta.2",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.1.0-beta.1",
+	"version": "7.1.0-beta.2",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
## [v7.1.0-beta.2](https://github.com/nextcloud/nextcloud-vue/tree/v7.1.0-beta.2) (2022-11-23)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.1.0-beta.1...v7.1.0-beta.2)

### :bug: Fixed bugs

- Fix multiselect checkmark and plus icon [\#3513](https://github.com/nextcloud/nextcloud-vue/pull/3513) ([skjnldsv](https://github.com/skjnldsv))
- Make gap in NcAppNavigation consistent in nested lists [\#3506](https://github.com/nextcloud/nextcloud-vue/pull/3506) ([juliushaertl](https://github.com/juliushaertl))

### Closed pull requests

- Finish emoji focus cleaning [\#3504](https://github.com/nextcloud/nextcloud-vue/pull/3504) ([skjnldsv](https://github.com/skjnldsv))