### PR TITLE
Remove last usage of ´--color-primary-element-lighter`

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -412,8 +412,8 @@ export default {
 	}
 
 	// Default button type
-	background-color: var(--color-primary-element-lighter), var(--color-primary-element-light);
 	color: var(--color-primary-light-text);
+	background-color: var(--color-primary-light);
 	&:hover:not(:disabled) {
 		background-color: var(--color-primary-light-hover);
 	}
@@ -421,7 +421,7 @@ export default {
 	// Back to the default color for this button when active
 	// TODO: add ripple effect
 	&:active {
-		background-color: var(--color-primary-element-lighter), var(--color-primary-element-light);
+		background-color: var(--color-primary-element-light);
 	}
 
 	&__wrapper {

--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -87,8 +87,7 @@ export default {
 	line-height: 1em;
 	padding: 4px 6px;
 	border-radius: var(--border-radius-pill);
-	// since -lighter is not present in the new version it will only apply to the old one and -light for the newer
-	background-color: var(--color-primary-element-lighter, var(--color-primary-element-light));
+	background-color: var(--color-primary-element-light);
 	font-weight: bold;
 	color: var(--color-primary-element);
 


### PR DESCRIPTION
* Resolves: #3276 

For the button:
The styling already falls back to `secondary` so we can simply use the same colors.