### PR TITLE
Don't fail if `NcButton` default slot contains not only text

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -310,7 +310,7 @@ export default {
 	 * @return {object|undefined} The created VNode
 	 */
 	render(h) {
-		const text = this.$slots.default?.[0]?.text.trim()
+		const text = this.$slots.default?.[0]?.text?.trim?.()
 
 		const hasText = !!text
 		const hasIcon = this.$slots?.icon


### PR DESCRIPTION
This fixes a runtime warning if the `default` slot of `NcButton` does not contain text only, e.g. `<p>Test</p>`.

Closes #3824.