### PR TITLE
No background for `tertiary-no-background` `NcActions`

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1169,6 +1169,10 @@ export default {
 		--open-background-color: var(--color-success-hover);
 	}
 
+	&.action-item--tertiary-no-background {
+		--open-background-color: transparent;
+	}
+
 	&.action-item--open .action-item__menutoggle {
 		opacity: $opacity_full;
 		background-color: var(--open-background-color);


### PR DESCRIPTION
This removes the background for open `NcActions` of type `tertiary-no-background`.

Closes #3720.

| Type | Before | After |
|-|-|-|
| `tertiary` | ![Screenshot 2023-02-06 at 10-09-44 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/216931135-95766b49-b247-4fb3-bb5d-489d589c0669.png) | ![Screenshot 2023-02-06 at 10-06-51 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/216930781-f7aca7fd-bc9f-4aa4-a3ba-a2e0808389a9.png) |
| `tertiary-no-background` | ![Screenshot 2023-02-06 at 10-10-43 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/216931280-a49c2c45-551c-4ad0-8770-06e2102d00a8.png) | ![Screenshot 2023-02-06 at 10-07-20 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/216930830-825d6c25-86ba-423c-b3f9-b49ad63f35dd.png) |
