### PR TITLE
Add console warning messages for deprecated multiselect components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
 	globals: {
 		EMOJIS: true,
+		PRODUCTION: true,
 		SCOPE_VERSION: true,
 		TRANSLATIONS: true,
 		oc_userconfig: true,

--- a/src/components/NcMultiselect/NcMultiselect.vue
+++ b/src/components/NcMultiselect/NcMultiselect.vue
@@ -247,6 +247,10 @@ import l10n from '../../mixins/l10n.js'
 
 import VueMultiselect from 'vue-multiselect'
 
+if (!PRODUCTION) {
+	console.warn('NcMultiselect usage has been deprecated. Use NcSelect instead.')
+}
+
 export default {
 	name: 'NcMultiselect',
 	components: {

--- a/src/components/NcMultiselectTags/NcMultiselectTags.vue
+++ b/src/components/NcMultiselectTags/NcMultiselectTags.vue
@@ -155,6 +155,10 @@ import NcMultiselect from '../NcMultiselect/index.js'
 import l10n from '../../mixins/l10n.js'
 import { t } from '../../l10n.js'
 
+if (!PRODUCTION) {
+	console.warn('NcMultiselectTags usage has been deprecated. Use NcSelectTags instead.')
+}
+
 export default {
 	name: 'NcMultiselectTags',
 	components: {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -26,5 +26,6 @@ import 'regenerator-runtime/runtime'
 
 global.OC = OC
 
-global.TRANSLATIONS = []
+global.PRODUCTION = false
 global.SCOPE_VERSION = 1
+global.TRANSLATIONS = []

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,6 +147,7 @@ module.exports = async () => {
 	const translations = await loadTranslations(path.resolve(__dirname, './l10n'))
 
 	config.plugins.push(new DefinePlugin({
+		PRODUCTION: JSON.stringify(!isDev),
 		SCOPE_VERSION,
 		TRANSLATIONS: JSON.stringify(translations),
 	}))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24800714/208000730-13cd283e-5d8b-47e3-b2c3-1d5d56422e33.png)

As discussed https://github.com/nextcloud/nextcloud-vue/issues/2951#issuecomment-1351963646

For developers in addition to the existing deprecation badges in the docs
![image](https://user-images.githubusercontent.com/24800714/207674149-80badf7b-015f-4132-864c-826b44ee8727.png)
![image](https://user-images.githubusercontent.com/24800714/207674160-61bd7f52-3c04-45f2-9059-86d266c43f3f.png)