### PR TITLE
Fix doubling attrs in `NcPopover` and improve docs

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -42,18 +42,18 @@ open prop on this component;
 <template>
 	<NcPopover>
 		<template #trigger>
-			<NcButton> I am the trigger </NcButton>
+			<NcButton>I am the trigger</NcButton>
 		</template>
 		<template>
 			<form tabindex="0" @submit.prevent>
 				<h2>this is some content</h2>
 				<p>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. </br>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br />
 					Vestibulum eget placerat velit.
 				</p>
 				<label>
 					Label element
-					<input type="text" placehold="input element" />
+					<input type="text" placeholder="input element" />
 				</label>
 			</form>
 		</template>
@@ -71,7 +71,7 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 <template>
 	<NcPopover :focus-trap="false">
 		<template #trigger>
-			<NcButton> Click me! </NcButton>
+			<NcButton>Click me!</NcButton>
 		</template>
 		<template>
 			Hi! 🚀

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -79,6 +79,21 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 	</NcPopover>
 </template>
 ```
+
+#### With passing props to `floating-vue`'s `Dropdown`:
+
+```vue
+<template>
+	<NcPopover container="body" :popper-hide-triggers="(triggers) => [...triggers, 'click']">
+		<template #trigger>
+			<NcButton>I am the trigger</NcButton>
+		</template>
+		<template #default>
+			<NcButton>Click on the button will close NcPopover</NcButton>
+		</template>
+	</NcPopover>
+</template>
+```
 </docs>
 
 <template>
@@ -107,9 +122,12 @@ import { getTrapStack } from '../../utils/focusTrap.js'
 
 export default {
 	name: 'NcPopover',
+
 	components: {
 		Dropdown,
 	},
+
+	inheritAttrs: false,
 
 	props: {
 		popoverBaseClass: {

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -40,24 +40,26 @@ open prop on this component;
 
 ```vue
 <template>
-	<NcPopover>
-		<template #trigger>
-			<NcButton>I am the trigger</NcButton>
-		</template>
-		<template>
-			<form tabindex="0" @submit.prevent>
-				<h2>this is some content</h2>
-				<p>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br />
-					Vestibulum eget placerat velit.
-				</p>
-				<label>
-					Label element
-					<input type="text" placeholder="input element" />
-				</label>
-			</form>
-		</template>
-	</NcPopover>
+	<div style="display: flex">
+		<NcPopover>
+			<template #trigger>
+				<NcButton>I am the trigger</NcButton>
+			</template>
+			<template>
+				<form tabindex="0" @submit.prevent>
+					<h2>this is some content</h2>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br/>
+						Vestibulum eget placerat velit.
+					</p>
+					<label>
+						Label element
+						<input type="text" placeholder="input element"/>
+					</label>
+				</form>
+			</template>
+		</NcPopover>
+	</div>
 </template>
 ```
 
@@ -69,14 +71,16 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 
 ```vue
 <template>
-	<NcPopover :focus-trap="false">
-		<template #trigger>
-			<NcButton>Click me!</NcButton>
-		</template>
-		<template>
-			Hi! 🚀
-		</template>
-	</NcPopover>
+	<div style="display: flex">
+		<NcPopover :focus-trap="false">
+			<template #trigger>
+				<NcButton>Click me!</NcButton>
+			</template>
+			<template>
+				Hi! 🚀
+			</template>
+		</NcPopover>
+	</div>
 </template>
 ```
 
@@ -84,14 +88,16 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 
 ```vue
 <template>
-	<NcPopover container="body" :popper-hide-triggers="(triggers) => [...triggers, 'click']">
-		<template #trigger>
-			<NcButton>I am the trigger</NcButton>
-		</template>
-		<template #default>
-			<NcButton>Click on the button will close NcPopover</NcButton>
-		</template>
-	</NcPopover>
+	<div style="display: flex">
+		<NcPopover container="body" :popper-hide-triggers="(triggers) => [...triggers, 'click']">
+			<template #trigger>
+				<NcButton>I am the trigger</NcButton>
+			</template>
+			<template #default>
+				<NcButton>Click on the button will close NcPopover</NcButton>
+			</template>
+		</NcPopover>
+	</div>
 </template>
 ```
 </docs>


### PR DESCRIPTION
## A problem

`NcPopover` is a wrapper around `floating-vue`'s `Dropdown` component. It proxies all attrs and listeners to the wrapped Dropdown. It allows setting any `Dropdown`'s props for customization.

But Vue inherits all attrs on the root node by default. It makes all attrs, passed as Dropdown prop, set as HTML attrs of root div.

### Expected behavior with the `Dropdown` props

![popover-expected](https://user-images.githubusercontent.com/25978914/224309335-6732bd75-2f16-43ae-b8a5-76feb66eeb70.png)

### Actual behavior 

![popover-actual](https://user-images.githubusercontent.com/25978914/224309257-9a3f185a-11c7-4f4a-9d57-408c8362a511.png)

## The solution

This PR adds the required `inheritAttrs: false`.

ESLint rule helping with this problem: https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html

## Docs improvements

- **Add an example with passing props to the `Dropdown`**
      ![image](https://user-images.githubusercontent.com/25978914/224309770-1e68a3c5-d13a-48cf-bb24-83665b1672b8.png)
- **Fix Popover positions in docs**
  - Before:
    ![popover-wrong-position](https://user-images.githubusercontent.com/25978914/224310012-32043c17-679c-4d18-a395-38c43e1f224a.png)
  - After: 
    ![popover-good-position](https://user-images.githubusercontent.com/25978914/224310069-40a24c09-63d1-4888-9b81-d5b0bb51aecf.png)
- **Fix typos in docs**

See commits for details 🦖