### PR TITLE
Fix dynamic tabs registration and a11y in NcAppSidebarTabs with provide/inject

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -31,22 +31,33 @@ include a standard-header like it's used by the files app.
 
 ```vue
 <template>
-	<NcAppSidebar
-		title="cat-picture.jpg"
-		subtitle="last edited 3 weeks ago">
-		<NcAppSidebarTab name="Settings" id="settings-tab">
-			<template #icon>
-				<Cog :size="20" />
-			</template>
-			Settings tab content
-		</NcAppSidebarTab>
-		<NcAppSidebarTab name="Sharing" id="share-tab">
-			<template #icon>
-				<ShareVariant :size="20" />
-			</template>
-			Sharing tab content
-		</NcAppSidebarTab>
-	</NcAppSidebar>
+	<div>
+		<NcCheckboxRadioSwitch :checked.sync="hideFirstTab">
+			The first tab is hidden
+		</NcCheckboxRadioSwitch>
+		<NcAppSidebar
+			title="cat-picture.jpg"
+			subtitle="last edited 3 weeks ago">
+			<NcAppSidebarTab v-if="!hideFirstTab" name="Fist tab" id="first-tab">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+				New tab
+			</NcAppSidebarTab>
+			<NcAppSidebarTab name="Settings" id="settings-tab">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+				Settings tab content
+			</NcAppSidebarTab>
+			<NcAppSidebarTab name="Sharing" id="share-tab">
+				<template #icon>
+					<ShareVariant :size="20" />
+				</template>
+				Sharing tab content
+			</NcAppSidebarTab>
+		</NcAppSidebar>
+	</div>
 </template>
 <script>
 	import Cog from 'vue-material-design-icons/Cog'
@@ -57,7 +68,84 @@ include a standard-header like it's used by the files app.
 			Cog,
 			ShareVariant,
 		},
+		data() {
+			return {
+				hideFirstTab: true,
+			}
+		},
 	}
+</script>
+```
+
+### One tab
+
+```vue
+<template>
+	<div>
+		<NcAppSidebar
+			title="cat-picture.jpg"
+			subtitle="last edited 3 weeks ago">
+			<NcAppSidebarTab name="Settings" id="settings-tab">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+				New tab
+			</NcAppSidebarTab>
+		</NcAppSidebar>
+	</div>
+</template>
+<script>
+import Cog from 'vue-material-design-icons/Cog'
+
+export default {
+	components: {
+		Cog,
+	},
+}
+</script>
+```
+
+### One or two tabs with condition
+
+```vue
+<template>
+	<div>
+		<NcCheckboxRadioSwitch :checked.sync="hideFirstTab">
+			The first tab is hidden
+		</NcCheckboxRadioSwitch>
+		<NcAppSidebar
+			title="cat-picture.jpg"
+			subtitle="last edited 3 weeks ago">
+			<NcAppSidebarTab v-if="!hideFirstTab" name="Settings" id="settings-tab">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+				Settings
+			</NcAppSidebarTab>
+			<NcAppSidebarTab name="Sharing" id="share-tab">
+				<template #icon>
+					<ShareVariant :size="20" />
+				</template>
+				Sharing tab content
+			</NcAppSidebarTab>
+		</NcAppSidebar>
+	</div>
+</template>
+<script>
+import Cog from 'vue-material-design-icons/Cog'
+import ShareVariant from 'vue-material-design-icons/ShareVariant'
+
+export default {
+	components: {
+		Cog,
+		ShareVariant,
+	},
+	data() {
+		return {
+			hideFirstTab: true,
+		}
+	},
+}
 </script>
 ```
 

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -31,53 +31,47 @@ include a standard-header like it's used by the files app.
 
 ```vue
 <template>
-	<div>
-		<NcCheckboxRadioSwitch :checked.sync="hideFirstTab">
-			The first tab is hidden
-		</NcCheckboxRadioSwitch>
-		<NcAppSidebar
-			title="cat-picture.jpg"
-			subtitle="last edited 3 weeks ago">
-			<NcAppSidebarTab v-if="!hideFirstTab" name="Fist tab" id="first-tab">
-				<template #icon>
-					<Cog :size="20" />
-				</template>
-				New tab
-			</NcAppSidebarTab>
-			<NcAppSidebarTab name="Settings" id="settings-tab">
-				<template #icon>
-					<Cog :size="20" />
-				</template>
-				Settings tab content
-			</NcAppSidebarTab>
-			<NcAppSidebarTab name="Sharing" id="share-tab">
-				<template #icon>
-					<ShareVariant :size="20" />
-				</template>
-				Sharing tab content
-			</NcAppSidebarTab>
-		</NcAppSidebar>
-	</div>
+	<NcAppSidebar
+		title="cat-picture.jpg"
+		subtitle="last edited 3 weeks ago">
+		<NcAppSidebarTab name="Search" id="search-tab">
+			<template #icon>
+				<Magnify :size="20" />
+			</template>
+			Search tab content
+		</NcAppSidebarTab>
+		<NcAppSidebarTab name="Settings" id="settings-tab">
+			<template #icon>
+				<Cog :size="20" />
+			</template>
+			Settings tab content
+		</NcAppSidebarTab>
+		<NcAppSidebarTab name="Sharing" id="share-tab">
+			<template #icon>
+				<ShareVariant :size="20" />
+			</template>
+			Sharing tab content
+		</NcAppSidebarTab>
+	</NcAppSidebar>
 </template>
 <script>
+	import Magnify from 'vue-material-design-icons/Magnify'
 	import Cog from 'vue-material-design-icons/Cog'
 	import ShareVariant from 'vue-material-design-icons/ShareVariant'
 
 	export default {
 		components: {
+			Magnify,
 			Cog,
 			ShareVariant,
-		},
-		data() {
-			return {
-				hideFirstTab: true,
-			}
 		},
 	}
 </script>
 ```
 
 ### One tab
+
+Single tab is rendered without navigation.
 
 ```vue
 <template>
@@ -89,7 +83,7 @@ include a standard-header like it's used by the files app.
 				<template #icon>
 					<Cog :size="20" />
 				</template>
-				New tab
+				Single tab content
 			</NcAppSidebarTab>
 		</NcAppSidebar>
 	</div>
@@ -105,18 +99,117 @@ export default {
 </script>
 ```
 
-### One or two tabs with condition
+### Dynamic tabs
 
 ```vue
 <template>
 	<div>
-		<NcCheckboxRadioSwitch :checked.sync="hideFirstTab">
-			The first tab is hidden
-		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :checked.sync="showTabs[0]">Show search tab</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :checked.sync="showTabs[1]">Show settings tab</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :checked.sync="showTabs[2]">Show sharing tab</NcCheckboxRadioSwitch>
 		<NcAppSidebar
 			title="cat-picture.jpg"
 			subtitle="last edited 3 weeks ago">
-			<NcAppSidebarTab v-if="!hideFirstTab" name="Settings" id="settings-tab">
+			<NcAppSidebarTab v-if="showTabs[0]" name="Search" id="search-tab">
+				<template #icon>
+					<Magnify :size="20" />
+				</template>
+				Search tab content
+			</NcAppSidebarTab>
+			<NcAppSidebarTab v-if="showTabs[1]" name="Settings" id="settings-tab">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+				Settings
+			</NcAppSidebarTab>
+			<NcAppSidebarTab v-if="showTabs[2]" name="Sharing" id="share-tab">
+				<template #icon>
+					<ShareVariant :size="20" />
+				</template>
+				Sharing tab content
+			</NcAppSidebarTab>
+		</NcAppSidebar>
+	</div>
+</template>
+<script>
+import Magnify from 'vue-material-design-icons/Magnify'
+import Cog from 'vue-material-design-icons/Cog'
+import ShareVariant from 'vue-material-design-icons/ShareVariant'
+
+export default {
+	components: {
+		Magnify,
+		Cog,
+		ShareVariant,
+	},
+	data() {
+		return {
+			showTabs: [true, true, false],
+		}
+	},
+}
+</script>
+```
+
+### Custom order
+
+```vue
+<template>
+	<NcAppSidebar
+		title="cat-picture.jpg"
+		subtitle="last edited 3 weeks ago">
+		<NcAppSidebarTab name="Search" id="search-tab" order="3">
+			<template #icon>
+				<Magnify :size="20" />
+			</template>
+			Search tab content
+		</NcAppSidebarTab>
+		<NcAppSidebarTab name="Settings" id="settings-tab" order="2">
+			<template #icon>
+				<Cog :size="20" />
+			</template>
+			Settings tab content
+		</NcAppSidebarTab>
+		<NcAppSidebarTab name="Sharing" id="share-tab" order="1">
+			<template #icon>
+				<ShareVariant :size="20" />
+			</template>
+			Sharing tab content
+		</NcAppSidebarTab>
+	</NcAppSidebar>
+</template>
+<script>
+import Magnify from 'vue-material-design-icons/Magnify'
+import Cog from 'vue-material-design-icons/Cog'
+import ShareVariant from 'vue-material-design-icons/ShareVariant'
+
+export default {
+	components: {
+		Magnify,
+		Cog,
+		ShareVariant,
+	},
+}
+</script>
+```
+
+### Activating tab programmatically
+
+```vue
+<template>
+	<div>
+		<NcMultiselect v-model="active" :options="['search-tab', 'settings-tab', 'share-tab']" />
+		<NcAppSidebar
+			title="cat-picture.jpg"
+			subtitle="last edited 3 weeks ago"
+			:active.sync="active">
+			<NcAppSidebarTab name="Search" id="search-tab">
+				<template #icon>
+					<Magnify :size="20" />
+				</template>
+				Search tab content
+			</NcAppSidebarTab>
+			<NcAppSidebarTab name="Settings" id="settings-tab">
 				<template #icon>
 					<Cog :size="20" />
 				</template>
@@ -132,17 +225,19 @@ export default {
 	</div>
 </template>
 <script>
+import Magnify from 'vue-material-design-icons/Magnify'
 import Cog from 'vue-material-design-icons/Cog'
 import ShareVariant from 'vue-material-design-icons/ShareVariant'
 
 export default {
 	components: {
+		Magnify,
 		Cog,
 		ShareVariant,
 	},
 	data() {
 		return {
-			hideFirstTab: true,
+			active: 'search-tab',
 		}
 	},
 }

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -60,6 +60,7 @@
 		<!-- tabs content -->
 		<div :class="{'app-sidebar-tabs__content--multiple': hasMultipleTabs}"
 			class="app-sidebar-tabs__content">
+			<!-- @slot Tabs content - NcAppSidebarTab components or any content if there is no tabs -->
 			<slot />
 		</div>
 	</div>
@@ -72,7 +73,6 @@ export default {
 	name: 'NcAppSidebarTabs',
 
 	components: {
-		// Component to render the material design icon (vnodes)
 		NcVNodes,
 	},
 
@@ -100,22 +100,28 @@ export default {
 	data() {
 		return {
 			/**
-			 * The tab component instances to build the tab navbar from.
+			 * Tab descriptions from the passed NcSidebarTab components' props to build the tab navbar from.
 			 */
 			tabs: [],
 			/**
-			 * The id of the currently active tab.
+			 * Local active (open) tab's ID. It allows to use component without active.sync
 			 */
 			activeTab: '',
 		}
 	},
 
 	computed: {
+		/**
+		 * Has multiple tabs. If only one tab - its content is shown without navigation
+		 *
+		 * @return {boolean}
+		 */
 		hasMultipleTabs() {
 			return this.tabs.length > 1
 		},
+
 		currentTabIndex() {
-			return this.tabs.findIndex(tab => tab.id === this.activeTab)
+			return this.tabs.findIndex((tab) => tab.id === this.activeTab)
 		},
 	},
 
@@ -137,6 +143,9 @@ export default {
 		 */
 		setActive(id) {
 			this.activeTab = id
+			/**
+			 * @property {string} active - active tab's id
+			 */
 			this.$emit('update:active', this.activeTab)
 		},
 
@@ -148,7 +157,7 @@ export default {
 			if (this.currentTabIndex > 0) {
 				this.setActive(this.tabs[this.currentTabIndex - 1].id)
 			}
-			this.focusActiveTab() // focus nav item
+			this.focusActiveTab()
 		},
 
 		/**
@@ -159,7 +168,7 @@ export default {
 			if (this.currentTabIndex < this.tabs.length - 1) {
 				this.setActive(this.tabs[this.currentTabIndex + 1].id)
 			}
-			this.focusActiveTab() // focus nav item
+			this.focusActiveTab()
 		},
 
 		/**
@@ -168,7 +177,7 @@ export default {
 		 */
 		focusFirstTab() {
 			this.setActive(this.tabs[0].id)
-			this.focusActiveTab() // focus nav item
+			this.focusActiveTab()
 		},
 
 		/**
@@ -177,7 +186,7 @@ export default {
 		 */
 		focusLastTab() {
 			this.setActive(this.tabs[this.tabs.length - 1].id)
-			this.focusActiveTab() // focus nav item
+			this.focusActiveTab()
 		},
 
 		/**
@@ -210,7 +219,7 @@ export default {
 		/**
 		 * Register child tab in the tabs
 		 *
-		 * @param {object} tab - tab props (only the "id" is used actually)
+		 * @param {object} tab child tab passed to slot
 		 */
 		registerTab(tab) {
 			this.tabs.push(tab)
@@ -226,9 +235,9 @@ export default {
 		},
 
 		/**
-		 * Unregister child tab in the tabs
+		 * Unregister child tab from the tabs
 		 *
-		 * @param {string} id - tab's id
+		 * @param {string} id tab's id
 		 */
 		unregisterTab(id) {
 			const tabIndex = this.tabs.findIndex((tab) => tab.id === id)

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -33,6 +33,8 @@
 			@keydown.left.exact.prevent="focusPreviousTab"
 			@keydown.right.exact.prevent="focusNextTab"
 			@keydown.tab.exact.prevent="focusActiveTabContent"
+			@keydown.home.exact.prevent="focusFirstTab"
+			@keydown.end.exact.prevent="focusLastTab"
 			@keydown.33.exact.prevent="focusFirstTab"
 			@keydown.34.exact.prevent="focusLastTab">
 			<ul>
@@ -43,7 +45,7 @@
 						:class="{ active: activeTab === tab.id }"
 						:data-id="tab.id"
 						:href="`#tab-${tab.id}`"
-						:tabindex="activeTab === tab.id ? undefined : -1"
+						:tabindex="activeTab === tab.id ? 0 : -1"
 						role="tab"
 						@click.prevent="setActive(tab.id)">
 						<span class="app-sidebar-tabs__tab-icon">

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -35,6 +35,7 @@
 		<h3 class="hidden-visually">
 			{{ name }}
 		</h3>
+		<!-- @slot Tab panel content -->
 		<slot />
 	</section>
 </template>
@@ -52,14 +53,26 @@ export default {
 			type: String,
 			required: true,
 		},
+
+		/**
+		 * Tab title in navigation
+		 */
 		name: {
 			type: String,
 			required: true,
 		},
+
+		/**
+		 * Tab icon's html class in navigation. Used if #icon slot is not provided
+		 */
 		icon: {
 			type: String,
 			default: '',
 		},
+
+		/**
+		 * Tab order in navigation. If not provided, name is used.
+		 */
 		order: {
 			type: Number,
 			default: 0,
@@ -74,16 +87,24 @@ export default {
 	expose: ['id', 'name', 'icon', 'order', 'renderIcon'],
 
 	computed: {
+		/**
+		 * Is the current tab an active tab, that should be shown?
+		 *
+		 * @return {boolean}
+		 */
 		isActive() {
 			return this.getActiveTab() === this.id
 		},
 	},
 
 	created() {
+		// As the tab is created - register it in the tabs component
+		// It's better to provide computed tab object, not component instance as it easy
 		this.registerTab(this)
 	},
 
 	beforeDestroy() {
+		// Unregister the tab from tabs
 		this.unregisterTab(this.id)
 	},
 
@@ -93,9 +114,14 @@ export default {
 			if (this.$el.scrollHeight - this.$el.scrollTop === this.$el.clientHeight) {
 				/**
 				 * Bottom scroll is reached
+				 *
+				 * @property {Event} event Native scroll event
 				 */
 				this.$emit('bottom-reached', event)
 			}
+			/**
+			 * @property {Event} event Native scroll event
+			 */
 			this.$emit('scroll', event)
 		},
 

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -40,8 +40,12 @@
 </template>
 
 <script>
+import { h } from 'vue'
+
 export default {
 	name: 'NcAppSidebarTab',
+
+	inject: ['registerTab', 'unregisterTab', 'getActiveTab'],
 
 	props: {
 		id: {
@@ -67,11 +71,20 @@ export default {
 		'scroll',
 	],
 
+	expose: ['id', 'name', 'icon', 'order', 'renderIcon'],
+
 	computed: {
-		// TODO: implement a better way to force pass a prop fromm Sidebar
 		isActive() {
-			return this.$parent.activeTab === this.id
+			return this.getActiveTab() === this.id
 		},
+	},
+
+	created() {
+		this.registerTab(this)
+	},
+
+	beforeDestroy() {
+		this.unregisterTab(this.id)
 	},
 
 	methods: {
@@ -84,6 +97,15 @@ export default {
 				this.$emit('bottom-reached', event)
 			}
 			this.$emit('scroll', event)
+		},
+
+		/**
+		 * Render tab's icon from slot or icon prop
+		 *
+		 * @return {import('vue').VNode|import('vue').VNode[]}
+		 */
+		renderIcon() {
+			return this.$slots.icon || this.$scopedSlots.icon?.() || h('span', { staticClass: this.icon })
 		},
 	},
 }

--- a/tests/unit/components/NcAppSidebar/NcAppSidebarTabs.spec.js
+++ b/tests/unit/components/NcAppSidebar/NcAppSidebarTabs.spec.js
@@ -189,23 +189,4 @@ describe('NcAppSidebarTabs.vue', () => {
 			})
 		})
 	})
-	describe('when tabs and other elements are mixed', () => {
-		it('Issues a warning and logs to console .', () => {
-			mount(NcAppSidebarTabs, {
-				slots: {
-					default: [
-						'<nc-app-sidebar-tab id="1" icon="icon-details" name="Tab1">Tab1</nc-app-sidebar-tab>',
-						'<NcAppSidebarTab id="2" icon="icon-details" name="Tab2">Tab2</NcAppSidebarTab>',
-						'<div>Non-tab-content</div>',
-						'Test',
-					],
-				},
-				stubs: {
-					NcAppSidebarTab,
-				},
-			})
-			expect(onWarning).toHaveBeenCalledTimes(1)
-			expect(consoleDebug).toHaveBeenCalledTimes(2)
-		})
-	})
 })


### PR DESCRIPTION
Fixes: #3461

Currently, `NcAppSidebarTabs` gets content passed slot, goes throw all nodes, and detects `NcAppSidebarTab` instances. But it happened once on mounted and does not support tabs update.

In this solution:
1. `NcAppSidebarTabs` provides:
   - `registerTab` method
   - `unregisterTab` method
   - `activeTab` property (replacement for `$parent`), could be reverted
2. All `NcAppSidebarTab` register and unregister themself on `created` and `beforeDestroy`
3. After registration `NcAppSidebarTabs` has the tab's data directly from the `NcAppSidebarTab`s

Sorting works the same way it was before. But there is no warnings if a user passes not-tabs as content.

This solution is fully compatible with Vue 3 as it is and Composition API.

![1](https://user-images.githubusercontent.com/25978914/225331451-c4b0f99f-9307-4252-85b3-8199f290d0e0.gif)

![2](https://user-images.githubusercontent.com/25978914/225331481-df7036d3-570e-4a0d-9bed-77a4e6ccd849.gif)
