### PR TITLE
Fix inverted validate label check in NcInputField

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -34,7 +34,7 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 
 <template>
 	<div class="input-field">
-		<label v-if="!labelOutside && label !== undefined"
+		<label v-if="!labelOutside && isValidLabel"
 			class="input-field__label"
 			:class="{ 'input-field__label--hidden': !labelVisible }"
 			:for="computedId">
@@ -283,20 +283,13 @@ export default {
 				return this.hasPlaceholder ? this.placeholder : this.label
 			}
 		},
-	},
-
-	watch: {
-		label() {
-			this.validateLabel()
+		isValidLabel() {
+			const isValidLabel = this.label || this.labelOutside
+			if (!isValidLabel) {
+				console.warn('You need to add a label to the NcInputField component. Either use the prop label or use an external one, as per the example in the documentation.')
+			}
+			return isValidLabel
 		},
-
-		labelOutside() {
-			this.validateLabel()
-		},
-	},
-
-	created() {
-		this.validateLabel()
 	},
 
 	methods: {
@@ -306,12 +299,6 @@ export default {
 
 		handleTrailingButtonClick(event) {
 			this.$emit('trailing-button-click', event)
-		},
-
-		validateLabel() {
-			if (!this.label && !this.labelOutside) {
-				console.warn('You need to add a label to the NcInputField component. Either use the prop label or use an external one, as per the example in the documentation.')
-			}
 		},
 	},
 }

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -310,7 +310,7 @@ export default {
 
 		validateLabel() {
 			if (!this.label && !this.labelOutside) {
-				throw new Error('You need to add a label to the NcInputField component. Either use the prop label or use an external one, as per the example in the documentation.')
+				console.warn('You need to add a label to the NcInputField component. Either use the prop label or use an external one, as per the example in the documentation.')
 			}
 		},
 	},

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -305,8 +305,8 @@ export default {
 		},
 
 		validateLabel() {
-			if (this.label && !this.labelOutside) {
-				throw new Error('You need to add a label to the textField component. Either use the prop label or use an external one, as per the example in the documentation')
+			if (!this.label && !this.labelOutside) {
+				throw new Error('You need to add a label to the NcInputField component. Either use the prop label or use an external one, as per the example in the documentation.')
 			}
 		},
 	},

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -295,6 +295,10 @@ export default {
 		},
 	},
 
+	created() {
+		this.validateLabel()
+	},
+
 	methods: {
 		handleInput(event) {
 			this.$emit('update:value', event.target.value)


### PR DESCRIPTION
The `NcInputField` component currently warns about a missing label only if a label is provided and if the label changes during the lifetime of the component (which probably is the reason why no one noticed this yet). This PR fixes the inverted logic and runs the check on component creation as well. This might spawn quite a few warnings in the apps using this component, but I guess that's what this warning is for :shrug: 

As a side note, I would propose to change from `throw new Error` to `Vue.warn`, but that's a matter of taste, I guess.