### PR TITLE
Create `aria-label` for icon link

### DIFF
--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -49,6 +49,7 @@ This component is to be used in the settings section of nextcloud.
 				:href="docUrl"
 				class="settings-section__info"
 				role="note"
+				:aria-label="docTitleTranslated"
 				:title="docTitleTranslated">
 				<HelpCircle :size="20" />
 			</a>


### PR DESCRIPTION
Resolves https://github.com/nextcloud/server/issues/35886

A11y issue: Create `aria-label` for icon link in SettingsSection

