### PR TITLE
`NcRichContentEditable`: Emit correct rich content on paste

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -504,7 +504,7 @@ export default {
 			selection.addRange(newRange)
 
 			// Propagate data
-			this.updateValue(event.target.innerHTML)
+			this.updateValue(this.$refs.contenteditable.innerHTML)
 		},
 
 		/**
@@ -549,6 +549,7 @@ export default {
 
 			// fix backspace bug in FF
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=685445
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=1665167
 			const selection = window.getSelection()
 			const node = event.target
 			if (!selection.isCollapsed || !selection.rangeCount) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/forms/issues/1536

Currently the previous content of the `NcRichContentEditable` is replaced when pasting behind a newline.
This fixes this by emitting the full content after a paste event.

## Screen recording
### Before

https://user-images.githubusercontent.com/1855448/221934330-dc88f086-d8b7-48f9-b907-5780f82219c7.mp4

### After


https://user-images.githubusercontent.com/1855448/221934362-04bd934b-fbce-4bea-98f3-e84d54f5d7fc.mp4

