### PR TITLE
NcPopover: Fix `setReturnFocus` property

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -126,10 +126,11 @@ export default {
 		/**
 		 * Set element to return focus to after focus trap deactivation
 		 *
-		 * @type {import('focus-trap').Options['setReturnFocus']}
+		 * @type {import('focus-trap').FocusTargetValueOrFalse}
 		 */
 		setReturnFocus: {
-			required: false,
+			default: undefined,
+			type: [Object, String, Function, Boolean],
 		},
 	},
 


### PR DESCRIPTION
Fixed the wrong JSDoc comment :

> Syntax error in type: import('focus-trap').Options['setReturnFocus'] eslint [jsdoc/valid-types](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-valid-types)

Also added a default value to make eslint happy (even if undefined) and added the missing type information:

> Prop 'setReturnFocus' requires default value to be set. eslint: [vue/require-default-prop](https://eslint.vuejs.org/rules/require-default-prop.html)
> Prop "setReturnFocus" should define at least its type. eslint: [vue/require-prop-types](https://eslint.vuejs.org/rules/require-prop-types.html)