### PR TITLE
Fix circular dependency with `@nextcloud/vue-richtext`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
-				"@nextcloud/vue-richtext": "^2.1.0-beta.5",
+				"@nextcloud/vue-richtext": "^2.1.0-beta.6",
 				"@nextcloud/vue-select": "^3.21.2",
 				"@skjnldsv/sanitize-svg": "^1.0.2",
 				"debounce": "1.2.1",
@@ -3163,9 +3163,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue-richtext": {
-			"version": "2.1.0-beta.5",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
-			"integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+			"version": "2.1.0-beta.6",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.6.tgz",
+			"integrity": "sha512-LIhBCpFEfimUCHlPuhRADwTDXwOf4SASaQLYowofwvFfqTBjYi/TZdQfP4UBPaVFP2aKssOxuZ3HT83Z77ROAw==",
 			"dependencies": {
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/event-bus": "^3.0.2",
@@ -28354,9 +28354,9 @@
 			}
 		},
 		"@nextcloud/vue-richtext": {
-			"version": "2.1.0-beta.5",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
-			"integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+			"version": "2.1.0-beta.6",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.6.tgz",
+			"integrity": "sha512-LIhBCpFEfimUCHlPuhRADwTDXwOf4SASaQLYowofwvFfqTBjYi/TZdQfP4UBPaVFP2aKssOxuZ3HT83Z77ROAw==",
 			"requires": {
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/event-bus": "^3.0.2",
@@ -28385,7 +28385,7 @@
 			"version": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#516d77c7012711a741baee53be745168c0456605",
 			"integrity": "sha512-SvgLgQ1NlSnTrv2ArapeCAcQFd2vgwMRgVTD1TtGs8s0veU0lR5QYe/CcJbN2eBavpJxqDaGi183mPeObJTH/Q==",
 			"dev": true,
-			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#516d77c7012711a741baee53be745168c0456605",
+			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#master",
 			"requires": {}
 		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"@nextcloud/l10n": "^2.0.1",
 		"@nextcloud/logger": "^2.2.1",
 		"@nextcloud/router": "^2.0.0",
-		"@nextcloud/vue-richtext": "^2.1.0-beta.5",
+		"@nextcloud/vue-richtext": "^2.1.0-beta.6",
 		"@nextcloud/vue-select": "^3.21.2",
 		"@skjnldsv/sanitize-svg": "^1.0.2",
 		"debounce": "1.2.1",


### PR DESCRIPTION
Use `@nextcloud/vue-richtext` 2.1.0-beta.6 which fixes the circular dependency by including `@nextcloud/vue` in its rollup package.

This made it impossible to import both `@nextcloud/vue` and `@nextcloud/vue-richtext` in the same script and caused rendering issues of  `@nextcloud/vue-richtext` when used in `@nextcloud/vue`.

This is a temporary fix for things to work until `@nextcloud/vue-richtext` is merged in here.
refs #3812