### PR TITLE
Fix missing NcVNodes import in NcListItem

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -304,6 +304,7 @@
 <script>
 import NcActions from '../NcActions/index.js'
 import NcCounterBubble from '../NcCounterBubble/index.js'
+import NcVNodes from '../NcVNodes/index.js'
 import { t } from '../../l10n.js'
 
 export default {
@@ -312,6 +313,7 @@ export default {
 	components: {
 		NcActions,
 		NcCounterBubble,
+		NcVNodes,
 	},
 
 	props: {


### PR DESCRIPTION
@raimund-schluessler When using `NcListItem` in https://github.com/julien-nc/integration_miro/blob/main/src/components/talk/SendModal.vue#L31-L49 we get this error:

![image](https://user-images.githubusercontent.com/11291457/226337463-abff780e-6420-4f6d-97a5-ebffd1558a73.png)

This appeared with `@nextcloud/vue` 7.8.1.

If I'm right about the fix, this PR might need some more changes to deal with the undefined `router-link` in `<component :is="to ? 'router-link' : 'NcVNodes'"`