### PR TITLE
Scope global #content styles via extra class

### DIFF
--- a/src/components/NcGuestContent/NcGuestContent.vue
+++ b/src/components/NcGuestContent/NcGuestContent.vue
@@ -49,6 +49,12 @@ This components provides a wrapper around a guest page content.
  */
 export default {
 	name: 'NcGuestContent',
+	mounted() {
+		document.getElementById('content').classList.add('nc-guest-content')
+	},
+	destroyed() {
+		document.getElementById('content').classList.remove('nc-guest-content')
+	},
 }
 </script>
 
@@ -66,7 +72,7 @@ export default {
 </style>
 
 <style lang="scss">
-#content {
+#content.nc-guest-content {
 	// Enable scrolling
 	overflow: auto;
 

--- a/src/components/NcGuestContent/NcGuestContent.vue
+++ b/src/components/NcGuestContent/NcGuestContent.vue
@@ -23,7 +23,10 @@
 <docs>
 ### General description
 
-This components provides a wrapper around a guest page content.
+This components provides a wrapper around guest page content.
+It should be used as the main wrapper for public pages, similar to `NcContent`.
+
+It can't be used multiple times on the same page.
 
 ### Usage
 


### PR DESCRIPTION
Fix #3534 

I also improved the documentation of `NcGuestContent` to clarify its usages and caveats.

## Unrelated sites

Observe the bottom margin that was incorrectly applied to all pages before. Now, it's only applied when `NcGuestContent` is actually used.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/205250320-3d905f0e-a62b-46f5-abd7-7856db5518dc.png) |![image](https://user-images.githubusercontent.com/1479486/205250395-1d39ea1d-3370-4fa9-9125-e928fd92edc9.png) |

## `NcGuestContent` sample usage from calendar appointments

The global styling still works with my patch applied. Otherwise, there would be weird margin between the bottom and the scrollable area.

[nc-guest-content-after.webm](https://user-images.githubusercontent.com/1479486/205250838-52e8e036-dd2b-4203-a7d3-844427a8cc7d.webm)


