### PR TITLE
`NcSelect`: Selected options should not overflow the container

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1007,6 +1007,36 @@ body {
 			}
 		}
 	}
+
+	// Hide search from dom if unused to prevent unneeded flex wrap
+	.vs__search[readonly] {
+		position: absolute;
+	}
+	// If search if hidden, ensure that the height of the search is the same
+	.vs__selected-options {
+		min-height: 40px; // 36px search height + 4px search margin
+	}
+
+	/**
+	 * Fix overlow of selected options
+	 * There is an upstream pull request, if it is merged and released remove this fix
+	 * https://github.com/sagalbot/vue-select/pull/1756
+	 */
+	.vs__selected-options {
+		min-width: 0;
+		.vs__selected {
+			min-width: 0;
+		}
+	}
+	&.vs--single {
+		&.vs--loading,
+		&.vs--open {
+			.vs__selected {
+				// Fix `max-width` for `position: absolute`
+				max-width: 100%;
+			}
+		}
+	}
 }
 
 .vs__dropdown-menu {


### PR DESCRIPTION
If the selected option is longer than the element it should not overflow the NcSelect but use ellipsis.

before | with `min-width: 0` | with hidden disabled search
---|---|---
![before](https://user-images.githubusercontent.com/1855448/219114982-eb4b2908-6928-44cf-bf53-f93e81d7f7e7.png)|![after](https://user-images.githubusercontent.com/1855448/219115009-1f9f168a-730a-48a6-b01a-a69f7f73b2ed.png)|![after-2](https://user-images.githubusercontent.com/1855448/219115020-f39775fc-a159-4dc8-9d58-0dcf454a4902.png)

As you can see currently the option overflows the select, note the actions (dropdown toggle) are missing because they are placed outside the select underneath other elements on the right.

After fixing the overflow there is still this weird height issues, which happens because `.vs__selected-options` have `flex-wrap` set and contain the search input even if it is disabled (`searchable=false`).
This can be fixed by removing the search input from the visible dom when not used.

I already submitted a upstream PR, but I doubt that it will be merged soon.