### PR TITLE
chore(release): Bump version to 7.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.8.5](https://github.com/nextcloud/nextcloud-vue/tree/v7.8.5) (2023-03-28)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.8.4...v7.8.5)
+
+### :bug: Fixed bugs
+
+- fix\(NcRichContenteditable\): Completely stop event propagation for keyup events [\#3937](https://github.com/nextcloud/nextcloud-vue/pull/3937) ([nickvergessen](https://github.com/nickvergessen))
+- fix\(NcRichText\): Match IP addresses as links [\#3935](https://github.com/nextcloud/nextcloud-vue/pull/3935) ([nickvergessen](https://github.com/nickvergessen))
+- fix\(NcRichText\): Fix NcRichText style [\#3932](https://github.com/nextcloud/nextcloud-vue/pull/3932) ([julien-nc](https://github.com/julien-nc))
+
 ## [v7.8.4](https://github.com/nextcloud/nextcloud-vue/tree/v7.8.4) (2023-03-24)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.8.3...v7.8.4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.8.4",
+	"version": "7.8.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.8.4",
+			"version": "7.8.5",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.8.4",
+	"version": "7.8.5",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION

## [v7.8.5](https://github.com/nextcloud/nextcloud-vue/tree/v7.8.5) (2023-03-28)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.8.4...v7.8.5)

### :bug: Fixed bugs

- fix\(NcRichContenteditable\): Completely stop event propagation for keyup events [\#3937](https://github.com/nextcloud/nextcloud-vue/pull/3937) ([nickvergessen](https://github.com/nickvergessen))
- fix\(NcRichText\): Match IP addresses as links [\#3935](https://github.com/nextcloud/nextcloud-vue/pull/3935) ([nickvergessen](https://github.com/nickvergessen))
- fix\(NcRichText\): Fix NcRichText style [\#3932](https://github.com/nextcloud/nextcloud-vue/pull/3932) ([julien-nc](https://github.com/julien-nc))
