### PR TITLE
fix: High contrast mode optimization

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -185,6 +185,13 @@ export default {
 	}
 }
 
+// add extra border for high contrast mode
+[data-themes*="highcontrast"] {
+	.app-navigation {
+		border-right: 1px solid var(--color-border);
+	}
+}
+
 // When on mobile, we make the navigation slide over the appcontent
 @media only screen and (max-width: $breakpoint-mobile) {
 	.app-navigation:not(.app-navigation--close) {

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -950,4 +950,12 @@ export default {
 	}
 }
 
+// Add more contrast for active entry
+[data-themes*="highcontrast"] {
+	.app-navigation-entry {
+		&:active {
+			background-color: var(--color-primary-light-hover) !important;
+		}
+	}
+}
 </style>

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -661,6 +661,19 @@ export default {
 	}
 }
 
+// Add more contrast for active entry
+[data-themes*="highcontrast"] {
+	.list-item__wrapper {
+		&--active,
+		&:active,
+		&.active {
+			.list-item {
+				background-color: var(--color-primary-light-hover);
+			}
+		}
+	}
+}
+
 .line-one {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
* Resolved: #3351 

Add the missing right border on the app navigation (high contrast mode). Unify design with settings view where the app navigation has a border on the right on high contrast mode.

Changed the background color of the active element on high contrast mode, as the highlighting was barley visible.

Also applied the styles for the NcListItem to have a common styling across apps, as some apps, like the forms app, use list items instead of app navigation items (to allow a second title within the item).

Normal | High-contrast before | High-contrast now|
---|--- | ---
![Screenshot_20230215_025927](https://user-images.githubusercontent.com/1855448/218909097-de61b982-8e2c-4865-a9a5-1f9a9130e560.png)|![Screenshot_20230215_030016](https://user-images.githubusercontent.com/1855448/218909131-55cbea52-7d0c-4410-a9fc-b45ef6b15d5c.png)|![Screenshot_20230215_031029](https://user-images.githubusercontent.com/1855448/218909540-43a1c400-817b-479e-bdd5-48bf4018a029.png)


