### PR TITLE
Fix icon repeat and position for AppNavigationItem

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -682,6 +682,8 @@ export default {
 			width: $clickable-area;
 			height: $clickable-area;
 			background-size: $icon-size $icon-size;
+			background-repeat: no-repeat;
+			background-position: $icon-margin center;
 		}
 
 		.app-navigation-entry__title {


### PR DESCRIPTION
I don't really understand how no one experienced this before...

EDIT: ah, ok.
Some icons do not start with `icon-`
![image](https://user-images.githubusercontent.com/14975046/205279308-809cb791-fe33-4af1-b663-863a590a11c6.png)


| Before | After |
|:---------:|:------:|
|![2022-12-02_12-04](https://user-images.githubusercontent.com/14975046/205278950-aa3705a4-8c5e-46cc-a0c3-1aadcb659714.png)|![2022-12-02_12-04_1](https://user-images.githubusercontent.com/14975046/205278954-a6ce83a9-7a86-4453-b602-1aac5fecbbf2.png)| 