### PR TITLE
Fix keyboard navigation of modal slides

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -612,7 +612,6 @@ export default {
 			case 37: // left arrow
 				this.previous(e)
 				break
-			case 13: // enter key
 			case 39: // right arrow
 				this.next(e)
 				break


### PR DESCRIPTION
We handle keydown events on the global window object
https://github.com/nextcloud/nextcloud-vue/blob/58b5c435979784c5143c1b539e52c9ada826981f/src/components/NcModal/NcModal.vue#L536
and click events on the previous and next arrow buttons
https://github.com/nextcloud/nextcloud-vue/blob/58b5c435979784c5143c1b539e52c9ada826981f/src/components/NcModal/NcModal.vue#L264
https://github.com/nextcloud/nextcloud-vue/blob/58b5c435979784c5143c1b539e52c9ada826981f/src/components/NcModal/NcModal.vue#L296

So when keyboard focus is on the previous or next button and we hit `Enter`, the click handler of either previous or next will fire and the global handler will always call `this.next()`

Focused element | Result
--- | ---
Previous button | Back then forward to the same slide
Next button | Forward two slides