### PR TITLE
Fix clipped background color for NcDatetimePicker

### DIFF
--- a/src/components/NcDatetimePicker/NcDatetimePicker.vue
+++ b/src/components/NcDatetimePicker/NcDatetimePicker.vue
@@ -382,6 +382,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.mx-datepicker :deep(.mx-input-wrapper .mx-input) {
+	background-clip: border-box;
+}
+
 .datetime-picker-inline-icon {
 	opacity: .3;
 	border: none;


### PR DESCRIPTION
The background of the DatetimePicker input field is clipped to `content-box` which gives the wrong background color on the left and right. As long as the background-color of the parent is white, it's not visible, but e.g. in the `NcActionInput` component you see a problem.

I added a bright color with the devtools to make this visible:

Before:
![Screenshot 2023-02-20 at 12-06-32 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220088265-a7d567ba-4e80-4b82-9c3e-892a66ad5b4f.png)

After:
![Screenshot 2023-02-20 at 12-07-27 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220088411-53dfb43b-c994-4bba-9aa5-e17da594c0ba.png)

