### PR TITLE
Fix : Disable hover behaviour on quota information

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -747,6 +747,18 @@ export default {
 		flex-wrap: wrap;
 		box-sizing: border-box;
 		width: 100%;
+		
+		&.app-navigation-entry__settings-quota {
+			.app-navigation-entry:hover {
+				background-color: transparent;
+				a {
+					cursor: default;
+					* {
+					cursor: default;
+					}
+				}
+			}
+		}
 
 		&.app-navigation-entry--collapsible:not(.app-navigation-entry--opened) > ul {
 			// NO ANIMATE because if not really hidden, we can still tab through it


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Disables background color and pointer cursor while hovering this area with mouse.

![2023-04-05_15-07](https://user-images.githubusercontent.com/33763786/230089608-aee2c544-0a42-4a10-a659-db17296dbfc5.png)
