### PR TITLE
Fix: update transition styles for NcButton

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -422,8 +422,9 @@ export default {
 		cursor: pointer;
 	}
 	border-radius: math.div($clickable-area, 2);
-	transition: background-color 0.1s linear !important;
-	transition: border 0.1s linear;
+	transition-property: color, border-color, background-color;
+	transition-duration: 0.1s;
+	transition-timing-function: linear;
 
 	// No outline feedback for focus. Handled with a toggled class in js (see data)
 	&:focus {


### PR DESCRIPTION
Solution to prevent overriding transition styles for NcButton component.

Fix #3689. Please see issue for details.


Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>
