### PR TITLE
fix(NcRichText): Match IP addresses as links

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -39,6 +39,8 @@ export default {
 		return {
 			text: `Hello {username}. The file {file} was added by {username}. Go visit https://nextcloud.com
 
+Local IP: http://127.0.0.1/status.php should be clickable
+
 Some examples for markdown syntax: **bold text** *italic text* ~~strikethrough~~`,
 			autolink: true,
 			useMarkdown: true,

--- a/src/components/NcRichText/helpers.js
+++ b/src/components/NcRichText/helpers.js
@@ -1,4 +1,16 @@
+/**
+ * Regex pattern to match links to be resolved by the link-reference provider
+ *
+ * @type {RegExp}
+ */
 export const URL_PATTERN = /(\s|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|$)/ig
 
-// FIXME See if we can merge those two
-export const URL_PATTERN_AUTOLINK = /(\s|\(|^)((https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?::[0-9]+)?(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*))(?=\s|\)|$)/ig
+/**
+ * Regex pattern to identify strings as links and then making them clickable
+ * Opposed to the above regex this one also matches IP addresses, which we would like to be clickable,
+ * but in general resolving references for them might mostly not work,
+ * as the link provider checks for local addresses and does not resolve them.
+ *
+ * @type {RegExp}
+ */
+export const URL_PATTERN_AUTOLINK = /(\s|\(|^)((https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z0-9]+(?::[0-9]+)?(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*))(?=\s|\)|$)/ig

--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -152,6 +152,17 @@ describe('Foo', () => {
 		expect(wrapper.find('a').attributes('href')).toEqual('https://example.com:444')
 	})
 
+	it('properly recognizes an url with an IP address and inserts a link', async() => {
+		const wrapper = mount(NcRichText, {
+			propsData: {
+				text: 'Testwith a link to https://127.0.0.1/status.php - go visit it',
+				autolink: true
+			}
+		})
+		expect(wrapper.text()).toEqual('Testwith a link to https://127.0.0.1/status.php - go visit it')
+		expect(wrapper.find('a').attributes('href')).toEqual('https://127.0.0.1/status.php')
+	})
+
 	it('properly formats markdown', async() => {
 		const wrapper = mount(NcRichText, {
 			propsData: {


### PR DESCRIPTION
Fix https://github.com/nextcloud/spreed/issues/9187

Before | After
---|---
![Bildschirmfoto vom 2023-03-28 12-31-20](https://user-images.githubusercontent.com/213943/228208969-1a0f88a6-2f65-4605-88f4-9e5513b2eb1f.png) | ![Bildschirmfoto vom 2023-03-28 12-31-27](https://user-images.githubusercontent.com/213943/228208976-535789de-df89-4b21-b5ee-cf41b7835c9e.png)
