### PR TITLE
Allow value of type array for NcActionInput

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -300,7 +300,7 @@ export default {
 		 * value attribute of the input field
 		 */
 		value: {
-			type: [String, Date, Number],
+			type: [String, Date, Number, Array],
 			default: '',
 		},
 		/**


### PR DESCRIPTION
For the `NcActionInput` type multiselect, we need to allow the `value` of type `array` in case on passes an object as the options. Otherwise we will get an invalid prop type check.

Follow-up of #3760.