### PR TITLE
Use material design icons in documentation everywhere

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -82,7 +82,10 @@ If you're using a long text you can specify a title
 ```vue
 	<template>
 		<NcActions>
-			<NcActionButton icon="icon-add" @click="showMessage('Add')">
+			<NcActionButton @click="showMessage('Add')">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
 				Add new
 			</NcActionButton>
 			<NcActionButton title="Long button" @click="showMessage('Delete')">
@@ -95,10 +98,12 @@ If you're using a long text you can specify a title
 	</template>
 	<script>
 	import Delete from 'vue-material-design-icons/Delete'
+	import Plus from 'vue-material-design-icons/Plus'
 
 	export default {
 		components: {
 			Delete,
+			Plus,
 		},
 		methods: {
 			showMessage(msg) {
@@ -115,13 +120,21 @@ Action icon attribute with a single action
 ```vue
 	<template>
 		<NcActions>
-			<NcActionButton icon="icon-add" @click="showMessage('Add')">
+			<NcActionButton @click="showMessage('Add')">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
 				Add new
 			</NcActionButton>
 		</NcActions>
 	</template>
 	<script>
+	import Plus from 'vue-material-design-icons/Plus'
+
 	export default {
+		components: {
+			Plus,
+		},
 		methods: {
 			showMessage(msg) {
 				alert(msg)

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -25,15 +25,56 @@
 This component is made to be used inside of the [NcActions](#NcActions) component slots.
 All undocumented attributes will be bound to the input, the datepicker or the multiselect component, e.g. `maxlength`, `not-before`.
 For the multiselect component, all events will be passed through. Please see the multiselect component's documentation for more details and examples.
-```
-<NcActions>
-	<NcActionInput icon="icon-edit" value="This is an input" />
-	<NcActionInput icon="icon-edit">This is the placeholder</NcActionInput>
-	<NcActionInput icon="icon-edit" label="Visible label">Input with visible label</NcActionInput>
-	<NcActionInput icon="icon-close" :disabled="true" value="This is a disabled input" />
-	<NcActionInput icon="icon-edit" type="date">Please pick a date</NcActionInput>
-	<NcActionInput icon="icon-edit" type="multiselect" :options="['Apple', 'Banana', 'Cherry']">Please pick a fruit</NcActionInput>
-</NcActions>
+```vue
+	<template>
+		<NcActions>
+			<NcActionInput value="This is an input">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+			</NcActionInput>
+			<NcActionInput>
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+				This is the placeholder
+			</NcActionInput>
+			<NcActionInput label="Visible label">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+				Input with visible label
+			</NcActionInput>
+			<NcActionInput :disabled="true" value="This is a disabled input">
+				<template #icon>
+					<Close :size="20" />
+				</template>
+			</NcActionInput>
+			<NcActionInput type="date">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+				Please pick a date
+			</NcActionInput>
+			<NcActionInput type="multiselect" :options="['Apple', 'Banana', 'Cherry']">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+				Please pick a fruit
+			</NcActionInput>
+		</NcActions>
+	</template>
+	<script>
+	import Close from 'vue-material-design-icons/Close'
+	import Pencil from 'vue-material-design-icons/Pencil'
+
+	export default {
+		components: {
+			Close,
+			Pencil,
+		},
+	}
+	</script>
 ```
 </docs>
 

--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -1,38 +1,81 @@
 <docs>
-```
-<NcAppNavigationCaption
-	title="Your caption goes here">
-	<template #actions>
-		<NcActionButton icon="icon-add"/>
+```vue
+	<template>
+		<NcAppNavigationCaption
+			title="Your caption goes here">
+			<template #actions>
+				<NcActionButton>
+					<template #icon>
+						<Plus :size="20" />
+					</template>
+				</NcActionButton>
+			</template>
+		</NcAppNavigationCaption>
 	</template>
-</NcAppNavigationCaption>
-```
-
-### Element with a slot for custom actions icon
-```
-<template>
-	<NcAppNavigationCaption
-		title="Your caption goes here">
-		<template #actionsTriggerIcon>
-			<PlusIcon slot="icon" :size="20" />
-		</template>
-		<template #actions>
-			<NcActionButton icon="icon-edit">Rename</NcActionButton>
-			<NcActionButton icon="icon-delete">Delete</NcActionButton>
-			<NcActionButton icon="icon-confirm">Validate</NcActionButton>
-			<NcActionButton icon="icon-download">Download</NcActionButton>
-		</template>
-	</NcAppNavigationCaption>
-</template>
-<script>
-	import PlusIcon from 'vue-material-design-icons/Plus'
+	<script>
+	import Plus from 'vue-material-design-icons/Plus'
 
 	export default {
 		components: {
-			PlusIcon
-		}
+			Plus,
+		},
 	}
-</script>
+	</script>
+```
+
+### Element with a slot for custom actions icon
+```vue
+	<template>
+		<NcAppNavigationCaption
+			title="Your caption goes here">
+			<template #actionsTriggerIcon>
+				<Plus slot="icon" :size="20" />
+			</template>
+			<template #actions>
+				<NcActionButton>
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					Rename
+				</NcActionButton>
+				<NcActionButton>
+					<template #icon>
+						<Delete :size="20" />
+					</template>
+					Delete
+				</NcActionButton>
+				<NcActionButton>
+					<template #icon>
+						<ArrowRight :size="20" />
+					</template>
+					Validate
+				</NcActionButton>
+				<NcActionButton>
+					<template #icon>
+						<Download :size="20" />
+					</template>
+					Download
+				</NcActionButton>
+			</template>
+		</NcAppNavigationCaption>
+	</template>
+	<script>
+		import ArrowRight from 'vue-material-design-icons/ArrowRight'
+		import Delete from 'vue-material-design-icons/Delete'
+		import Download from 'vue-material-design-icons/Download'
+		import Pencil from 'vue-material-design-icons/Pencil'
+		import Plus from 'vue-material-design-icons/Plus'
+
+		export default {
+			components: {
+				ArrowRight,
+				Delete,
+				Download,
+				Pencil,
+				Plus,
+			}
+		}
+	</script>
 ```
 
 </docs>

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -31,9 +31,23 @@
 
 * With an icon:
 
-```
-<NcAppNavigationItem title="My title" icon="icon-category-enabled" />
+```vue
+	<template>
+		<NcAppNavigationItem title="My title">
+			<template #icon>
+				<Check :size="20" />
+			</template>
+		</NcAppNavigationItem>
+	</template>
+	<script>
+	import Check from 'vue-material-design-icons/Check'
 
+	export default {
+		components: {
+			Check,
+		},
+	}
+	</script>
 ```
 * With a spinning loader instead of the icon:
 
@@ -45,33 +59,77 @@
 Wrap the children in a template. If you have more than 2 actions, a popover menu and a menu
 button will be automatically created.
 
-```
-<div id="app-navigation-vue"><!-- Just a wrapper necessary in the docs. Not needed when NcAppNavigation is correctly used as parent. -->
-	<NcAppNavigationItem title="Item with actions" icon="icon-category-enabled">
-		<template #actions>
-			<NcActionButton icon="icon-edit" @click="alert('Edit')">
-				Edit
-			</NcActionButton>
-			<NcActionButton icon="icon-delete" @click="alert('Delete')">
-				Delete
-			</NcActionButton>
-			<NcActionLink icon="icon-external" title="Link" href="https://nextcloud.com" />
-		</template>
-	</NcAppNavigationItem>
-</div>
+```vue
+	<template>
+		<div id="app-navigation-vue"><!-- Just a wrapper necessary in the docs. Not needed when NcAppNavigation is correctly used as parent. -->
+			<NcAppNavigationItem title="Item with actions">
+				<template #icon>
+					<Check :size="20" />
+				</template>
+				<template #actions>
+					<NcActionButton @click="alert('Edit')">
+						<template #icon>
+							<Pencil :size="20" />
+						</template>
+						Edit
+					</NcActionButton>
+					<NcActionButton @click="alert('Delete')">
+						<template #icon>
+							<Delete :size="20" />
+						</template>
+						Delete
+					</NcActionButton>
+					<NcActionLink title="Link" href="https://nextcloud.com">
+						<template #icon>
+							<OpenInNew :size="20" />
+						</template>
+					</NcActionLink>
+				</template>
+			</NcAppNavigationItem>
+		</div>
+	</template>
+	<script>
+	import Check from 'vue-material-design-icons/Check'
+	import Delete from 'vue-material-design-icons/Delete'
+	import OpenInNew from 'vue-material-design-icons/OpenInNew'
+	import Pencil from 'vue-material-design-icons/Pencil'
+
+	export default {
+		components: {
+			Check,
+			Delete,
+			OpenInNew,
+			Pencil,
+		},
+	}
+	</script>
 ```
 
 ### Element with counter
 Just nest the counter in a template within `<NcAppNavigationItem>` and add `#counter` to it.
 
-```
-<NcAppNavigationItem title="Item with counter" icon="icon-folder">
-	<template #counter>
-		<NcCounterBubble>
-			99+
-		</NcCounterBubble>
+```vue
+	<template>
+		<NcAppNavigationItem title="Item with counter">
+			<template #icon>
+				<Folder :size="20" />
+			</template>
+			<template #counter>
+				<NcCounterBubble>
+					99+
+				</NcCounterBubble>
+			</template>
+		</NcAppNavigationItem>
 	</template>
-</NcAppNavigationItem>
+	<script>
+	import Folder from 'vue-material-design-icons/Folder'
+
+	export default {
+		components: {
+			Folder,
+		},
+	}
+	</script>
 ```
 
 ### Element with children
@@ -94,9 +152,24 @@ prevent the user from collapsing the items.
 Add the prop `:editable=true` and an edit placeholder if you need it. By default
 the placeholder is the previous title of the element.
 
-```
-<NcAppNavigationItem title="Editable Item" :editable="true"
-	editPlaceholder="your_placeholder_here" icon="icon-folder" @update:title="function(value){alert(value)}" />
+```vue
+	<template>
+		<NcAppNavigationItem title="Editable Item" :editable="true"
+			editPlaceholder="your_placeholder_here" @update:title="function(value){alert(value)}">
+			<template #icon>
+				<Folder :size="20" />
+			</template>
+		</NcAppNavigationItem>
+	</template>
+	<script>
+	import Folder from 'vue-material-design-icons/Folder'
+
+	export default {
+		components: {
+			Folder,
+		},
+	}
+	</script>
 ```
 
 ### Undo element

--- a/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
+++ b/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
@@ -24,13 +24,43 @@
 # Usage
 
 ### New Item element
-```
-<NcAppNavigationNewItem title="New Item" icon="icon-add" @new-item="function(value){alert(value)}" />
+```vue
+	<template>
+		<NcAppNavigationNewItem title="New Item" @new-item="function(value){alert(value)}">
+			<template #icon>
+				<Plus :size="20" />
+			</template>
+		</NcAppNavigationNewItem>
+	</template>
+	<script>
+	import Plus from 'vue-material-design-icons/Plus'
+
+	export default {
+		components: {
+			Plus,
+		},
+	}
+	</script>
 ```
 
 ### New Item element with a loading animation instead of the icon
-```
-<NcAppNavigationNewItem title="New Item" icon="icon-add" :loading="true" />
+```vue
+	<template>
+		<NcAppNavigationNewItem title="New Item" :loading="true">
+			<template #icon>
+				<Plus :size="20" />
+			</template>
+		</NcAppNavigationNewItem>
+	</template>
+	<script>
+	import Plus from 'vue-material-design-icons/Plus'
+
+	export default {
+		components: {
+			Plus,
+		},
+	}
+	</script>
 ```
 </docs>
 <template>

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -34,23 +34,28 @@ include a standard-header like it's used by the files app.
 	<NcAppSidebar
 		title="cat-picture.jpg"
 		subtitle="last edited 3 weeks ago">
-		<NcAppSidebarTab icon="icon-settings" name="Settings" id="settings-tab">
+		<NcAppSidebarTab name="Settings" id="settings-tab">
 			<template #icon>
 				<Cog :size="20" />
 			</template>
 			Settings tab content
 		</NcAppSidebarTab>
-		<NcAppSidebarTab icon="icon-share" name="Sharing" id="share-tab">
+		<NcAppSidebarTab name="Sharing" id="share-tab">
+			<template #icon>
+				<ShareVariant :size="20" />
+			</template>
 			Sharing tab content
 		</NcAppSidebarTab>
 	</NcAppSidebar>
 </template>
 <script>
 	import Cog from 'vue-material-design-icons/Cog'
+	import ShareVariant from 'vue-material-design-icons/ShareVariant'
 
 	export default {
 		components: {
 			Cog,
+			ShareVariant,
 		},
 	}
 </script>
@@ -121,15 +126,26 @@ include a standard-header like it's used by the files app.
 ### Empty sidebar for e.g. empty content component.
 
 ```vue
-<template>
-	<NcAppSidebar
-		title="cat-picture.jpg"
-		:empty="true">
-		<NcEmptyContent icon="icon-search">
-			Content not found.
-		</NcEmptyContent>
-	</NcAppSidebar>
-</template>
+	<template>
+		<NcAppSidebar
+			title="cat-picture.jpg"
+			:empty="true">
+			<NcEmptyContent title="Content not found.">
+				<template #icon>
+					<Magnify :size="20" />
+				</template>
+			</NcEmptyContent>
+		</NcAppSidebar>
+	</template>
+	<script>
+	import Magnify from 'vue-material-design-icons/Magnify'
+
+	export default {
+		components: {
+			Magnify,
+		},
+	}
+	</script>
 ```
 </docs>
 

--- a/src/components/NcContent/NcContent.vue
+++ b/src/components/NcContent/NcContent.vue
@@ -31,30 +31,39 @@ It includes the Navigation, the App content and the Sidebar.
 ### Standard usage
 
 ```vue
-<template>
-	<NcContent app-name="forms">
-		<NcAppNavigation>
-			<template #list>
-				<NcAppNavigationNew text="Create article" />
-				<NcAppNavigationItem title="My title" icon="icon-category-enabled" />
-			</template>
-		</NcAppNavigation>
-		<NcAppContent>
-			<h2>Your main app content here</h2>
-			<NcButton @click="opened = !opened">Toggle sidebar</NcButton>
-		</NcAppContent>
-		<NcAppSidebar v-if="opened" title="cat-picture.jpg" @close="opened=false"></AppSidebar>
-	</NcContent>
-</template>
-<script>
-export default {
-	data() {
-		return {
-			opened: false,
+	<template>
+		<NcContent app-name="forms">
+			<NcAppNavigation>
+				<template #list>
+					<NcAppNavigationNew text="Create article" />
+					<NcAppNavigationItem title="My title">
+						<template #icon>
+							<Check :size="20" />
+						</template>
+					</NcAppNavigationItem>
+				</template>
+			</NcAppNavigation>
+			<NcAppContent>
+				<h2>Your main app content here</h2>
+				<NcButton @click="opened = !opened">Toggle sidebar</NcButton>
+			</NcAppContent>
+			<NcAppSidebar v-if="opened" title="cat-picture.jpg" @close="opened=false"></AppSidebar>
+		</NcContent>
+	</template>
+	<script>
+	import Check from 'vue-material-design-icons/Check'
+
+	export default {
+		components: {
+			Check,
+		},
+		data() {
+			return {
+				opened: false,
+			}
 		}
 	}
-}
-</script>
+	</script>
 ```
 
 </docs>

--- a/src/components/NcListItemIcon/NcListItemIcon.vue
+++ b/src/components/NcListItemIcon/NcListItemIcon.vue
@@ -30,29 +30,97 @@ It might be used for list rendering or within the multiselect for example
 <NcListItemIcon title="User 1" subtitle="Hidden subtitle because size is too small" :avatar-size="24" />
 ```
 ```vue
-<NcListItemIcon title="User 1" :avatar-size="44" icon="icon-user" />
+	<template>
+		<NcListItemIcon title="User 1" :avatar-size="44">
+			<template>
+				<Account :size="20" />
+			</template>
+		</NcListItemIcon>
+	</template>
+	<script>
+	import Account from 'vue-material-design-icons/Account'
+
+	export default {
+		components: {
+			Account,
+		},
+	}
+	</script>
 ```
 
 ### With icon
 ```vue
-<NcListItemIcon title="Group 1" subtitle="13 members" icon="icon-group" :is-no-user="true" />
+	<template>
+		<NcListItemIcon title="Group 1" subtitle="13 members" :is-no-user="true">
+			<template>
+				<AccountMultiple :size="20" />
+			</template>
+		</NcListItemIcon>
+	</template>
+	<script>
+	import AccountMultiple from 'vue-material-design-icons/AccountMultiple'
+
+	export default {
+		components: {
+			AccountMultiple,
+		},
+	}
+	</script>
 ```
 
 ### Searching
 ```vue
-<NcListItemIcon title="Test user 1" subtitle="callmetest@domain.com" search="test" />
-<NcListItemIcon title="Testing admin" subtitle="testme@example.com" search="test" />
-<NcListItemIcon title="Test group 2" subtitle="loremipsum@domain.com" icon="icon-group" :is-no-user="true" search="test" />
+	<template>
+		<NcListItemIcon title="Test user 1" subtitle="callmetest@domain.com" search="test" />
+		<NcListItemIcon title="Testing admin" subtitle="testme@example.com" search="test" />
+		<NcListItemIcon title="Test group 2" subtitle="loremipsum@domain.com" :is-no-user="true" search="test">
+			<template>
+				<AccountMultiple :size="20" />
+			</template>
+		</NcListItemIcon>
+	</template>
+	<script>
+	import AccountMultiple from 'vue-material-design-icons/AccountMultiple'
+
+	export default {
+		components: {
+			AccountMultiple,
+		},
+	}
+	</script>
 ```
 
 ### With actions
 ```vue
-<NcListItemIcon title="Test user 1" subtitle="callmetest@domain.com">
-	<NcActions>
-		<NcActionButton icon="icon-edit" @click="alert('Edit')">Edit</NcActionButton>
-		<NcActionButton icon="icon-delete" @click="alert('Delete')">Delete</NcActionButton>
-	</NcActions>
-</NcListItemIcon>
+	<template>
+		<NcListItemIcon title="Test user 1" subtitle="callmetest@domain.com">
+			<NcActions>
+				<NcActionButton @click="alert('Edit')">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					Edit
+				</NcActionButton>
+				<NcActionButton @click="alert('Delete')">
+					<template #icon>
+						<Delete :size="20" />
+					</template>
+					Delete
+				</NcActionButton>
+			</NcActions>
+		</NcListItemIcon>
+	</template>
+	<script>
+	import Delete from 'vue-material-design-icons/Delete'
+	import Pencil from 'vue-material-design-icons/Pencil'
+
+	export default {
+		components: {
+			Delete,
+			Pencil,
+		},
+	}
+	</script>
 ```
 </docs>
 


### PR DESCRIPTION
This PR replaces all legacy icon classes in the docs with material design icons. It only affects the docs, not the components itself. See e.g. here:

Before:
![Screenshot 2023-01-06 at 11-46-19 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/210995993-71b1cf91-910e-4535-91a2-49c6123e1112.png)

After:
![Screenshot 2023-01-06 at 11-46-06 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/210996067-0e857825-1df2-474c-81ec-e164be99ce72.png)
