### PR TITLE
fix(NcSelect): Do not squash selected items with `no-wrap` set

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1022,12 +1022,15 @@ body {
 	 * There is an upstream pull request, if it is merged and released remove this fix
 	 * https://github.com/sagalbot/vue-select/pull/1756
 	 */
-	.vs__selected-options {
-		min-width: 0;
-		.vs__selected {
+	&:not(.select--no-wrap) {
+		.vs__selected-options {
 			min-width: 0;
+			.vs__selected {
+				min-width: 0;
+			}
 		}
 	}
+
 	&.vs--single {
 		&.vs--loading,
 		&.vs--open {


### PR DESCRIPTION
* Resolves: #3808 

I think this resolves the issue, does this looks like you would expect it to look with `no-wrap` set?

before | after
---|---
![image](https://user-images.githubusercontent.com/1855448/220661249-54956b95-bb5e-4b43-bf32-1a889ffccb71.png) | ![image](https://user-images.githubusercontent.com/1855448/220661311-85928658-8d92-4bfc-99b2-94d2d75813c9.png)


https://user-images.githubusercontent.com/1855448/220661348-1ed78048-cb97-49f3-ac1e-8bb8a04b47f7.mp4

