### PR TITLE
Do not add aria-label when avatar is not interactive

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -384,10 +384,12 @@ export default {
 	},
 	computed: {
 		avatarAriaLabel() {
+			if (!this.hasMenu) {
+				return
+			}
 			if (this.ariaLabel !== null) {
 				return this.ariaLabel
 			}
-
 			if (this.hasStatus && this.showUserStatus && this.showUserStatusCompact) {
 				return t('Avatar of {displayName}, {status}', { displayName: this.displayName ?? this.user, status: this.userStatus.status })
 			}


### PR DESCRIPTION
[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) should only be present when the element is interactive