### PR TITLE
Fix dashboard padding with half-empty content view

### DIFF
--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -354,6 +354,7 @@ export default {
 	margin-top: 0;
 	padding-top: 5vh;
 	&.half-screen {
+		padding-top: 0;
 		margin-top: 0;
 		margin-bottom: 1vh;
 	}


### PR DESCRIPTION
Fix https://github.com/nextcloud/spreed/issues/8611

25 | 26 Before | 26 After
---|---|---
![Bildschirmfoto vom 2023-02-02 07-34-58](https://user-images.githubusercontent.com/213943/216250355-58d277f3-36ae-4247-9c8d-4e8f7da52051.png) | ![Bildschirmfoto vom 2023-02-02 07-35-13](https://user-images.githubusercontent.com/213943/216250353-f2bc9bc8-1b66-4933-8618-dd703cf6f2ab.png) | ![grafik](https://user-images.githubusercontent.com/213943/216250585-96944e52-c4e0-4dfd-99a8-85df99032454.png)

