### PR TITLE
Use proper default actions aria label in `NcListItem`

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -11,6 +11,9 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
+msgid "Actions for item with title \"{title}\""
+msgstr ""
+
 msgid "Activities"
 msgstr ""
 

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -268,7 +268,7 @@
 						@click.prevent.stop="">
 						<NcActions ref="actions"
 							menu-align="right"
-							:aria-label="actionsAriaLabel"
+							:aria-label="computedActionsAriaLabel"
 							@update:open="handleActionsUpdateOpen">
 							<!-- @slot Provide the actions for the right side quick menu -->
 							<slot name="actions" />
@@ -281,7 +281,7 @@
 					@click.prevent.stop="">
 					<NcActions ref="actions"
 						menu-align="right"
-						:aria-label="actionsAriaLabel"
+						:aria-label="computedActionsAriaLabel"
 						@update:open="handleActionsUpdateOpen">
 						<!-- @slot Provide the actions for the right side quick menu -->
 						<slot name="actions" />
@@ -300,6 +300,7 @@
 <script>
 import NcActions from '../NcActions/index.js'
 import NcCounterBubble from '../NcCounterBubble/index.js'
+import { t } from '../../l10n.js'
 
 export default {
 	name: 'NcListItem',
@@ -475,6 +476,10 @@ export default {
 		showDetails() {
 			return this.hasDetails && (!this.displayActionsOnHoverFocus || this.forceDisplayActions)
 		},
+
+		computedActionsAriaLabel() {
+			return this.actionsAriaLabel || t('Actions for item with title "{title}"', { title: this.title })
+		}
 
 	},
 


### PR DESCRIPTION
We currently overwrite the `aria-label` of the `NcActions` component used in the `NcListItem` component with an empty string, which leads to a `You need to fill either the text or the ariaLabel props in the button component.` triggered by `NcListItem` by default. This PR sets the default aria-label in `NcListItem` to the same value as used in `NcActions`.