### PR TITLE
Use `NcActions` component for `NcAvatar`

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -604,6 +604,17 @@ export default {
 		},
 
 		/**
+		 * This disables the internal open management,
+		 * so the actions menu only respects the `open` prop.
+		 * This is e.g. necessary for the NcAvatar component
+		 * to only open the actions menu after loading it's entries has finished.
+		 */
+		manualOpen: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Force the actions to display in a three dot menu
 		 */
 		forceMenu: {
@@ -717,7 +728,6 @@ export default {
 	},
 
 	emits: [
-		'update:open',
 		'open',
 		'update:open',
 		'close',
@@ -809,7 +819,6 @@ export default {
 			this.$emit('close')
 
 			// close everything
-			this.opened = false
 			this.focusIndex = 0
 
 			// focus back the menu button
@@ -1074,6 +1083,7 @@ export default {
 						placement: this.placement,
 						boundary: this.boundariesElement,
 						container: this.container,
+						...this.manualOpen && { triggers: [] },
 						popoverBaseClass: 'action-item__popper',
 					},
 					on: {


### PR DESCRIPTION
This PR migrates the `NcAvatar` component from using the deprecated `NcPopoverMenu` to `NcActions`.

| Before | After |
|-|-|
| ![Screenshot 2023-04-29 at 13-06-41 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/235299601-a3822697-3a39-4dac-b9b4-d0731b03f8ee.png) | ![Screenshot 2023-04-29 at 13-09-07 Tasks - Nextcloud](https://user-images.githubusercontent.com/2496460/235299604-4bbfd33d-6ce0-410b-96b4-f5f0f13f9511.png) |


Closes #1683, closes #1762