### PR TITLE
Add missing trailing comma

### DIFF
--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -168,7 +168,7 @@ export default {
 
 		matchTimezoneId(timezoneId, terms) {
 			return terms.every(term => timezoneId.toLowerCase().includes(term.toLowerCase()))
-		}
+		},
 	},
 }
 </script>


### PR DESCRIPTION
Adds a missing trailing comma in the timezone picker. Regression of #3781.