### PR TITLE
Use NcSelect in NcAppSidebar example

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -198,7 +198,7 @@ export default {
 ```vue
 <template>
 	<div>
-		<NcMultiselect v-model="active" :options="['search-tab', 'settings-tab', 'share-tab']" />
+		<NcSelect v-model="active" :options="['search-tab', 'settings-tab', 'share-tab']" />
 		<NcAppSidebar
 			title="cat-picture.jpg"
 			subtitle="last edited 3 weeks ago"


### PR DESCRIPTION
`NcMultiselect` is deprecated, we should not use it in the lib. No functional changes here, it only affects the docs. Ref #3743.