### PR TITLE
Don't overwrite router-link href in NcBreadcrumb

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -42,7 +42,7 @@ This component is meant to be used inside a Breadcrumbs component.
 		<component :is="tag"
 			v-if="(nameTitleFallback || icon) && !$slots.default"
 			:title="title"
-			v-bind="{ ...$attrs, ...to && { to, exact }, ...!to && { href } }"
+			v-bind="linkAttributes"
 			v-on="$listeners">
 			<!-- @slot Slot for passing a material design icon. Precedes the icon and title prop. -->
 			<slot name="icon">
@@ -200,6 +200,14 @@ export default {
 		 */
 		tag() {
 			return this.to ? 'router-link' : 'a'
+		},
+
+		/**
+		 * The attributes to pass to `router-link` or `a`
+		 */
+		linkAttributes() {
+			// If it's a router-link, we pass `to` and `exact`, otherwise only `href`
+			return this.to ? { to: this.to, exact: this.exact, ...this.$attrs } : { href: this.href, ...this.$attrs }
 		},
 	},
 	methods: {

--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -41,11 +41,8 @@ This component is meant to be used inside a Breadcrumbs component.
 		@dragleave="dragLeave">
 		<component :is="tag"
 			v-if="(nameTitleFallback || icon) && !$slots.default"
-			:exact="exact"
-			:to="to"
-			:href="href"
 			:title="title"
-			v-bind="$attrs"
+			v-bind="{ ...$attrs, ...to && { to, exact }, ...!to && { href } }"
 			v-on="$listeners">
 			<!-- @slot Slot for passing a material design icon. Precedes the icon and title prop. -->
 			<slot name="icon">


### PR DESCRIPTION
We currently wrongfully overwrite the `href` attribute of the `router-link` in `NcBreadcrumb` with the default `href` prop value. This makes the link rendered by `router-link` to not have its `href` attribute correctly set, which prevents the default link behavior. Navigating still works though, so I guess this is why we didn't notice yet. This PR fixes it by only setting the `href` attribute from the prop if it's not a `router-link`.