### PR TITLE
Add placeholder for heading inside of app content

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -72,6 +72,10 @@ The list size must be between the min and the max width value.
 
 <template>
 	<main id="app-content-vue" class="app-content no-snapper" :class="{ 'app-content--has-list': hasList }">
+		<h1 v-if="pageHeading" class="hidden-visually">
+			{{ pageHeading }}
+		</h1>
+
 		<template v-if="hasList">
 			<!-- Mobile view does not allow resizeable panes -->
 			<div v-if="isMobile"
@@ -191,6 +195,14 @@ export default {
 		showDetails: {
 			type: Boolean,
 			default: true,
+		},
+
+		/**
+		 * Specify the `<h1>` page heading
+		 */
+		pageHeading: {
+			type: String,
+			default: null,
 		},
 	},
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36911

## Summary

Add a possibility for providing a heading for `NcAppContent`.

Move `<h1>` heading in the <main> landmark instead of the `<header>`.
By jumping directly to the h1 heading the user would be able to navigate through the main content of the page immediately.
See https://github.com/nextcloud/server/issues/36911#issuecomment-1492439336

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-04-05 10-47-51](https://user-images.githubusercontent.com/6078378/230030511-7eb2b4a4-dbe3-4732-b4f8-ac58e674a3db.png) |![Screenshot from 2023-04-05 10-42-58](https://user-images.githubusercontent.com/6078378/230029271-35e8dc5a-c658-4074-9821-808699becd3c.png)

All apps which are using Vue for main content rendering are overriding `<main>` content from https://github.com/nextcloud/server/blob/master/core/templates/layout.user.php#L91-L93. Because of it it is important to provide a possibility to place a heading in a right place.