### PR TITLE
Fix NcButton router-link

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -348,6 +348,7 @@ export default {
 				},
 				props: {
 					to: this.to ? this.to : null,
+					tag: this.to ? 'button' : null,
 					exact: this.exact,
 				},
 				on: {


### PR DESCRIPTION
Seems with #3726 I broke the `NcButton` component of type `router-link`.
This PR brings back the correct `button` tag. `NcButton` will need a migration to the `router-link` slot later on, as the `tag` prop is decprecated.