### PR TITLE
Remove the smart picker modal padding

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -153,7 +153,6 @@ export default {
 
 <style lang="scss" scoped>
 .reference-picker-modal--content {
-	padding: 12px 16px 16px 16px;
 	width: 100%;
 	display: flex;
 	flex-direction: column;
@@ -175,7 +174,7 @@ export default {
 
 	> h2 {
 		display: flex;
-		margin-bottom: 20px;
+		margin: 12px 0 20px 0;
 		.icon {
 			margin-right: 8px;
 		}

--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -1,8 +1,8 @@
 <template>
-	<div class="search" :class="{ 'with-empty-content': showEmptyContent }">
+	<div class="smart-picker-search" :class="{ 'with-empty-content': showEmptyContent }">
 		<NcMultiselect ref="search-select"
 			v-model="selectedResult"
-			class="search--select"
+			class="smart-picker-search--select"
 			track-by="resourceUrl"
 			:placeholder="mySearchPlaceholder"
 			:options="options"
@@ -52,7 +52,7 @@
 			</template>
 		</NcMultiselect>
 		<NcEmptyContent v-if="showEmptyContent"
-			class="search--empty-content">
+			class="smart-picker-search--empty-content">
 			<template #icon>
 				<img v-if="provider.icon_url"
 					class="provider-icon"
@@ -273,10 +273,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.search {
+.smart-picker-search {
 	width: 100%;
 	display: flex;
 	flex-direction: column;
+	padding: 0 16px 16px 16px;
 	&.with-empty-content {
 		min-height: 350px;
 	}


### PR DESCRIPTION
* Remove it to let custom picker components set it if needed.
* Adjust the padding of the generic search.
* Make one class more explicit

This allows, for example, custom picker components that have infinite scrolling (like the Giphy integration one) to remove bottom padding/margin which looks better.

As we can't make sure nextcloud/vue is updated everywhere at once and all the providers are adjusted (I'll make sure most of them are :grin: ), we might temporarily have:
* double padding with adjusted providers displayed in apps using an old nextcloud/vue release
* no padding at all for old providers displayed in apps using a nextcloud/vue release which includes those changes

Not that bad IMO.