### PR TITLE
Adjust `NcDatetimePicker` styling

### DIFF
--- a/src/components/NcDatetimePicker/NcDatetimePicker.vue
+++ b/src/components/NcDatetimePicker/NcDatetimePicker.vue
@@ -140,13 +140,16 @@ export default {
 		@select-year="handleSelectYear"
 		@select-month="handleSelectMonth"
 		@update:value="$emit('update:value', value)">
-		<template v-if="showTimezoneSelect" #icon-calendar>
-			<NcPopover :open.sync="showTimezonePopover"
+		<template #icon-calendar>
+			<NcPopover v-if="showTimezoneSelect"
+				:open.sync="showTimezonePopover"
 				open-class="timezone-popover-wrapper">
 				<template #trigger>
-					<button class="datetime-picker-inline-icon icon-timezone icon"
+					<button class="datetime-picker-inline-icon"
 						:class="{'datetime-picker-inline-icon--highlighted': highlightTimezone}"
-						@mousedown.stop.prevent="() => {}" />
+						@mousedown.stop.prevent="() => {}">
+						<Web :size="20" />
+					</button>
 				</template>
 
 				<div class="timezone-popover-wrapper__title">
@@ -158,6 +161,7 @@ export default {
 					class="timezone-popover-wrapper__timezone-select"
 					@input="$emit('update:timezone-id', arguments[0])" />
 			</NcPopover>
+			<CalendarBlank v-else :size="20" />
 		</template>
 		<template v-for="(_, slot) of $scopedSlots" #[slot]="scope">
 			<slot :name="slot" v-bind="scope" />
@@ -169,6 +173,9 @@ export default {
 import NcTimezonePicker from '../NcTimezonePicker/index.js'
 import NcPopover from '../NcPopover/index.js'
 import l10n from '../../mixins/l10n.js'
+
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
+import Web from 'vue-material-design-icons/Web.vue'
 
 import {
 	getFirstDay,
@@ -194,9 +201,11 @@ export default {
 	name: 'NcDatetimePicker',
 
 	components: {
+		CalendarBlank,
 		DatePicker,
 		NcPopover,
 		NcTimezonePicker,
+		Web,
 	},
 
 	mixins: [l10n],
@@ -391,7 +400,8 @@ export default {
 	border: none;
 	background-color: transparent;
 	border-radius: 0;
-	padding: 6px !important;
+	padding: 0 !important;
+	margin: 0;
 
 	&--highlighted {
 		opacity: .7;

--- a/src/components/NcDatetimePicker/index.scss
+++ b/src/components/NcDatetimePicker/index.scss
@@ -15,9 +15,15 @@ $cell_height: 32px;
 		// input
 		.mx-input {
 			width: 100%;
-			border: 1px solid var(--color-border);
+			border: 2px solid var(--color-border-maxcontrast);
 			background-color: var(--color-main-background);
 			background-clip: content-box;
+			
+			&:active:not(.disabled),
+			&:hover:not(.disabled),
+			&:focus:not(.disabled) {
+				border-color: var(--color-primary-element);
+			}
 		}
 
 		&:disabled,


### PR DESCRIPTION
This PR adjust the `NcDatetimePicker` styling to bring it inline with the other picker and input styles. It also replaces the icons used with material design icons.

| Before | After |
|-|-|
| ![Screenshot 2023-02-23 at 13-52-58 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220912141-b082aa46-397e-44bf-850a-a091c6db6de7.png) | ![Screenshot 2023-02-23 at 13-53-23 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220912167-1e88b73d-5c3c-44c4-a47c-111f6e035b01.png) |
| <img width="265" alt="ActionInputBefore" src="https://user-images.githubusercontent.com/2496460/220912201-5b232a6a-3cfa-492d-b11d-29e7932c53d1.png"> | <img width="266" alt="ActionInputAfter" src="https://user-images.githubusercontent.com/2496460/220946493-01ca7284-e037-4cd7-933a-0b7cac62145d.png"> |

Closes #3809.