### PR TITLE
Add aria-hidden attr to the whole navigation depending on a sidebar state

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -59,15 +59,16 @@ emit('toggle-navigation', {
 		role="navigation"
 		:class="{'app-navigation--close':!open }">
 		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
-		<slot />
+		<div :aria-hidden="ariaHidden" class="app-navigation__content">
+			<slot />
+			<!-- List for Navigation li-items -->
+			<ul class="app-navigation__list">
+				<slot name="list" />
+			</ul>
 
-		<!-- List for Navigation li-items -->
-		<ul class="app-navigation__list">
-			<slot name="list" />
-		</ul>
-
-		<!-- Footer for e.g. AppNavigationSettings -->
-		<slot name="footer" />
+			<!-- Footer for e.g. AppNavigationSettings -->
+			<slot name="footer" />
+		</div>
 	</div>
 </template>
 
@@ -90,6 +91,11 @@ export default {
 		return {
 			open: true,
 		}
+	},
+	computed: {
+		ariaHidden() {
+			return this.open ? 'false' : 'true'
+		},
 	},
 
 	watch: {
@@ -156,10 +162,6 @@ export default {
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-	display: flex;
-	flex-direction: column;
-	flex-grow: 0;
-	flex-shrink: 0;
 	background-color:  var(--color-main-background-blur, var(--color-main-background));
 	-webkit-backdrop-filter: var(--filter-background-blur, none);
 	backdrop-filter: var(--filter-background-blur, none);
@@ -182,6 +184,13 @@ export default {
 		flex-direction: column;
 		gap: var(--default-grid-baseline, 4px);
 		padding: calc(var(--default-grid-baseline, 4px) * 2);
+	}
+	&__content {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 0;
+		flex-shrink: 0;
 	}
 }
 


### PR DESCRIPTION
Fix an old sidebar navigation on server.

This fix is only for (where `app-navigation-vue` is used):
- [x] Files
- [x] Photos
- [x] Users
- [x] Apps

* Fixes: https://github.com/nextcloud/server/issues/36990
* Fixes: https://github.com/nextcloud/server/issues/36926

## Summary

The goal of this fix: don't allow screen reader navigation through a sidebar if sidebar is closed. No visual changes.

After:
![Peek 2023-04-28 20-57](https://user-images.githubusercontent.com/6078378/235231694-46c0bfd6-78d3-439a-a7a8-7c02be15586e.gif)