### PR TITLE
Don't use deprecated v-deep

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -319,7 +319,7 @@ export default {
 
 		// multiselect dropdown is wider than the select input
 		// this avoids overflow
-		::v-deep .multiselect__content-wrapper {
+		:deep(.multiselect__content-wrapper) {
 			width: calc(100% - 4px) !important;
 		}
 	}


### PR DESCRIPTION
This migrates the usage of the deprecated `v-deep` directive in `NcSearch`.