### PR TITLE
Fix rich content placeholder position

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -628,7 +628,7 @@ export default {
 	overflow-y: auto;
 	width: auto;
 	margin: 0;
-	padding: 6px;
+	padding: 8px;
 	cursor: text;
 	white-space: pre-wrap;
 	word-break: break-word;
@@ -646,6 +646,7 @@ export default {
 	&--empty:before {
 		content: attr(placeholder);
 		color: var(--color-text-maxcontrast);
+		position: absolute;
 	}
 
 	&[contenteditable='false']:not(&--disabled) {


### PR DESCRIPTION
This fixes the position of the cursor in the `NcRichContenteditable` component after one types text and deletes it again. I also adjusted the padding a bit, to bring the text to the center. Closes #3828.

Before:
<img width="606" alt="Before" src="https://user-images.githubusercontent.com/2496460/221804400-0d243c97-dffa-43af-95e4-ad6755f1ca90.png">

After:
<img width="606" alt="After" src="https://user-images.githubusercontent.com/2496460/221804421-1a854b10-0841-4776-9dd1-66bd817062a9.png">
