### PR TITLE
Fix styles inheritance in `NcAvatar` when being mounted

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -617,7 +617,7 @@ export default {
 		 * @return {string}
 		 */
 		avatarUrlGenerator(user, size) {
-			const darkTheme = window.getComputedStyle(this.$el)
+			const darkTheme = window.getComputedStyle(document.body)
 				.getPropertyValue('--background-invert-if-dark') === 'invert(100%)'
 			let url = '/avatar/{user}/{size}' + (darkTheme ? '/dark' : '')
 			if (this.isGuest) {


### PR DESCRIPTION
Fix #3877 and fix https://github.com/nextcloud/spreed/issues/8625

Apply similar solution to what we have in https://github.com/nextcloud/nextcloud-vue/pull/3707: at the moment of mounting component we can't rely on styles, generated by `this.$el`, so it's better to refer to `document.body`, where we have rules for dark / light themes

