### PR TITLE
Split Bootstrap version reference in Tooltip .scss

### DIFF
--- a/src/directives/Tooltip/index.scss
+++ b/src/directives/Tooltip/index.scss
@@ -5,7 +5,8 @@
 * @copyright Copyright (c) 2016, Erik Pellikka <erik@pellikka.org>
 * @copyright Copyright (c) 2015, Vincent Petry <pvince81@owncloud.com>
 *
-* Bootstrap v3.3.5 (http://getbootstrap.com)
+* Bootstrap (http://getbootstrap.com)
+* SCSS copied from version 3.3.5
 * Copyright 2011-2015 Twitter, Inc.
 * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
 */


### PR DESCRIPTION
Equivalent of https://github.com/nextcloud/server/pull/35485 for nextcloud-vue

Bootstrap 3.3.5 has XSS vulnerabilities and some security scanners report that Nextcloud is using a vulnerable dependency. However, this is a false positive, as only some SCSS from that version is included ([originally in server](https://github.com/nextcloud/server/commit/1c128e93913caa350be3c4274c73b28eaddc6a90), then [in nextcloud-vue](https://github.com/nextcloud/nextcloud-vue/commit/026a5f05fe616bb8dbc5d21b41aa1eba06bd270e#diff-d176069cb5022ae4bd2f74e41e25845de1291330544cb0c335bdd71a36b9135d)) and nothing can be exploited.

It seems that the scanners [just look for the version string instead of actually checking the vulnerability](https://www.tenable.com/plugins/was/112373), so the version reference was split to avoid that (although the version is not simply removed to keep the proper copyright assignment).

Note that to get rid of the [`Bootstrap v3.3.5` string in Nextcloud server](https://raw.githubusercontent.com/nextcloud/server/5aab2bb41d6f81aed032e23195bf3e843fb1abb2/dist/core-common.js) it will be needed to also release new versions of:
- [`nextcloud-vue-dashboard`](https://github.com/nextcloud/server/blob/5aab2bb41d6f81aed032e23195bf3e843fb1abb2/package.json#L57) (latest release, [2.0.1, uses nextcloud-vue 3.9.0](https://github.com/nextcloud/nextcloud-vue-dashboard/blob/v2.0.1/package-lock.json#L5455-L5456))
- [`nextcloud-vue-collections`](https://github.com/nextcloud/server/blob/5aab2bb41d6f81aed032e23195bf3e843fb1abb2/package.json#L86) (latest release, [0.10.0, uses nextcloud-vue 3.10.2](https://github.com/nextcloud/nextcloud-vue-collections/blob/v0.10.0/package-lock.json#L3652-L3653)) 
- [`nextcloud-password-confirmation`](https://github.com/nextcloud/server/blob/5aab2bb41d6f81aed032e23195bf3e843fb1abb2/package.json#L52) (latest release, [4.0.4, uses nextcloud-vue 7.5.0](https://github.com/nextcloud/nextcloud-password-confirmation/blob/v4.0.4/package-lock.json#L602-L603)).