### PR TITLE
Add button role for NcButton with href

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -202,7 +202,6 @@ button {
 		v-bind="rootElement"
 		:class="buttonClassObject"
 		:aria-label="ariaLabel"
-		:type="nativeType"
 		:disabled="disabled"
 		v-on="$listeners">
 		<span class="button-vue__wrapper">
@@ -321,6 +320,7 @@ export default {
 				return {
 					is: 'router-link',
 					tag: 'button',
+					type: this.nativeType,
 					to: this.to,
 					exact: this.exact,
 					...this.$attrs,
@@ -335,6 +335,7 @@ export default {
 			}
 			return {
 				is: 'button',
+				type: this.nativeType,
 				...this.$attrs,
 			}
 		},

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -330,6 +330,7 @@ export default {
 				return {
 					is: 'a',
 					href: this.href,
+					role: 'button',
 					...this.$attrs,
 				}
 			}


### PR DESCRIPTION
Attribute `role="button"` added for anchor element in NcButton with `href` and fixed the invalid `type="button"` attr being added to the DOM when using NcButton as a link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type

`router-link` is rendered as a button element https://v3.router.vuejs.org/api/#tag