### PR TITLE
Fix navigate handler call

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -650,7 +650,7 @@ export default {
 		// forward click event
 		onClick(event, navigate) {
 			// Navigate is only defined if it is a router-link
-			navigate?.()
+			navigate?.(event)
 			this.$emit('click', event)
 		},
 


### PR DESCRIPTION
With my last "cleanup" commit 4ce516e959d5ca2c180e178c54e5433af134aa00 in #3775 I introduced a little bug by not providing the `$event` to the `navigate` handler. This makes the navigation fail and gets fixed by this PR.