### PR TITLE
Improve breadcrumbs accessibility

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -29,7 +29,7 @@ This component is meant to be used inside a Breadcrumbs component.
 </docs>
 
 <template>
-	<div ref="crumb"
+	<li ref="crumb"
 		class="vue-crumb"
 		:class="{'vue-crumb--hovered': hovering}"
 		:[crumbId]="''"
@@ -68,7 +68,7 @@ This component is meant to be used inside a Breadcrumbs component.
 			<slot />
 		</NcActions>
 		<ChevronRight class="vue-crumb__separator" :size="20" />
-	</div>
+	</li>
 </template>
 
 <script>

--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -523,6 +523,12 @@ export default {
 
 				props: this.menuBreadcrumbProps,
 
+				attrs: {
+					// Hide the dropdown menu from screen-readers,
+					// since the crumbs in the menu are still in the list.
+					'aria-hidden': true,
+				},
+
 				// Add a ref to the Actions menu
 				ref: 'actionsBreadcrumb',
 				key: 'actions-breadcrumb-1',
@@ -595,7 +601,7 @@ export default {
 			this.hideCrumbs(crumbs2, crumbs.length - 1)
 		}
 
-		const wrapper = [h('div', { class: 'breadcrumb__crumbs' }, crumbs)]
+		const wrapper = [h('nav', {}, [h('ul', { class: 'breadcrumb__crumbs' }, crumbs)])]
 		// Append the actions slot if it is populated
 		if (this.$slots.actions) {
 			wrapper.push(h('div', { class: 'breadcrumb__actions', ref: 'breadcrumb__actions' }, this.$slots.actions))


### PR DESCRIPTION
This improves the accessibility of `NcBreadcrumbs`:

- the bread crumbs are now wrapped in a `nav`
- the breadcrumbs are now a list, each crumb is a `li`
- the Action menu holding the hidden crumbs got an `aria-hidden` atrribute

Closes #3951.