### PR TITLE
Disable wrap on overflow

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1040,6 +1040,9 @@ body {
 				max-width: 100%;
 			}
 		}
+		.vs__selected-options {
+			flex-wrap: nowrap;
+		}
 	}
 }
 


### PR DESCRIPTION
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/24800714/233749373-9b7c748a-0134-4c9a-af8a-2ff25bf9dee5.png) | ![image](https://user-images.githubusercontent.com/24800714/233749381-d09b4afa-5760-499c-bc31-1b1db02e8320.png)

Keep the `input` and selected option on a single line