### PR TITLE
fix(NcRichContenteditable): Completely stop event propagation for keyup events

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -660,6 +660,7 @@ export default {
 
 		onKeyUp(event) {
 			// prevent tribute from opening on keyup
+			event.stopImmediatePropagation()
 		},
 	},
 }


### PR DESCRIPTION
### Steps

1. Open http://localhost:6060/#/Components/NcRichContenteditable
2. Paste `@Test01 or inserting emoji` into the input
3. Check that there is no dangeling Tribute in the top left

![grafik](https://user-images.githubusercontent.com/213943/228217193-8bd0ed5b-5b62-4d97-a4b6-d4d73ce24dc6.png)

Seems there was yet another event triggering the tribute.

With the given modification the problem does not occur anymore.

Seems that preventDefault() (from vue `.prevent`) is not enough.
