### PR TITLE
Adjust emits option

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -143,7 +143,9 @@ export default {
 
 	emits: [
 		'close',
+		'closed',
 		'open',
+		'opened',
 		'update:open',
 		'cancel',
 	],

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -427,7 +427,10 @@ export default {
 		},
 	},
 
-	emits: ['click'],
+	emits: [
+		'click',
+		'update:menuOpen',
+	],
 
 	data() {
 		return {


### PR DESCRIPTION
No effect for vue2, required for vue3. Makes the migration in #3692 a tiny bit shorter.