### PR TITLE
Add additionalTrapElements prop to settingsDialog

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -123,6 +123,15 @@ export default {
 			type: String,
 			default: '',
 		},
+
+		/**
+		 * Additional elements to add to the focus trap
+		 */
+		additionalTrapElements: {
+			type: Array,
+			default: () => [],
+		},
+
 	},
 
 	emits: ['update:open'],
@@ -311,6 +320,7 @@ export default {
 				attrs: {
 					container: this.container,
 					size: 'large',
+					additionalTrapElements: this.additionalTrapElements,
 				},
 				on: {
 					close: () => { this.handleCloseModal() },


### PR DESCRIPTION
In the photos app the file picker inside of NcAppSettingsDialog loses focus because it's appended to the body

reproduction: 

1. open the photos app
2. go to photos settings 
3. try changing the photos directory 
4. Navigate with tab or try adding a new folder 
