### PR TITLE
Unify datetimepicker opacity in NcActionInput

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -122,7 +122,6 @@ For the multiselect component, all events will be passed through. Please see the
 <template>
 	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span :class="{
-				'action-input--picker': datePickerType,
 				'action-input-picker--disabled': disabled,
 				'action-input--visible-label': labelVisible && label,
 			}"
@@ -469,6 +468,7 @@ $input-margin: 4px;
 	cursor: pointer;
 	white-space: nowrap;
 
+	opacity: $opacity_normal;
 	color: var(--color-main-text);
 	border: 0;
 	border-radius: 0; // otherwise Safari will cut the border-radius area
@@ -476,6 +476,11 @@ $input-margin: 4px;
 	box-shadow: none;
 
 	font-weight: normal;
+
+	&:hover,
+	&:focus {
+		opacity: $opacity_full;
+	}
 
 	&__icon-wrapper {
 		display: flex;
@@ -491,26 +496,6 @@ $input-margin: 4px;
 			.material-design-icon__svg {
 				vertical-align: middle;
 			}
-		}
-	}
-
-	// do not change the opacity of the datepicker
-	&:not(.action-input--picker) {
-		opacity: $opacity_normal;
-		&:hover,
-		&:focus {
-			opacity: $opacity_full;
-		}
-	}
-
-	// only change for the icon then
-	&--picker {
-		.action-input__icon {
-			opacity: $opacity_normal;
-		}
-		&:hover .action-input__icon,
-		&:focus .action-input__icon {
-			opacity: $opacity_full;
 		}
 	}
 


### PR DESCRIPTION
The `date` type of the `NcActionInput` component didn't have it's opacity reduced when not hovered. This PR unifies this.

| Before | After |
|-|-|
| ![Screenshot 2023-02-23 at 14-49-11 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220926449-d6eb15c5-8f3d-47eb-904a-2f415ffb70df.png) | ![Screenshot 2023-02-23 at 14-49-29 Nextcloud Vue Style Guide](https://user-images.githubusercontent.com/2496460/220926485-b55e4efa-fdcc-438f-962c-591016ca6b6e.png) |

