### PR TITLE
fix(NcAvatar): Use correct prop to track "open" aka. "shown" state

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -136,7 +136,7 @@ export default {
 		<NcPopover v-if="hasMenu"
 			placement="auto"
 			:container="menuContainer"
-			:open="contactsMenuOpenState"
+			:shown="contactsMenuOpenState"
 			@after-show="handlePopoverAfterShow"
 			@after-hide="handlePopoverAfterHide">
 			<NcPopoverMenu ref="popoverMenu" :menu="menu" />

--- a/src/components/NcDatetimePicker/NcDatetimePicker.vue
+++ b/src/components/NcDatetimePicker/NcDatetimePicker.vue
@@ -142,7 +142,7 @@ export default {
 		@update:value="$emit('update:value', value)">
 		<template #icon-calendar>
 			<NcPopover v-if="showTimezoneSelect"
-				:open.sync="showTimezonePopover"
+				:shown.sync="showTimezonePopover"
 				open-class="timezone-popover-wrapper">
 				<template #trigger>
 					<button class="datetime-picker-inline-icon"


### PR DESCRIPTION
It's a regression from the NcPopover update.

Can be reproduced by trying to open the avatar menu on https://nextcloud-vue-components.netlify.app/#/Components/NcAvatar at "Avatar with preloaded status" multiple times

Fix #4008 