### PR TITLE
fix(NcHeaderMenu): fix unnecessary filter invert

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -295,8 +295,8 @@ $externalMargin: 8px;
 		opacity: .85;
 
 		// header is filled with primary or image background
-		filter: var(--background-image-invert-if-bright);
-		color: #fff !important;
+		filter: none !important;
+		color: var(--color-primary-text) !important;
 	}
 
 	&--opened &__trigger,


### PR DESCRIPTION
- This was here for legacy menus that were still using icon classes
- Because this is a vue component, it means apps using it are already using svg (notifications, settings menu, contacts menu, search... etc) 

This also fixes the weird avatar invert bug
Fix https://github.com/nextcloud/server/issues/37379