### PR TITLE
Add missing space in NcMultiselect ternary expression

### DIFF
--- a/src/components/NcMultiselect/NcMultiselect.vue
+++ b/src/components/NcMultiselect/NcMultiselect.vue
@@ -178,7 +178,7 @@ export default {
 		v-model="localValue"
 		v-bind="$attrs"
 		:class="[
-			multiple ? 'multiselect--multiple': 'multiselect--single'
+			multiple ? 'multiselect--multiple' : 'multiselect--single'
 		]"
 		:options="options"
 		:limit="maxOptions"


### PR DESCRIPTION
This adds a missing space in the ternary expression which messed up the syntax highlighting in my editor.