### PR TITLE
fix(ncselect): Fix styling if a custom theme is applied

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -899,8 +899,11 @@ export default {
 </script>
 
 <style lang="scss">
-:root {
-	/* Set custom vue-select CSS variables */
+body {
+	/**
+	 * Set custom vue-select CSS variables.
+	 * Needs to be on the body (not :root) for theming to apply (see nextcloud/server#36462)
+	 */
 
 	/* Search Input */
 	--vs-search-input-color: var(--color-main-text);


### PR DESCRIPTION
We can not set variables referencing themeable variables on the `:root` as currently the theme variables are applied on the `body` element. Meaning `var()` will be evaluated with the context of the `:root` element, which does not apply the user selected theme.
We neither can set this variables on the `select`, because the some of the variables are used to style the dropdown list which is a modal so not a child of the select.

This fixes issues like this:
https://github.com/nextcloud/forms/pull/1471#pullrequestreview-1277505842

See also https://github.com/nextcloud/server/pull/36462