### PR TITLE
Fix jsdoc: Add missing documentation for events

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -191,8 +191,8 @@ export default {
 			}
 			/**
 			 * Event emitted when something is dropped on the breadcrumb.
-			 *
-			 * @type {null}
+			 * @param {Event} event The DOM drop event
+			 * @param {(string|object)} to The `to` prop or, if not set, the `href` prop
 			 */
 			this.$emit('dropped', e, this.to || this.href)
 			this.$parent.$emit('dropped', e, this.to || this.href)

--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -374,7 +374,8 @@ export default {
 				/**
 				 * Event emitted when something is dropped on the breadcrumb.
 				 *
-				 * @type {null}
+				 * @param {Event} e the drop DOM event
+				 * @param {string} path The path of the breadcrumb
 				 */
 				this.$emit('dropped', e, path)
 			}

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -352,7 +352,7 @@ export default {
 		},
 
 		/**
-		 * Id for the <a> element
+		 * Id for the `<a>` element
 		 */
 		anchorId: {
 			type: String,


### PR DESCRIPTION
Added some missing documentation for events.

(This is a cherry pick from https://github.com/nextcloud/nextcloud-vue/pull/3529 as that PR is still WIP)