### PR TITLE
Fix tag search

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -669,7 +669,8 @@ export default {
 		/**
 		 * Key of the displayed label for object options
 		 *
-		 * Defaults to `'label'`
+		 * Defaults to the internal vue-select string documented at the link
+		 * below
 		 *
 		 * Enabling `userSelect` will automatically set this to `'displayName'`
 		 * unless this prop is set explicitly
@@ -855,7 +856,6 @@ export default {
 			if (this.filterBy !== null) {
 				return this.filterBy
 			}
-
 			if (this.userSelect) {
 				return (option, label, search) => {
 					return (`${label} ${option.subtitle}` || '')
@@ -863,27 +863,22 @@ export default {
 						.indexOf(search.toLocaleLowerCase()) > -1
 				}
 			}
-			return null
+			return VueSelect.props.filterBy.default
 		},
 
 		localLabel() {
 			if (this.label !== null) {
 				return this.label
 			}
-
 			if (this.userSelect) {
 				return 'displayName'
 			}
-			return 'label'
+			return VueSelect.props.label.default
 		},
 
 		propsToForward() {
 			const {
-				// Custom overrides of vue-select props
-				calculatePosition,
-				filterBy,
-				label,
-				// Props handled by the component itself
+				// Props handled by this component
 				noWrap,
 				placement,
 				userSelect,
@@ -893,12 +888,10 @@ export default {
 
 			const propsToForward = {
 				...initialPropsToForward,
+				// Custom overrides of vue-select props
 				calculatePosition: this.localCalculatePosition,
+				filterBy: this.localFilterBy,
 				label: this.localLabel,
-			}
-
-			if (this.localFilterBy) {
-				propsToForward.filterBy = this.localFilterBy
 			}
 
 			return propsToForward

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -619,6 +619,14 @@ export default {
 		},
 
 		/**
+		 * Sets the maximum number of options to display in the dropdown list
+		 */
+		limit: {
+			type: Number,
+			default: null,
+		},
+
+		/**
 		 * Disable the component
 		 *
 		 * @see https://vue-select.org/api/props.html#disabled

--- a/src/components/NcSelectTags/NcSelectTags.vue
+++ b/src/components/NcSelectTags/NcSelectTags.vue
@@ -67,11 +67,11 @@ export default {
 ```
 
 ### Custom filter
-Because of compatibility reasons only 5 tag entries are shown by default. If you want to show all available tags set the `optionsFilter` function-prop to `null`:
+Because of compatibility reasons only 5 tag entries are shown by default. If you want to show all available tags set the `limit` prop to `null`:
 ```vue
 <template>
 	<div class="wrapper">
-		<NcSelectTags v-model="value" :options-filter="null" />
+		<NcSelectTags v-model="value" :limit="null" />
 		{{ value }}
 	</div>
 </template>
@@ -193,6 +193,17 @@ export default {
 		},
 
 		/**
+		 * Sets the maximum number of tags to display in the dropdown list
+		 *
+		 * Because of compatibility reasons only 5 tag entries are shown by
+		 * default
+		 */
+		limit: {
+			type: Number,
+			default: 5,
+		},
+
+		/**
 		 * Allow selection of multiple options
 		 *
 		 * This prop automatically sets the internal `closeOnSelect` prop to
@@ -210,7 +221,7 @@ export default {
 		 */
 		optionsFilter: {
 			type: Function,
-			default: (_element, index) => index < 5,
+			default: null,
 		},
 
 		/**
@@ -280,7 +291,7 @@ export default {
 
 		propsToForward() {
 			const {
-				// Props handled by the component itself
+				// Props handled by this component
 				optionsFilter,
 				// Props to forward
 				...propsToForward


### PR DESCRIPTION
Fix https://github.com/nextcloud/nextcloud-vue/issues/3662 and make minor updates to `vue-select` prop handling

The `limit` prop is now used instead of `optionsFilter` to limit the available tags

Previously only 5 tags were being passed as options to `VueSelect`, since `VueSelect` handles searching internally any tag after the 5th one could not be searched for

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/24800714/218602047-1f1572ee-f946-4bc1-8638-03c2aeb05da4.png) | ![image](https://user-images.githubusercontent.com/24800714/218602061-c00b01e5-340e-4487-8087-a954f24a7a3a.png)