### PR TITLE
Make datetimepicker full width in NcActionInput

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -135,7 +135,7 @@ For the multiselect component, all events will be passed through. Please see the
 					:disabled="disabled"
 					:type="datePickerType"
 					:input-class="['mx-input', { focusable: isFocusable }]"
-					class="action-input__picker"
+					class="action-input__datetimepicker"
 					v-bind="$attrs"
 					@input="onInput"
 					@change="onChange" />
@@ -145,6 +145,7 @@ For the multiselect component, all events will be passed through. Please see the
 					:value="value"
 					:type="nativeDatePickerType"
 					:class="{ focusable: isFocusable }"
+					class="action-input__datetimepicker"
 					v-bind="$attrs"
 					@input="$emit('input', $event)"
 					@change="$emit('change', $event)" />
@@ -591,8 +592,12 @@ $input-margin: 4px;
 		}
 	}
 
-	&__picker :deep(.mx-input) {
-		margin: 0;
+	&__datetimepicker {
+		width: 100%;
+
+		:deep(.mx-input) {
+			margin: 0;
+		}
 	}
 
 	&__multi {


### PR DESCRIPTION
This PR makes the datetimepickers in `NcActionInput` the full width.

| Before | After |
|-|-|
| ![Screenshot 2023-02-20 at 13-32-36 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220109074-cf26b4c5-b4cb-4b0c-9367-0df0652cbd3a.png) | ![Screenshot 2023-02-20 at 13-36-17 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220109813-baf655f0-513e-4370-bac5-ed7424edfe5b.png) |
