### PR TITLE
Fix setting trailingButtonLabel for PasswordField

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -98,6 +98,7 @@ export default {
 		ref="inputField"
 		:type="isPasswordHidden ? 'password' : 'text'"
 		:show-trailing-button="true"
+		:trailing-button-label="trailingButtonLabelPassword"
 		:helper-text="computedHelperText"
 		:error="computedError"
 		:success="computedSuccess"
@@ -218,7 +219,7 @@ export default {
 			}
 		},
 
-		trailingButtonLabel() {
+		trailingButtonLabelPassword() {
 			return this.isPasswordHidden ? t('Show password') : t('Hide password')
 		},
 	},


### PR DESCRIPTION
This fixes setting the `trailingButtonLabel` (which is the `aria-label` of the trailing button in the `NcInputField` component) from the `NcPasswordField` so that the password toggle button gets the correct label.

This also fixes the `You need to fill either the text or the ariaLabel props in the button component.` warning currently visible in the docs when looking at the `NcPasswordField` component.