### PR TITLE
fix: Add a webpackrule to resolve module js files in `node_modules`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,6 +110,15 @@ webpackRules.RULE_RAW_SVG = {
 	type: 'asset/source',
 }
 
+webpackRules.RULE_NODE_MJS = {
+	test: /\.m?js$/,
+	include: /node_modules/,
+	type: 'javascript/auto',
+	resolve: {
+		fullySpecified: false
+	}
+}
+
 webpackConfig.module.rules = Object.values(webpackRules)
 
 module.exports = async () => {


### PR DESCRIPTION
* Resolves: #3753 

This should probably go into the webpack config project, but until it is fixed there, we should fix it here.

Somewhere in a module js (ESM) file, probably by webpack-node-polyfills, `process/browser` without the required `.js` extension is imported. We do not use babel-loader on the node_modules and the default loader defaults to `resolveFullySpecified = true`, so this causes an issue. See also https://webpack.js.org/configuration/module/#resolvefullyspecified