### PR TITLE
Fix NcAppNavigationItem hasUtils computed

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -583,13 +583,10 @@ export default {
 		},
 
 		hasUtils() {
-			if (this.editing) {
-				return false
-			} else if (this.$slots.actions || this.$slots.counter || this.editable || this.undo) {
+			if (this.$slots.actions || this.$slots.counter || this.editable || this.undo) {
 				return true
-			} else {
-				return false
 			}
+			return false
 		},
 
 		// This is used to decide which outer element type to use


### PR DESCRIPTION
This fixes an undefined variable bug in the `NcAppNavigationItem` component.
`this.editing` is undefined, but since the function returns `true` in only one case, it worked nevertheless. I took the chance to simplify this conditional a bit as well.