### PR TITLE
fix(NcRichContenteditable): Fix tribute opening and eating input after pasting text

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -488,13 +488,13 @@ export default {
 			// If no selection, replace the whole data
 			if (!selection.rangeCount) {
 				this.updateValue(html)
+				return
 			}
 
 			// Generate text and insert
-			const text = this.parseContent(html)
 			const range = selection.getRangeAt(0)
 			selection.deleteFromDocument()
-			range.insertNode(document.createTextNode(text))
+			range.insertNode(document.createTextNode(html))
 
 			// Put cursor at the end of the selection
 			const newRange = document.createRange()


### PR DESCRIPTION
Pasting content will pop up tribute automatically,
when the message starts with a trigger

	: for emojis
	@ for mentions
	/ for link picker

So we detach tribute before pasting and then
attach it again afterwards, so the opened tribute
doesn't eat the rest of your message until you press
Enter and just "autocomplete" the tribute that has
been actively hanging in the top left of the screen

Fix #3913 

Based on top of #3915 as it is in the same lines