### PR TITLE
Fix `NcButton` cursor style

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -418,7 +418,8 @@ export default {
 
 	// Cursor pointer on element and all children
 	cursor: pointer;
-	& * {
+	& *,
+	span {
 		cursor: pointer;
 	}
 	border-radius: math.div($clickable-area, 2);


### PR DESCRIPTION
Nextcloud server has a CSS rule `span { cursor: default; }` that would sometimes (depending on the order in which the bundle is loaded) overwrite the button cursor style. This should make it more explicit so it takes precedence over the server style.