### PR TITLE
fix(NcRichContenteditable): Also quote ids containing a slash

### DIFF
--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -83,7 +83,7 @@ export default {
 				: null
 		},
 		mentionText() {
-			return this.id.indexOf(' ') === -1
+			return !this.id.includes(' ') && !this.id.includes('/')
 				? `@${this.id}`
 				: `@"${this.id}"`
 		},

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -116,7 +116,7 @@ export default {
 			// Fallback to @mention in case no data matches
 			if (!data) {
 				// return `@${value}`
-				return value.indexOf(' ') === -1
+				return !value.includes(' ') && !value.includes('/')
 					? `@${value}`
 					: `@"${value}"`
 			}


### PR DESCRIPTION
This is e.g. the case with guests and user groups in talk.
It's the follow up to the removal of the quotes in talk from https://github.com/nextcloud/spreed/pull/9420 which previously caused double quoting for users and groups with a space. But now groups and guests without a space are no longer quoted.