### PR TITLE
Don't regard 1024px width viewport as mobile

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -381,7 +381,7 @@ export default {
 			position: sticky;
 			top: var(--header-height);
 
-			@media only screen and (max-width: $breakpoint-mobile) {
+			@media only screen and (width < $breakpoint-mobile) {
 				display: none;
 			}
 		}
@@ -389,7 +389,7 @@ export default {
 		&-details {
 			overflow-y: auto;
 
-			@media only screen and (max-width: $breakpoint-mobile) {
+			@media only screen and (width < $breakpoint-mobile) {
 				min-width: 100%;
 			}
 		}


### PR DESCRIPTION
* In IsMobileState.js we treat viewports smaller 1024px as mobile.
* In NcAppContent.vue we treat viewports starting with 1024px as mobile.

This results in weird behaviour with screens that have exactly 1024px width. E.g., on three-pane apps, NcAppContentList is hidden but the NcAppDetailsToggle button is not displayed yet.

This commit changes NcAppContent.vue to treat viewports smaller 1024px as mobile, to be in sync with IsMobileState.js.

This PR accompanies https://github.com/nextcloud/server/pull/36751.
    
Both are required to fix https://github.com/nextcloud/nextcloud-vue/issues/3758.

Fixes: #3758