### PR TITLE
v7.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.8.0](https://github.com/nextcloud/nextcloud-vue/tree/v7.8.0) (2023-03-02)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.7.2...v7.8.0)
+
+### Closed pull requests
+
+- Merge `@nextcloud/vue-richtext` into `@nextcloud/vue` [\#3841](https://github.com/nextcloud/nextcloud-vue/pull/3841) ([raimund-schluessler](https://github.com/raimund-schluessler))
+
 ## [v7.7.2](https://github.com/nextcloud/nextcloud-vue/tree/v7.7.2) (2023-02-28)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.7.1...v7.7.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.7.2",
+	"version": "7.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.7.2",
+			"version": "7.8.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.7.2",
+	"version": "7.8.0",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
## [v7.8.0](https://github.com/nextcloud/nextcloud-vue/tree/v7.8.0) (2023-03-02)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.7.2...v7.8.0)

### Closed pull requests

- Merge `@nextcloud/vue-richtext` into `@nextcloud/vue` [\#3841](https://github.com/nextcloud/nextcloud-vue/pull/3841) ([raimund-schluessler](https://github.com/raimund-schluessler))
