### PR TITLE
fix(NcAppNavigationItem): Make sure that icon-collapse styles take precendense over NcButton styles

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
@@ -77,7 +77,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.icon-collapse {
+.button-vue.icon-collapse {
 	position: absolute;
 	z-index: 105; // above a, under button
 	color: var(--color-main-text);


### PR DESCRIPTION
Upstream fix for https://github.com/nextcloud/mail/pull/7856

Fixes https://github.com/nextcloud/deck/issues/4352
Fixes https://github.com/nextcloud/mail/issues/7095

This makes sure that the NcAppNavigationIconCollapsible styles always take precendence over the NcButton ones as for the mail/deck app the loading order seems to be different compared to the vue component docs. Before this the NcButton relative positioning was applied within the apps instead of the absolute one.

Tested and works with deck.
