### PR TITLE
fix(ProgressBar): Fix progress rounded corners

### DIFF
--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -115,11 +115,11 @@ export default {
 		height: var(--progress-bar-height);
 	}
 	&::-webkit-progress-value {
-		background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
+		background: var(--gradient-primary-background);
 		border-radius: calc(var(--progress-bar-height) / 2);
 	}
 	&::-moz-progress-bar {
-		background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
+		background: var(--gradient-primary-background);
 		border-radius: calc(var(--progress-bar-height) / 2);
 	}
 	&--error {

--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -102,12 +102,15 @@ export default {
 
 .progress-bar {
 	display: block;
+	height: var(--progress-bar-height);
 	width: 100%;
-	background: var(--color-background-dark);
+	overflow: hidden;
 	border: 0;
 	padding: 0;
-	height: var(--progress-bar-height);
+	background: var(--color-background-dark);
 	border-radius: calc(var(--progress-bar-height) / 2);
+
+	// Browser specific rules
 	&::-webkit-progress-bar {
 		height: var(--progress-bar-height);
 	}


### PR DESCRIPTION
This is very subtle, check the gif below where I toggle the overflow rule on and off

![Peek 04-01-2023 18-52](https://user-images.githubusercontent.com/14975046/210618531-c5c8f06c-20ac-475d-aac9-c09a032fbb22.gif)

EDIT: Also fixed the background variable
| Before | After |
|:---------:|:------:|
|![image](https://user-images.githubusercontent.com/14975046/210620582-c3c51544-8c96-44a1-b005-511d37823dff.png)|![image](https://user-images.githubusercontent.com/14975046/210620637-5103b280-e5df-43f3-9374-671d2834a789.png)|
