### PR TITLE
Add aria-labels to example buttons in docs

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -8,6 +8,7 @@
 					<template #icon>
 						<Plus :size="20" />
 					</template>
+					This is an action
 				</NcActionButton>
 			</template>
 		</NcAppNavigationCaption>

--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -30,27 +30,27 @@ Render raw SVG string icons.
 ```vue
 <template>
 	<div class="grid">
-		<NcButton>
+		<NcButton aria-label="Close">
 			<template #icon>
 				<NcIconSvgWrapper :svg="closeSvg" title="Close" />
 			</template>
 		</NcButton>
-		<NcButton>
+		<NcButton aria-label="Settings">
 			<template #icon>
 				<NcIconSvgWrapper :svg="cogSvg" title="Cog" />
 			</template>
 		</NcButton>
-		<NcButton>
+		<NcButton aria-label="Add">
 			<template #icon>
 				<NcIconSvgWrapper :svg="plusSvg" title="Plus" />
 			</template>
 		</NcButton>
-		<NcButton>
+		<NcButton aria-label="Send">
 			<template #icon>
 				<NcIconSvgWrapper :svg="sendSvg" title="Send" />
 			</template>
 		</NcButton>
-		<NcButton>
+		<NcButton aria-label="Star">
 			<template #icon>
 				<NcIconSvgWrapper :svg="starSvg" title="Star" />
 			</template>


### PR DESCRIPTION
This fixes a warning `You need to fill either the text or the ariaLabel props in the button component` triggered in the docs because the `NcActionButton` component has no title. Just cleanup of the docs, no effect on the component itself.

Edit: I added a commit fixing the same warning for buttons used in the `NcIconSvgWrapper` docs.