### PR TITLE
Fix prop type check for NcPopover setReturnFocus

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -130,7 +130,7 @@ export default {
 		 */
 		setReturnFocus: {
 			default: undefined,
-			type: [Object, String, Function, Boolean],
+			type: [HTMLElement, SVGElement, String, Boolean],
 		},
 	},
 


### PR DESCRIPTION
This fixes the invalid prop type check for `NcPopover` `setReturnFocus`. As per the focus-trap docs, allowed values are
`HTMLElement | SVGElement | string | Boolean`, see
https://github.com/focus-trap/focus-trap/blob/4cbbef5e971bcdadcc07c3cbb08d0fccfc001809/index.d.ts#L4-L5

Fixes #3801.