### PR TITLE
Fix throw when header menu contains no tabbable nodes

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -69,7 +69,8 @@ export default {
 		:class="{ 'header-menu--opened': opened }"
 		class="header-menu">
 		<!-- Open trigger icon -->
-		<a class="header-menu__trigger"
+		<a ref="trigger"
+			class="header-menu__trigger"
 			href="#"
 			:aria-label="ariaLabel"
 			:aria-controls="`header-menu-${id}`"
@@ -254,6 +255,7 @@ export default {
 			this.focusTrap = createFocusTrap(contentContainer, {
 				allowOutsideClick: true,
 				trapStack: getTrapStack(),
+				fallbackFocus: this.$refs.trigger,
 			})
 			this.focusTrap.activate()
 		},


### PR DESCRIPTION
Fix focus trap error throw "Your focus-trap must have at least one container with at least one tabbable node in it at all times" with `fallbackFocus` option documented in https://github.com/focus-trap/focus-trap#createoptions

This occurs e.g. when opening the notifications menu when there are no notifications
![image](https://user-images.githubusercontent.com/24800714/217402489-2aa6625c-d433-4de1-88ec-b5e407b614bf.png)