### PR TITLE
Allow using v-show for `NcModal`, fix modal-wrapper transition

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -90,14 +90,7 @@ export default {
 	</div>
 </template>
 <script>
-import NcButton from '../NcButton/index.js'
-import NcTextField from '../NcTextField/index.js'
-
 export default {
-	components: {
-		NcButton,
-		NcTextField,
-	},
 	data() {
 		return {
 			modal: false,


### PR DESCRIPTION
This PR allows to toggle the modal visibility by setting the `show` prop of the modal, which will keep the modal in the DOM.
It also fixes the transition animation of the modal-wrapper when showing/hiding the modal with `v-if`.
Checkout the docs https://deploy-preview-3769--nextcloud-vue-components.netlify.app/#/Components/NcModal and enjoy a smooth modal wrapper animation 😉 

@susnux I think this is the best version of the solution now, as it allows to use `v-show / :show.sync="modal"` or `v-if`, fixes the transition animations for both and requires no watcher.

Fixes #497.