### PR TITLE
Use `NcSelect` for `NcActionInput` type multiselect

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -115,12 +115,14 @@ For the multiselect component, all events will be passed through. Please see the
 			}"
 			class="action-input"
 			@mouseleave="onLeave">
-			<!-- @slot Manually provide icon -->
-			<slot name="icon">
-				<span :class="[isIconUrl ? 'action-input__icon--url' : icon]"
-					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-					class="action-input__icon" />
-			</slot>
+			<span class="action-input__icon-wrapper">
+				<!-- @slot Manually provide icon -->
+				<slot name="icon">
+					<span :class="[isIconUrl ? 'action-input__icon--url' : icon]"
+						:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
+						class="action-input__icon" />
+				</slot>
+			</span>
 
 			<!-- form and input -->
 			<form ref="form"
@@ -149,10 +151,11 @@ For the multiselect component, all events will be passed through. Please see the
 					@input="$emit('input', $event)"
 					@change="$emit('change', $event)" />
 
-				<NcMultiselect v-else-if="isMultiselectType"
+				<NcSelect v-else-if="isMultiselectType"
 					:value="value"
 					:placeholder="text"
 					:disabled="disabled"
+					:append-to-body="false"
 					:class="{ focusable: isFocusable }"
 					class="action-input__multi"
 					v-bind="$attrs"
@@ -194,7 +197,7 @@ For the multiselect component, all events will be passed through. Please see the
 
 <script>
 import NcDatetimePicker from '../NcDatetimePicker/index.js'
-import NcMultiselect from '../NcMultiselect/index.js'
+import NcSelect from '../NcSelect/index.js'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 
@@ -207,7 +210,7 @@ export default {
 	components: {
 		ArrowRight,
 		NcDatetimePicker,
-		NcMultiselect,
+		NcSelect,
 		NcDateTimePickerNative,
 	},
 
@@ -435,13 +438,20 @@ $input-margin: 4px;
 
 	font-weight: normal;
 
-	&:deep(.material-design-icon) {
-		width: $clickable-area;
-		height: $clickable-area;
-		opacity: $opacity_full;
+	&__icon-wrapper {
+		display: flex;
+		align-self: center;
+		align-items: center;
+		justify-content: center;
 
-		.material-design-icon__svg {
-			vertical-align: middle;
+		&:deep(.material-design-icon) {
+			width: $clickable-area;
+			height: $clickable-area;
+			opacity: $opacity_full;
+
+			.material-design-icon__svg {
+				vertical-align: middle;
+			}
 		}
 	}
 

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -80,6 +80,18 @@ For the multiselect component, all events will be passed through. Please see the
 				</template>
 				Please pick a fruit
 			</NcActionInput>
+			<NcActionInput
+				v-model="multiSelected"
+				type="multiselect"
+				label="label"
+				track-by="id"
+				:multiple="true"
+				:options="[{label:'Apple', id: 'apple'}, {label:'Banana', id: 'banana'}, {label:'Cherry', id: 'cherry'}]">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+				Please pick a fruit object
+			</NcActionInput>
 		</NcActions>
 	</template>
 	<script>
@@ -99,6 +111,7 @@ For the multiselect component, all events will be passed through. Please see the
 			return {
 				color: '#0082C9',
 				text: 'This is the input text',
+				multiSelected: [],
 			}
 		},
 	}


### PR DESCRIPTION
This replaces the deprecated `NcMultiselect` with the new `NcSelect` component for the `NcActionInput` component of type multiselect.

~Although it got better (the dropdown wasn't visible at all before),~ Like before, there currently still is a `z-index` issue for the select dropdown. This is because the `NcActions` component has a `z-index: 100000` and the select dropdown only got `9999`. Fixing this is tricky at the moment, because the dropdown gets appended to body without a custom class that could be targeted, which means we can only set the `z-index` for all select dropdowns globally, which I don't know whether we want this. The proper solution would be to enhance `NcSelect` to allow to set a custom dropdown class, but that needs an upstream fix.

| | Before | After |
|-|-|-|
| select closed | ![Screenshot 2023-02-15 at 21-48-03 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/219155872-4362bd38-2c6e-43e9-afb2-1dcac74865b1.png) | ![Screenshot 2023-02-15 at 21-47-11 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/219156159-a126578d-dcb5-41a3-b751-3ec1516be53d.png) |
| select open | ![image](https://user-images.githubusercontent.com/2496460/219155561-7a802250-7181-4c7d-a918-31faea5d1a0f.png) | ![Screenshot 2023-02-15 at 22-17-25 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/219168144-0bdd64fd-ecb0-4c3f-a4b2-903e1ee04f4d.png) |

I propose we go ahead despite the z-index issue, since it is already better than before.

Fixes 1/3 of #3743.