### PR TITLE
NcSelect: Only hide search input if disabled and an element was selected

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1008,13 +1008,14 @@ body {
 		}
 	}
 
-	// Hide search from dom if unused to prevent unneeded flex wrap
-	.vs__search[readonly] {
-		position: absolute;
-	}
-	// If search if hidden, ensure that the height of the search is the same
 	.vs__selected-options {
+		// If search is hidden, ensure that the height of the search is the same
 		min-height: 40px; // 36px search height + 4px search margin
+
+		// Hide search from dom if unused to prevent unneeded flex wrap
+		.vs__selected ~ .vs__search[readonly] {
+			position: absolute;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This fixes a regression where the placeholder text is not shown if `NcSelect` is configured to be not searchable, in this case the input element was hidden but this also hides the placeholder.
