### PR TITLE
NcAppNavigation - change toggle icon for opened sidebar

### DIFF
--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -30,7 +30,8 @@
 		aria-controls="app-navigation-vue"
 		@click="toggleNavigation">
 		<template #icon>
-			<MenuIcon :size="20" />
+			<MenuOpenIcon v-if="open" :size="20" />
+			<MenuIcon v-else :size="20" />
 		</template>
 	</NcButton>
 </template>
@@ -41,6 +42,7 @@ import Tooltip from '../../directives/Tooltip/index.js'
 import { t } from '../../l10n.js'
 
 import MenuIcon from 'vue-material-design-icons/Menu.vue'
+import MenuOpenIcon from 'vue-material-design-icons/MenuOpen.vue'
 
 export default {
 	name: 'NcAppNavigationToggle',
@@ -52,6 +54,7 @@ export default {
 	components: {
 		NcButton,
 		MenuIcon,
+		MenuOpenIcon,
 	},
 
 	props: {


### PR DESCRIPTION
Closes #3688 

Changed icon for NcAppNavigationToggle in open state with more visually and semantically appropiate icon
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/93392545/220146611-e8baee13-c9fd-479a-a1cd-ee6f7e4c324b.png) | ![Screenshot from 2023-02-20 16-24-35](https://user-images.githubusercontent.com/93392545/220146455-36cdde04-3ec7-4bf4-a83e-34b3379fad0a.png)
