### PR TITLE
Fix invalid svg errors in styleguide

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,6 +105,11 @@ webpackRules.RULE_JS.exclude = BabelLoaderExcludeNodeModulesExcept([
 	'tributejs',
 ])
 
+webpackRules.RULE_RAW_SVG = {
+	resourceQuery: /raw/,
+	type: 'asset/source',
+}
+
 webpackConfig.module.rules = Object.values(webpackRules)
 
 module.exports = async () => {


### PR DESCRIPTION
Add https://github.com/nextcloud/nextcloud-vue/blob/83b054e15af5be35c8709098f485612bd5ae74e5/webpack.config.js#L127-L128 back after https://github.com/nextcloud/nextcloud-vue/pull/3633

| | Screenshot |
--- | ---
**Before** | ![image](https://user-images.githubusercontent.com/24800714/213319190-63df51c4-1b7a-45e4-a70f-e84a29b940ca.png)
**After** | ![image](https://user-images.githubusercontent.com/24800714/213319197-08705278-82c1-4581-8cc8-716d06df04d9.png)