### PR TITLE
Remove unused parseUrl parameter

### DIFF
--- a/src/components/NcRichText/autolink.js
+++ b/src/components/NcRichText/autolink.js
@@ -32,7 +32,7 @@ export const remarkAutolink = function({ autolink, useMarkdown }) {
 		}
 
 		visit(tree, (node) => node.type === 'text', (node, index, parent) => {
-			let parsed = parseUrl(node.value, Link)
+			let parsed = parseUrl(node.value)
 			parsed = parsed.map((n) => {
 				if (typeof n === 'string') {
 					return u('text', n)
@@ -49,7 +49,7 @@ export const remarkAutolink = function({ autolink, useMarkdown }) {
 	}
 }
 
-export const parseUrl = (text, linkComponent) => {
+export const parseUrl = (text) => {
 	let match = URL_PATTERN_AUTOLINK.exec(text)
 	const list = []
 	let start = 0


### PR DESCRIPTION
The second parameter of the `parseUrl` function is not used, so I removed it. It was called without it anyway already here:
https://github.com/nextcloud/nextcloud-vue/blob/d36b3f694405e49a34ec1ac0422c1657c8908cac/src/components/NcRichText/placeholder.js#L39