### PR TITLE
Fix native open in a new tab in components with a custom router link

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -642,13 +642,23 @@ export default {
 			this.$emit('update:open', this.opened)
 		},
 
-		// forward click event
+		/**
+		 * Handle link click
+		 *
+		 * @param {PointerEvent} event - Native click event
+		 * @param {Function} [navigate] - VueRouter link's navigate if any
+		 * @param {string} [routerLinkHref] - VueRouter link's href
+		 */
 		onClick(event, navigate, routerLinkHref) {
-			// Navigate is only defined if it is a router-link
-			navigate?.(event)
+			// Always forward native event
 			this.$emit('click', event)
-			// Prevent default link behaviour if it's a router-link
+			// Do not navigate with control keys - it is opening in a new tab
+			if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+				return
+			}
+			// Prevent default link behaviour if it's a router-link and navigate manually
 			if (routerLinkHref) {
+				navigate?.(event)
 				event.preventDefault()
 			}
 		},

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -494,14 +494,23 @@ export default {
 	},
 
 	methods: {
-
-		// forward click event
+		/**
+		 * Handle link click
+		 *
+		 * @param {PointerEvent} event - Native click event
+		 * @param {Function} [navigate] - VueRouter link's navigate if any
+		 * @param {string} [routerLinkHref] - VueRouter link's href
+		 */
 		onClick(event, navigate, routerLinkHref) {
-			// Navigate is only defined if it is a router-link
-			navigate?.(event)
+			// Always forward native event
 			this.$emit('click', event)
-			// Prevent default link behaviour if it's a router-link
+			// Do not navigate with control keys - it is opening in a new tab
+			if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+				return
+			}
+			// Prevent default link behaviour if it's a router-link and navigate manually
 			if (routerLinkHref) {
+				navigate?.(event)
 				event.preventDefault()
 			}
 		},


### PR DESCRIPTION
## Expected behavior

`Ctrl+Click`, `Shift+Click` and etc. on a link in `NcListItem` and `NcAppNavigationitem` opens the link in a new tab.

## Actual behavior

Nothing happened

## Problem description

In `NcListItem` and `NcAppNavigationitem` when the item is a `RouterLink`, navigation after a click is handled manually, while default behavior stops with `event.preventDefault()`.

It breaks a native web-browser behavior - the ability to open a link in a new tab by combining a Click with a modifier key, for example, `Ctrl+Click`.

This PR checks if modifiers are pressed before the manual navigation and preventing default behavior.

Regression of: https://github.com/nextcloud/nextcloud-vue/pull/3775

Continue of: https://github.com/nextcloud/nextcloud-vue/pull/3922

Related: https://github.com/nextcloud/talk-desktop/issues/104
