### PR TITLE
Add `aria-hidden` to icons of different components

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -190,6 +190,7 @@ export default {
 			<slot name="icon">
 				<span :class="[isIconUrl ? 'action-button__icon--url' : icon]"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
+					:aria-hidden="ariaHidden"
 					class="action-button__icon" />
 			</slot>
 
@@ -238,6 +239,13 @@ export default {
 		disabled: {
 			type: Boolean,
 			default: false,
+		},
+		/**
+		 * aria-hidden attribute for the icon slot
+		 */
+		ariaHidden: {
+			type: Boolean,
+			default: null,
 		},
 	},
 	computed: {

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -132,6 +132,7 @@ For the multiselect component, all events will be passed through. Please see the
 				<slot name="icon">
 					<span :class="[isIconUrl ? 'action-input__icon--url' : icon]"
 						:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
+						:aria-hidden="ariaHidden"
 						class="action-input__icon" />
 				</slot>
 			</span>
@@ -340,6 +341,13 @@ export default {
 		ariaLabel: {
 			type: String,
 			default: '',
+		},
+		/**
+		 * aria-hidden attribute for the icon slot
+		 */
+		ariaHidden: {
+			type: Boolean,
+			default: null,
 		},
 	},
 

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -62,6 +62,7 @@ export default {
 			<slot name="icon">
 				<span :class="[isIconUrl ? 'action-link__icon--url' : icon]"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
+					:aria-hidden="ariaHidden"
 					class="action-link__icon" />
 			</slot>
 
@@ -139,6 +140,13 @@ export default {
 		 */
 		title: {
 			type: String,
+			default: null,
+		},
+		/**
+		 * aria-hidden attribute for the icon slot
+		 */
+		ariaHidden: {
+			type: Boolean,
 			default: null,
 		},
 	},

--- a/src/components/NcActionText/NcActionText.vue
+++ b/src/components/NcActionText/NcActionText.vue
@@ -29,6 +29,7 @@
 			<slot name="icon">
 				<span v-if="icon !== ''"
 					:class="[isIconUrl ? 'action-text__icon--url' : icon]"
+					:aria-hidden="ariaHidden"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
 					class="action-text__icon" />
 			</slot>

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -620,6 +620,14 @@ export default {
 		},
 
 		/**
+		 * aria-hidden attribute for the icon slot
+		 */
+		ariaHidden: {
+			type: Boolean,
+			default: null,
+		},
+
+		/**
 		 * Wanted direction of the menu
 		 */
 		placement: {
@@ -946,6 +954,7 @@ export default {
 						// If it has a title, we use a secondary button
 						type: this.type || (title ? 'secondary' : 'tertiary'),
 						disabled: this.disabled || action?.componentOptions?.propsData?.disabled,
+						ariaHidden: this.ariaHidden,
 						...action?.componentOptions?.propsData,
 					},
 					directives: [{
@@ -1030,6 +1039,7 @@ export default {
 						props: {
 							type: this.triggerBtnType,
 							disabled: this.disabled,
+							ariaHidden: this.ariaHidden,
 						},
 						slot: 'trigger',
 						ref: 'menuButton',

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -287,6 +287,13 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * aria-hidden attribute for the icon slot
+		 */
+		ariaHidden: {
+			type: Boolean,
+			default: null,
+		},
 	},
 
 	/**
@@ -345,7 +352,16 @@ export default {
 			},
 			[
 				h('span', { class: 'button-vue__wrapper' }, [
-					hasIcon ? h('span', { class: 'button-vue__icon' }, [this.$slots.icon]) : null,
+					hasIcon
+						? h('span', {
+							class: 'button-vue__icon',
+							attrs: {
+								'aria-hidden': this.ariaHidden,
+							},
+						},
+						[this.$slots.icon],
+						)
+						: null,
 					hasText ? h('span', { class: 'button-vue__text' }, [text]) : null,
 				]),
 			]

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -54,6 +54,13 @@ export default {
 			type: String,
 			default: '',
 		},
+		/**
+		 * aria-hidden attribute for the icon slot
+		 */
+		ariaHidden: {
+			type: Boolean,
+			default: null,
+		},
 	},
 
 	emits: [


### PR DESCRIPTION
**Accessibility issue**

Fixes https://github.com/nextcloud/server/issues/36909

Add `aria-hidden` attributes for decorative icons for all components from weather menu:

![Screenshot from 2023-03-28 09-52-14](https://user-images.githubusercontent.com/6078378/228166984-da9069cf-cc80-419c-8ee1-acc4d1861d2f.png)

