### PR TITLE
Remove empty beforeDestroy block in `NcReferencePicker`

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
@@ -111,8 +111,6 @@ export default {
 		}
 
 	},
-	beforeDestroy() {
-	},
 	methods: {
 		onEscapePressed() {
 			if (this.selectedProvider !== null) {


### PR DESCRIPTION
This is just a little cleanup which removes the empty `beforeDestroy` block.