### PR TITLE
Only transform necessary packages for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 			".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
 		},
 		"transformIgnorePatterns": [
-			"/node_modules/(?!(.*)/)"
+			"/node_modules/(?!(vue-material-design-icons)|(unist*)|(unified)|(bail)|(remark*)|(is-*)|(trough)|(vfile)|(mdast*)|(micromark)|(decode-named-character-reference)|(trim-lines)|(rehype*)|(hast-*)|(property-information)|(space-separated-tokens)|(comma-separated-tokens)|(web-namespaces))"
 		],
 		"snapshotSerializers": [
 			"<rootDir>/node_modules/jest-serializer-vue"


### PR DESCRIPTION
This white-lists only the packages necessary for jest to run the tests without transforming all packages in `node_modules`. I think this speeds up the test run a bit, but it's difficult to say, as jest (or babel?) kind of seems to cache the transformation result.