### PR TITLE
Remove superfluous input close icon template

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -8,9 +8,6 @@
 				@trailing-button-click="onClear"
 				@update:value="onInput"
 				@keyup.native.enter="onSubmit">
-				<template #trailing-button-icon>
-					<CloseIcon :size="16" />
-				</template>
 				<NcLoadingIcon v-if="loading" :size="16" />
 				<LinkVariantIcon v-else :size="16" />
 			</NcTextField>


### PR DESCRIPTION
The close/clear icon in the `NcRawLinkInput` component is not registered. However, since the default close button icon is already `close`, providing it is anyway superfluous. So this PR just removed the useless template. No visual or functional changes.