### PR TITLE
Remove outdated and unused menu-align attributes

### DIFF
--- a/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
+++ b/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
@@ -56,7 +56,7 @@ This component is meant to be used inside a DashboardWidget component.
 					{{ subText }}
 				</p>
 			</div>
-			<NcActions v-if="gotMenu" :force-menu="forceMenu" menu-align="right">
+			<NcActions v-if="gotMenu" :force-menu="forceMenu">
 				<!-- @slot This slot can be used to provide actions for each dashboard widget item. -->
 				<slot name="actions">
 					<NcActionButton v-for="(m, menuItemId) in itemMenu"

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -267,7 +267,6 @@
 						class="list-item-content__actions"
 						@click.prevent.stop="">
 						<NcActions ref="actions"
-							menu-align="right"
 							:aria-label="computedActionsAriaLabel"
 							@update:open="handleActionsUpdateOpen">
 							<!-- @slot Provide the actions for the right side quick menu -->
@@ -280,7 +279,6 @@
 					class="list-item-content__actions"
 					@click.prevent.stop="">
 					<NcActions ref="actions"
-						menu-align="right"
 						:aria-label="computedActionsAriaLabel"
 						@update:open="handleActionsUpdateOpen">
 						<!-- @slot Provide the actions for the right side quick menu -->


### PR DESCRIPTION
This removes the outdated `menu-align` prop that has no effect anymore. The menus are automatically positioned since a while already, since the prop simply was ignored. I think it works very well that way.

Supersedes #2847.