### PR TITLE
Fix CheckboxHeight

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -471,9 +471,9 @@ $spacing: 4px;
 		position: relative;
 		align-items: center;
 		user-select: none;
-		height: $clickable-area;
+		min-height: $clickable-area;
 		border-radius: $clickable-area;
-		padding: 0 $icon-margin;
+		padding: 4px $icon-margin;
 		margin: 0 #{-$icon-margin};
 
 		&, * {


### PR DESCRIPTION
Fixing the checkbox-height for multiline content. Single-line content just looks as before.

|Before|After|
|---|---|
|![grafik](https://user-images.githubusercontent.com/47433654/208526190-384724d2-8b22-4152-886b-d71b7df2154c.png)|![grafik](https://user-images.githubusercontent.com/47433654/208524616-5e683452-609d-4a7c-9ddc-1ced388dd45e.png)|