### PR TITLE
Allow setting modal size when registering a custom picker component

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -38,7 +38,7 @@
 
 <script>
 import NcReferencePicker from './NcReferencePicker.vue'
-import { isCustomPickerElementRegistered } from './customPickerElements.js'
+import { getCustomPickerElementSize, isCustomPickerElementRegistered } from './customPickerElements.js'
 import NcButton from '../../NcButton/index.js'
 import NcModal from '../../NcModal/index.js'
 import { t } from '../../../l10n.js'
@@ -103,7 +103,7 @@ export default {
 		},
 		modalSize() {
 			return this.isProviderSelected && isCustomPickerElementRegistered(this.selectedProvider.id)
-				? 'large'
+				? (getCustomPickerElementSize(this.selectedProvider.id) ?? 'large')
 				: 'normal'
 		},
 		showModalTitle() {

--- a/src/components/NcRichText/NcReferencePicker/customPickerElements.js
+++ b/src/components/NcRichText/NcReferencePicker/customPickerElements.js
@@ -23,7 +23,15 @@ const isCustomPickerElementRegistered = (id) => {
 	return !!window._vue_richtext_custom_picker_elements[id]
 }
 
-const registerCustomPickerElement = (id, callback, onDestroy = (el) => {}) => {
+const getCustomPickerElementSize = (id) => {
+	const size = window._vue_richtext_custom_picker_elements[id]?.size
+	if (['small', 'normal', 'large', 'full'].includes(size)) {
+		return size
+	}
+	return null
+}
+
+const registerCustomPickerElement = (id, callback, onDestroy = (el) => {}, size = 'large') => {
 	if (window._vue_richtext_custom_picker_elements[id]) {
 		console.error('Custom reference picker element for id ' + id + ' already registered')
 		return
@@ -33,6 +41,7 @@ const registerCustomPickerElement = (id, callback, onDestroy = (el) => {}) => {
 		id,
 		callback,
 		onDestroy,
+		size,
 	}
 }
 
@@ -61,4 +70,5 @@ export {
 	renderCustomPickerElement,
 	destroyCustomPickerElement,
 	isCustomPickerElementRegistered,
+	getCustomPickerElementSize,
 }


### PR DESCRIPTION
Design review outcome: Some custom picker components don't look good in a "large" `NcModal`.

This allows to pass the desired modal size when registering a custom picker component.
This size is then used by `NcReferencePickerModal`.