### PR TITLE
Add link picker in RichContentEditable with tribute

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -107,6 +107,9 @@ msgstr ""
 msgid "No emoji found"
 msgstr ""
 
+msgid "No link provider found"
+msgstr ""
+
 msgid "No results"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue-richtext": "^2.1.0-beta.5",
 				"@nextcloud/vue-select": "^3.21.2",
 				"@skjnldsv/sanitize-svg": "^1.0.2",
 				"debounce": "1.2.1",
@@ -3115,6 +3116,80 @@
 			"engines": {
 				"node": "^16.0.0",
 				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.6.1.tgz",
+			"integrity": "sha512-MKYn72BUR73iZWAYROGbT3Uf1ihlVBS/XxAqQOQEs9oqF4ULdCY0EA+xR43OzGpDOQdgWeW5wt9I59kcC3qbzw==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.1.0",
+				"@nextcloud/auth": "^2.0.0",
+				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/browser-storage": "^0.2.0",
+				"@nextcloud/calendar-js": "^5.0.3",
+				"@nextcloud/capabilities": "^1.0.4",
+				"@nextcloud/dialogs": "^4.0.0",
+				"@nextcloud/event-bus": "^3.0.0",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/l10n": "^2.0.1",
+				"@nextcloud/logger": "^2.2.1",
+				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue-select": "^3.21.2",
+				"@skjnldsv/sanitize-svg": "^1.0.2",
+				"debounce": "1.2.1",
+				"emoji-mart-vue-fast": "^12.0.1",
+				"escape-html": "^1.0.3",
+				"floating-vue": "^1.0.0-beta.19",
+				"focus-trap": "^7.1.0",
+				"hammerjs": "^2.0.8",
+				"linkify-string": "^4.0.0",
+				"md5": "^2.3.0",
+				"node-polyfill-webpack-plugin": "^2.0.1",
+				"splitpanes": "^2.4.1",
+				"string-length": "^5.0.1",
+				"striptags": "^3.2.0",
+				"tributejs": "^5.1.3",
+				"v-click-outside": "^3.2.0",
+				"vue": "^2.7.14",
+				"vue-color": "^2.8.1",
+				"vue-material-design-icons": "^5.1.2",
+				"vue-multiselect": "^2.1.6",
+				"vue2-datepicker": "^3.11.0"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue-richtext": {
+			"version": "2.1.0-beta.5",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
+			"integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+			"dependencies": {
+				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/event-bus": "^3.0.2",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue": "^7.5.0",
+				"clone": "^2.1.2",
+				"vue": "^2.7.8",
+				"vue-material-design-icons": "^5.1.2"
+			},
+			"engines": {
+				"node": ">=14.0.0",
+				"npm": ">=7.0.0"
+			},
+			"peerDependencies": {
+				"vue": "^2.7.8"
+			}
+		},
+		"node_modules/@nextcloud/vue-richtext/node_modules/clone": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/@nextcloud/vue-select": {
@@ -28153,6 +28228,68 @@
 				"@types/jquery": "2.0.60"
 			}
 		},
+		"@nextcloud/vue": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.6.1.tgz",
+			"integrity": "sha512-MKYn72BUR73iZWAYROGbT3Uf1ihlVBS/XxAqQOQEs9oqF4ULdCY0EA+xR43OzGpDOQdgWeW5wt9I59kcC3qbzw==",
+			"requires": {
+				"@floating-ui/dom": "^1.1.0",
+				"@nextcloud/auth": "^2.0.0",
+				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/browser-storage": "^0.2.0",
+				"@nextcloud/calendar-js": "^5.0.3",
+				"@nextcloud/capabilities": "^1.0.4",
+				"@nextcloud/dialogs": "^4.0.0",
+				"@nextcloud/event-bus": "^3.0.0",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/l10n": "^2.0.1",
+				"@nextcloud/logger": "^2.2.1",
+				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue-select": "^3.21.2",
+				"@skjnldsv/sanitize-svg": "^1.0.2",
+				"debounce": "1.2.1",
+				"emoji-mart-vue-fast": "^12.0.1",
+				"escape-html": "^1.0.3",
+				"floating-vue": "^1.0.0-beta.19",
+				"focus-trap": "^7.1.0",
+				"hammerjs": "^2.0.8",
+				"linkify-string": "^4.0.0",
+				"md5": "^2.3.0",
+				"node-polyfill-webpack-plugin": "^2.0.1",
+				"splitpanes": "^2.4.1",
+				"string-length": "^5.0.1",
+				"striptags": "^3.2.0",
+				"tributejs": "^5.1.3",
+				"v-click-outside": "^3.2.0",
+				"vue": "^2.7.14",
+				"vue-color": "^2.8.1",
+				"vue-material-design-icons": "^5.1.2",
+				"vue-multiselect": "^2.1.6",
+				"vue2-datepicker": "^3.11.0"
+			}
+		},
+		"@nextcloud/vue-richtext": {
+			"version": "2.1.0-beta.5",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
+			"integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+			"requires": {
+				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/event-bus": "^3.0.2",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue": "^7.5.0",
+				"clone": "^2.1.2",
+				"vue": "^2.7.8",
+				"vue-material-design-icons": "^5.1.2"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+				}
+			}
+		},
 		"@nextcloud/vue-select": {
 			"version": "3.22.2",
 			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.22.2.tgz",
@@ -28163,7 +28300,7 @@
 			"version": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#17ec724240862ce65d32b0522fd949bda1e143ce",
 			"integrity": "sha512-SvgLgQ1NlSnTrv2ArapeCAcQFd2vgwMRgVTD1TtGs8s0veU0lR5QYe/CcJbN2eBavpJxqDaGi183mPeObJTH/Q==",
 			"dev": true,
-			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#17ec724240862ce65d32b0522fd949bda1e143ce",
+			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#master",
 			"requires": {}
 		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@nextcloud/l10n": "^2.0.1",
 		"@nextcloud/logger": "^2.2.1",
 		"@nextcloud/router": "^2.0.0",
+		"@nextcloud/vue-richtext": "^2.1.0-beta.5",
 		"@nextcloud/vue-select": "^3.21.2",
 		"@skjnldsv/sanitize-svg": "^1.0.2",
 		"debounce": "1.2.1",

--- a/src/functions/linkPicker/index.js
+++ b/src/functions/linkPicker/index.js
@@ -1,0 +1,27 @@
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { searchProvider, getLinkWithPicker } from '@nextcloud/vue-richtext'
+
+export const linkProviderSearch = searchProvider
+
+export const getLink = getLinkWithPicker


### PR DESCRIPTION
This integrates the vue-richtext's link picker in RichContentEditable with TributeJS. The trigger is "/". The item list is obtained from a vue-richtext function call.

The workflow:
* type /
* choose a link provider
* this opens a modal which contains either
    * a generic search (using one or multiple unified search providers)
    * a custom picker element
* user does the work which results in getting a link
* the link is inserted in the RCE content

As picking a link is asynchronous, I used a trick to make it work with Tribute:
A dummy invisible element is inserted immediately when opening the link picker (when selecting a tribute dropdown item). Once the picker returns the link (with a promise), the dummy element is replaced by the link.

:warning: For the link picker to get the provider list, the page in which RCE is used must have dispatched `RenderReferenceEvent`. This will be documented in Nextcloud's general link reference chapter. Maybe it's worth mentioning it in RCE's doc as well.

We could make this a little bit more generic (passing data and callback as RCE props) but we figured (with @juliushaertl) the link picker was strongly depending on unified search and vue-richtext and cannot really be used with other data sources anyway. What do you think?


https://user-images.githubusercontent.com/11291457/216076359-5c435ab4-544d-4d31-a33c-a8acf71e08ae.mp4


