### PR TITLE
RichContent autocomplete not required

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -176,8 +176,9 @@ export default {
 
 		autoComplete: {
 			type: Function,
-			required: true,
+			default: () => [],
 		},
+
 		menuContainer: {
 			type: Element,
 			default: () => document.body,


### PR DESCRIPTION
Since we don't need autocompletion on forms, we would just pass an empty function (as talk does btw., too :wink:). So why not doing this here. 