### PR TITLE
fix: Export NcHighlight through default package export

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -66,6 +66,7 @@ export { default as NcEmojiPicker } from './NcEmojiPicker/index.js'
 export { default as NcEmptyContent } from './NcEmptyContent/index.js'
 export { default as NcGuestContent } from './NcGuestContent/index.js'
 export { default as NcHeaderMenu } from './NcHeaderMenu/index.js'
+export { default as NcHighlight } from './NcHighlight/index.js'
 export { default as NcIconSvgWrapper } from './NcIconSvgWrapper/index.js'
 // Not exported on purpose
 // export { default as NcInputField } from './NcInputField/index.js'


### PR DESCRIPTION
Otherwise importing with `import { NcHighlight } from ‘@nextcloud/vue'` fails
