### PR TITLE
Adjust breadcrumb CSS to new html structure

### DIFF
--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -623,7 +623,7 @@ export default {
 		flex-shrink: 1;
 	}
 
-	& #{&}__crumbs {
+	nav {
 		flex-shrink: 1;
 		max-width: 100%;
 		/**
@@ -631,6 +631,10 @@ export default {
 		 * two times the width of a crumb with an icon (first crumb and hidden crumbs actions).
 		 */
 		min-width: 228px;
+	}
+
+	& #{&}__crumbs {
+		max-width: 100%;
 	}
 
 	& #{&}__crumbs,


### PR DESCRIPTION
This adjusts the CSS of the `NcBreadcrumbs` component to the new HTML structure changed in #3990. After #3990 the breadcrumbs would not shrink correctly anymore on small screens, this PR fixes it.

Before (overlaps the `NcActions` on the right):
![grafik](https://user-images.githubusercontent.com/2496460/235762569-3f749938-0da9-4939-8932-1d708cdc3a4f.png)

After (no overlap, correctly shrinks):
![grafik](https://user-images.githubusercontent.com/2496460/235762829-5523ac9d-067a-4209-a71d-5a29e27190ef.png)
