### PR TITLE
NcAppSidebarTabs: fix activating the tab being added

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -233,9 +233,7 @@ export default {
 				}
 				return a.order - b.order
 			})
-			if (!this.activeTab) {
-				this.updateActive()
-			}
+			this.updateActive()
 		},
 
 		/**


### PR DESCRIPTION
Fix: https://github.com/nextcloud/spreed/issues/9345

## Steps to reproduce

1. Add tabs `A`, `C` to `NcAppSidebarTabs`
2. Set active `B` add add tab `B`

## Actual behavior

New tab is added, but not active.

![Actual](https://user-images.githubusercontent.com/25978914/234133818-c8139ccd-aa7e-4dd7-9c43-805f11dd6eb5.gif)

## Expected behavior

New tab is added and active.

![Expected](https://user-images.githubusercontent.com/25978914/234133838-cb7b945a-2000-4ece-a16d-9d1b683018b6.gif)

## Fix

Local `activeTab` should be updated on each new tab registration. Previously it was updated only if it wasn't set before (I have no ideas, why).

## Manual testing example

It's a bit specific, I decided not to add it to the documentation.

```vue
<template>
	<div>
	        <button @click="active = 'settings-tab', showTabs[1] = true">Activate settings and add settings-tab</button>
		<NcCheckboxRadioSwitch :checked.sync="showTabs[0]">Show search tab</NcCheckboxRadioSwitch>
		<NcCheckboxRadioSwitch :checked.sync="showTabs[1]">Show settings tab</NcCheckboxRadioSwitch>
		<NcCheckboxRadioSwitch :checked.sync="showTabs[2]">Show sharing tab</NcCheckboxRadioSwitch>
		<NcAppSidebar
		        :active.sync="active"
			title="cat-picture.jpg"
			subtitle="last edited 3 weeks ago">
			<NcAppSidebarTab v-if="showTabs[0]" name="Search" id="search-tab">
				<template #icon>
					<Magnify :size="20" />
				</template>
				Search tab content
			</NcAppSidebarTab>
			<NcAppSidebarTab v-if="showTabs[1]" name="Settings" id="settings-tab">
				<template #icon>
					<Cog :size="20" />
				</template>
				Settings
			</NcAppSidebarTab>
			<NcAppSidebarTab v-if="showTabs[2]" name="Sharing" id="share-tab">
				<template #icon>
					<ShareVariant :size="20" />
				</template>
				Sharing tab content
			</NcAppSidebarTab>
		</NcAppSidebar>
	</div>
</template>
<script>
import Magnify from 'vue-material-design-icons/Magnify'
import Cog from 'vue-material-design-icons/Cog'
import ShareVariant from 'vue-material-design-icons/ShareVariant'

export default {
	components: {
		Magnify,
		Cog,
		ShareVariant,
	},
	data() {
		return {
		        active: '',
			showTabs: [true, true, false],
		}
	},
}
</script>
```