### PR TITLE
Fix focus returning to top of page instead of actions toggle button

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1003,6 +1003,7 @@ export default {
 						boundary: this.boundariesElement,
 						container: this.container,
 						popoverBaseClass: 'action-item__popper',
+						setReturnFocus: this.$refs.menuButton?.$el,
 					},
 					// For some reason the popover component
 					// does not react to props given under the 'props' key,

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -123,6 +123,14 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		/**
+		 * Set element to return focus to after focus trap deactivation
+		 *
+		 * @type {import('focus-trap').Options['setReturnFocus']}
+		 */
+		setReturnFocus: {
+			required: false,
+		},
 	},
 
 	emits: [
@@ -157,6 +165,7 @@ export default {
 				// Focus will be release when popover be hide
 				escapeDeactivates: false,
 				allowOutsideClick: true,
+				setReturnFocus: this.setReturnFocus,
 				trapStack: getTrapStack(),
 			})
 			this.$focusTrap.activate()


### PR DESCRIPTION
Fix focused element when tabbing after reaching the last actions menu item

### Before

https://nextcloud-vue-components.netlify.app/#/Components/NcActions?id=ncactions-1 (Scroll down to "Multiple actions")

Focus returns to the top of the page

### After

https://deploy-preview-3530--nextcloud-vue-components.netlify.app/#/Components/NcActions?id=ncactions-1 (Scroll down to "Multiple actions")

Focus returns to the actions menu toggle button