### PR TITLE
fix(NcRichContenteditable): prevent tribute from opening on keyup

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -139,7 +139,8 @@ export default {
 		@keydown.delete="onDelete"
 		@keydown.enter.exact="onEnter"
 		@keydown.ctrl.enter.exact.stop.prevent="onCtrlEnter"
-		@paste="onPaste" />
+		@paste="onPaste"
+		@keyup.stop.prevent.capture="onKeyUp" />
 </template>
 
 <script>
@@ -619,6 +620,10 @@ export default {
 		debouncedAutoComplete: debounce(async function(search, callback) {
 			this.autoComplete(search, callback)
 		}, 100),
+
+		onKeyUp(event) {
+			// prevent tribute from opening on keyup
+		},
 	},
 }
 </script>


### PR DESCRIPTION
Tribute is listening to keyup, but we don't need this.

### How to reproduce:
1. Start writing a completion `@al`
2. Cancel with Escape
3. Paste a sentence starting with a space ` Lorep Ipsum`
4. See the tribute opening on the top left of the screen

### Alternative way of reproducing the issue:
1. Paste some string starting with a valid mention like `@all lorem ipsum`
4. See the tribute opening on the top left of the screen

### Now:
- The tribute popup does not opens