### PR TITLE
Fix hover for ActionInput datepicker native

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -116,6 +116,7 @@ For the multiselect component, all events will be passed through. Please see the
 					:id="idNativeDateTimePicker"
 					:value="value"
 					:type="nativeDatePickerType"
+					:class="{ focusable: isFocusable }"
 					v-bind="$attrs"
 					@input="$emit('input', $event)"
 					@change="$emit('change', $event)" />


### PR DESCRIPTION
Working on #3785 I noticed that the `NcActionInput` native datepicker has no background-color effect on hover. This PR fixes this.

| Before | After |
|-|-|
| ![Bildschirmaufzeichnung vom 2023-02-19, 13-26-42](https://user-images.githubusercontent.com/2496460/219947963-d87b30ba-8af2-4238-ab68-de653422ed1b.gif) | ![Bildschirmaufzeichnung vom 2023-02-19, 13-30-20](https://user-images.githubusercontent.com/2496460/219948037-34770d2e-4ffc-4d74-b83d-23f8b4fd8400.gif) |