### PR TITLE
Use `NcSelect` for `NcTimezonePicker`

### DIFF
--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -112,6 +112,7 @@ export default {
 				timezonesGrouped.push({
 					label: group.continent,
 					timezoneId: `tz-group__${group.continent}`,
+					regions: group.regions,
 				})
 				timezonesGrouped = timezonesGrouped.concat(group.regions)
 			})
@@ -151,11 +152,23 @@ export default {
 		 * @return {boolean}
 		 */
 		filterBy(option, label, search) {
-			// We split the search term in case one searches "continent region".
+			// We split the search term in case one searches "<continent> <region>".
 			const terms = search.trim().split(' ')
-			// Every search term must be found.
-			return terms.every(term => option.timezoneId.toLowerCase().includes(term.toLowerCase()))
+
+			// For the continent labels, we have to check if one region matches every search term.
+			if (option.timezoneId.startsWith('tz-group__')) {
+				return option.regions.some(region => {
+					return this.matchTimezoneId(region.timezoneId, terms)
+				})
+			}
+
+			// For a region, every search term must be found.
+			return this.matchTimezoneId(option.timezoneId, terms)
 		},
+
+		matchTimezoneId(timezoneId, terms) {
+			return terms.every(term => timezoneId.toLowerCase().includes(term.toLowerCase()))
+		}
 	},
 }
 </script>


### PR DESCRIPTION
This PR moves `NcTimezonePicker` from using `NcMultiselect` to `NcSelect`. Since `NcSelect` does not support grouping, I had to work around this a bit, but the outcome is the same as when using `NcMultiselect`. I additionally enhanced the search function a bit, so one can now also search for the continent name and see all timezones e.g. in Europe, and searching for "Europe London", will give the correct timezone.

The styling probably needs a bit of adjustment still, because it currently uses the default `NcSelect` style with a gray/blue border, whereas the current timezone picker has no border. But maybe we want to update the style here and match with the other pickers, so I left it for now.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2496460/219797388-f8e84b5f-21b9-4051-aa06-2275c9251f46.png) | ![image](https://user-images.githubusercontent.com/2496460/219797486-75737bbb-f74a-4a96-b843-421c37fbf251.png) |

Fixes 1/3 of #3743.