### PR TITLE
Allow using v-show for `NcModal`

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -26,12 +26,13 @@
 	<div>
 		<NcButton @click="showModal">Show Modal</NcButton>
 		<NcModal
-			v-if="modal"
+			v-show="modal"
 			@close="closeModal"
 			size="small"
 			title="Title"
 			:outTransition="true"
 			:hasNext="true"
+			:show.sync="modal"
 			:hasPrevious="true">
 			<div class="modal__content">Hello world</div>
 		</NcModal>
@@ -464,12 +465,22 @@ export default {
 			type: Number,
 			default: 0,
 		},
+
+		/**
+		 * Whether the modal is to be shown.
+		 * Needs to be provided if NcModal is toggled with v-show.
+		 */
+		show: {
+			type: Boolean,
+			default: undefined,
+		},
 	},
 
 	emits: [
 		'previous',
 		'next',
 		'close',
+		'update:show',
 	],
 
 	data() {
@@ -530,6 +541,15 @@ export default {
 				this.focusTrap.updateContainerElements([contentContainer, ...elements])
 			}
 		},
+
+		/**
+		 * Watch the external show prop to update the internal showModal value
+		 *
+		 * @param {boolean} show whether the modal should be shown
+		 */
+		show(show) {
+			this.showModal = show
+		},
 	},
 
 	beforeMount() {
@@ -541,7 +561,11 @@ export default {
 		this.mc.destroy()
 	},
 	mounted() {
-		this.showModal = true
+		// Don't show the modal if the external show prop is exactly false.
+		if (this.show !== false) {
+			this.showModal = true
+			this.$emit('update:show', true)
+		}
 
 		// init clear view
 		this.useFocusTrap()
@@ -595,6 +619,7 @@ export default {
 			// do not fire event if forbidden
 			if (this.canClose) {
 				this.showModal = false
+				this.$emit('update:show', false)
 
 				// delay closing for animation
 				setTimeout(() => {


### PR DESCRIPTION
This is an alternative approach to #3762 to fix #497. It is a bit more effort compared to #3762 because we need an additional prop and kind of duplicate the internal `showModal` state with the `show` prop to keep it non-breaking, but it feels more like vue to me.

For the next major version we could make the `show` prop required and get rid of the watcher and the internal `showModal` value, which would simplify it a lot.