### PR TITLE
Fix hidden select

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -942,6 +942,7 @@ export default {
 	/* Dropdown */
 	--vs-dropdown-bg: var(--color-main-background);
 	--vs-dropdown-color: var(--color-main-text);
+	--vs-dropdown-z-index: 9999;
 	--vs-dropdown-box-shadow: 0px 2px 2px 0px var(--color-box-shadow);
 
 	/* Options */


### PR DESCRIPTION
Explicitly set the `z-index` to ensure the select is visible in instances where the container would otherwise overlap it i.e.
https://github.com/nextcloud/nextcloud-vue/blob/f2d3d9994e4cc6fba8a5026aaedd35cc15834b03/src/components/NcModal/NcModal.vue#L710

https://github.com/nextcloud/server/blob/b765a227052300ac76daaecaf37f8e48e77dedec/apps/files/src/views/Sidebar.vue#L523