### PR TITLE
Add `aria-hidden` to icon of empty content

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -84,7 +84,7 @@ export default {
 
 <template>
 	<div class="empty-content" role="note">
-		<div v-if="$slots.icon" class="empty-content__icon">
+		<div v-if="$slots.icon" class="empty-content__icon" aria-hidden="true">
 			<!-- @slot Optional material design icon -->
 			<slot name="icon" />
 		</div>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/37325

No visual changes. Add `aria-hidden="true"` to icon slot because an icon have only decorative purposes in all cases.