### PR TITLE
Remove doubling proxied event handlers in `NcRichContenteditable`

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -160,8 +160,8 @@ export default {
 		aria-multiline="true"
 		class="rich-contenteditable__input"
 		role="textbox"
+		v-on="listeners"
 		@input="onInput"
-		v-on="$listeners"
 		@keydown.delete="onDelete"
 		@keydown.enter.exact="onEnter"
 		@keydown.ctrl.enter.exact.stop.prevent="onCtrlEnter"
@@ -422,6 +422,23 @@ export default {
 		 */
 		canEdit() {
 			return this.contenteditable && !this.disabled
+		},
+
+		/**
+		 * Proxied native event handlers without custom event handlers
+		 *
+		 * @return {Record<string, Function>}
+		 */
+		listeners() {
+			/**
+			 * All component's event handlers are set as native event handlers with by v-on directive.
+			 * The component also raised custom events manually by $emit for corresponding events.
+			 * As a result, it triggers handlers twice.
+			 * The v-on="listeners" directive should only set proxied native events handler without custom events
+			 */
+			const listeners = { ...this.$listeners }
+			delete listeners.paste
+			return listeners
 		},
 	},
 


### PR DESCRIPTION
## A problem

All component's event handlers were set as native event handlers with by `v-on="$listeners"`.
It allows using event handlers without the `.native` modifier for native events.

But the component also raised custom events manually by `$emit`, including corresponding native events. As a result, it triggers such handlers twice.

Related issue: https://github.com/nextcloud/spreed/issues/9004

## Steps to reproduce

1. Set paste event handler:
   ```html
   <NcRichContenteditable @paste="handler" />
   ```
2. Paste anything

## Actual behavior

`handler` is called twice:
- Once `handler` will be called by `$emit('paste')`
- One more time, `handler` will be called by `v-on="$listeners"`.

## Expected behavior

`handler` is called once.

## Proposed solution

In this PR with the `v-on="listeners"` directive only proxied native event handlers are set, without custom events.

## Alternative solution

There is a simple alternative solution: remove `this.$emit('paste', event)` from `onPaste` handler. It also removes the doubling `paste` event.

I suggest the solution from the PR because:
- It doesn't change the component's interface (`emits` option) and behavior with conditions in `onPaste`.
- It is scalable: it allows adding more custom processing to paste event handling as well as custom processing of other "native" events.

`submit` and `update:value` event handlers are not removed because they don't exist as native events on `div`.
