### PR TITLE
Fix NcRichText style

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -238,6 +238,8 @@ export default {
 }
 </script>
 <style scoped>
+@import './richtext.scss';
+
 a:not(.rich-text--component) {
 	text-decoration: underline;
 }

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -238,6 +238,7 @@ export default {
 }
 </script>
 <style scoped>
+/* stylelint-disable-next-line scss/at-import-partial-extension */
 @import './richtext.scss';
 
 a:not(.rich-text--component) {

--- a/src/components/NcRichText/placeholder.js
+++ b/src/components/NcRichText/placeholder.js
@@ -44,9 +44,11 @@ export const prepareTextNode = ({ h, context }, text) => {
 				return entry
 			}
 			const { component, props } = entry
+			// do not override class of NcLink
+			const componentClass = component.name === 'NcLink' ? undefined : 'rich-text--component'
 			return h(component, {
 				props,
-				class: 'rich-text--component',
+				class: componentClass,
 			})
 		})
 	}


### PR DESCRIPTION
@juliushaertl We missed something when moving `RichText` in here as `NcRichText`.
The `richtext.scss` file is not used anymore. It had to be imported separately when `RichText` was used.
We could now simply import it in `NcRichText`.

@raimund-schluessler No problem with importing it, right?

Another problem raised in https://github.com/nextcloud/spreed/issues/9163 is that links have the `rich-text--component` class and they apparently used to have the `rich-text--external-link` (with `useMarkdown` set to false). This leads to them not being underlined anymore.
@juliushaertl Apparently this appeared after `@nextcloud/vue-richtext` v2.0.4. Does it ring a bell? Any intentional change in the link class?

Fix nextcloud/spreed#9163