### PR TITLE
Fix nativeOn is only valid on components error, make rootElement computed

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -289,7 +289,7 @@ export default {
 		},
 	},
 
-	methods: {
+	computed: {
 		// Determines whether the root element is an a,
 		// a router-link or a button
 		rootElement() {
@@ -326,7 +326,7 @@ export default {
 			this)
 		}
 
-		return h(this.rootElement(),
+		return h(this.rootElement,
 			{
 				class: [
 					'button-vue',
@@ -354,7 +354,7 @@ export default {
 					...this.$listeners,
 				},
 				// nativeOn is only valid on components
-				...(this.rootElement() === 'router-link' && {
+				...(this.rootElement === 'router-link' && {
 					nativeOn: {
 						...this.$listeners,
 					},

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -353,9 +353,12 @@ export default {
 				on: {
 					...this.$listeners,
 				},
-				nativeOn: {
-					...this.$listeners,
-				},
+				// nativeOn is only valid on components
+				...(this.rootElement() === 'router-link' && {
+					nativeOn: {
+						...this.$listeners,
+					},
+				}),
 			},
 			[
 				h('span', { class: 'button-vue__wrapper' }, [


### PR DESCRIPTION
This fixes the warning
```
[Vue warn]: The .native modifier for v-on is only valid on components but it was used on <button>.
```
which is triggered for `NcButton` currently. This is a problem due to #3726.