### PR TITLE
Allow to override showTrailingButton from an NcAction

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -33,6 +33,11 @@ For the multiselect component, all events will be passed through. Please see the
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
+			<NcActionInput :value.sync="text" :show-trailing-button="false">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+			</NcActionInput>
 			<NcActionInput :value.sync="text">
 				<template #icon>
 					<Pencil :size="20" />
@@ -40,6 +45,12 @@ For the multiselect component, all events will be passed through. Please see the
 				This is the placeholder
 			</NcActionInput>
 			<NcActionInput type="password" :value.sync="text">
+				<template #icon>
+					<Key :size="20" />
+				</template>
+				Password placeholder
+			</NcActionInput>
+			<NcActionInput type="password" :value.sync="text" :show-trailing-button="false">
 				<template #icon>
 					<Key :size="20" />
 				</template>
@@ -191,7 +202,7 @@ For the multiselect component, all events will be passed through. Please see the
 								:disabled="disabled"
 								:input-class="{ focusable: isFocusable }"
 								trailing-button-icon="arrowRight"
-								:show-trailing-button="value !== '' && !disabled"
+								:show-trailing-button="showTrailingButton && value !== '' && !disabled"
 								v-bind="$attrs"
 								v-on="$listeners"
 								@trailing-button-click="$refs.form.requestSubmit()"
@@ -219,7 +230,7 @@ For the multiselect component, all events will be passed through. Please see the
 								:input-class="{ focusable: isFocusable }"
 								:type="type"
 								trailing-button-icon="arrowRight"
-								:show-trailing-button="value !== '' && !disabled"
+								:show-trailing-button="showTrailingButton && value !== '' && !disabled"
 								v-bind="$attrs"
 								v-on="$listeners"
 								@trailing-button-click="$refs.form.requestSubmit()"
@@ -348,6 +359,13 @@ export default {
 		ariaHidden: {
 			type: Boolean,
 			default: null,
+		},
+		/**
+		 * Attribute forwarded to the underlining NcPasswordField and NcTextField
+		 */
+		showTrailingButton: {
+			type: Boolean,
+			default: true,
 		},
 	},
 

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -97,7 +97,7 @@ export default {
 	<NcInputField v-bind="{...$attrs, ...$props }"
 		ref="inputField"
 		:type="isPasswordHidden ? 'password' : 'text'"
-		:show-trailing-button="true"
+		:show-trailing-button="showTrailingButton && true"
 		:trailing-button-label="trailingButtonLabelPassword"
 		:helper-text="computedHelperText"
 		:error="computedError"
@@ -180,6 +180,14 @@ export default {
 		maxlength: {
 			type: Number,
 			default: null,
+		},
+
+		/**
+		 * Controls whether to display the trailing button.
+		 */
+		showTrailingButton: {
+			type: Boolean,
+			default: true,
 		},
 	},
 


### PR DESCRIPTION
This would allow to not show the eye icon on sharing password field.

#### New `NcActionInput` examples: 

![Screenshot from 2023-04-27 14-37-29](https://user-images.githubusercontent.com/6653109/234864741-11dff1d2-63ab-40fd-9492-0b1978bf87ca.png)

#### Use case example in sharing (https://github.com/nextcloud/server/pull/37954):

Before | After
-- | --
![Screenshot from 2023-04-27 15-30-09](https://user-images.githubusercontent.com/6653109/234877245-330823b4-696d-4e6c-aa52-760c642d37ce.png) | ![Screenshot from 2023-04-27 14-59-48](https://user-images.githubusercontent.com/6653109/234877007-f43ab931-b90d-40f2-bf4c-dccdab0390ca.png)
![Screenshot from 2023-04-27 14-49-40](https://user-images.githubusercontent.com/6653109/234867327-0fa837b1-c88a-4028-b62a-94aff1e7675b.png) | ![Screenshot from 2023-04-27 14-59-52](https://user-images.githubusercontent.com/6653109/234876980-c52ac77e-4926-4b4c-ba0e-c76c189c5210.png)
![Screenshot from 2023-04-27 14-49-47](https://user-images.githubusercontent.com/6653109/234867320-64c60c46-d174-4e57-a90d-42ca3a93fa5a.png) | -