### PR TITLE
Show round corners for scrolling NcActions

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1183,10 +1183,15 @@ export default {
 <style lang="scss">
 // We overwrote the popover base class, so we can style
 // the popover__inner for actions only.
-.v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__inner {
+.v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__wrapper {
 	border-radius: var(--border-radius-large);
-	padding: 4px;
-	max-height: calc(50vh - 16px);
-	overflow: auto;
+	overflow:hidden;
+
+	.v-popper__inner {
+		border-radius: var(--border-radius-large);
+		padding: 4px;
+		max-height: calc(50vh - 16px);
+		overflow: auto;
+	}
 }
 </style>


### PR DESCRIPTION
The scrollbar in an `NcActions` component makes the right top and bottom corners square. This PR fixes it.

| Before | After |
|-|-|
| ![Screenshot 2023-02-20 at 14-03-36 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220117175-cf43135a-99e3-4e26-9c00-ac52e08c2b30.png) | ![Screenshot 2023-02-20 at 14-09-32 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220117919-4dd2917b-6b8e-4537-8974-c466295c7e97.png) |