### PR TITLE
Allow to add class to native datepicker input

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -159,7 +159,7 @@ For the multiselect component, all events will be passed through. Please see the
 					:id="idNativeDateTimePicker"
 					:value="value"
 					:type="nativeDatePickerType"
-					:class="{ focusable: isFocusable }"
+					:input-class="{ focusable: isFocusable }"
 					class="action-input__datetimepicker"
 					v-bind="$attrs"
 					@input="$emit('input', $event)"

--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -140,6 +140,7 @@ All available types are: 'date', 'datetime-local', 'month', 'time' and 'week', p
 		<label :class="{ 'hidden-visually': hideLabel }" :for="id">{{ label }}</label>
 		<input :id="id"
 			class="native-datetime-picker--input"
+			:class="inputClass"
 			:type="type"
 			:value="formattedValue"
 			:min="formattedMin"
@@ -217,6 +218,14 @@ export default {
 		hideLabel: {
 			type: Boolean,
 			default: false,
+		},
+		/**
+		 * Class to add to the input field.
+		 * Necessary to use NcDateTimePickerNative in the NcActionInput component.
+		 */
+		inputClass: {
+			type: [Object, String],
+			default: '',
 		},
 	},
 


### PR DESCRIPTION
This adds the `inputClass` prop to the `NcDateTimePickerNative` component. This is necessary so the input field gets correctly focused when the datepicker is used in the `NcActionInput` component. With this PR, the datepicker gets the focus when you use the keyboard to navigate through the actions. Before, there was no way of focusing the datepicker with the keyboard only.