### PR TITLE
Release 7.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.11.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.11.1) (2023-05-04)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.11.0...v7.11.1)
+
+### :bug: Fixed bugs
+
+- fix\(NcRichContenteditable\): Also quote ids containing a slash [\#4031](https://github.com/nextcloud/nextcloud-vue/pull/4031) ([nickvergessen](https://github.com/nickvergessen))
+
 ## [v7.11.0](https://github.com/nextcloud/nextcloud-vue/tree/v7.11.0) (2023-05-03)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.10.0...v7.11.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.11.0",
+	"version": "7.11.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.11.0",
+			"version": "7.11.1",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.11.0",
+	"version": "7.11.1",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
# Changelog

## [v7.11.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.11.1) (2023-05-04)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.11.0...v7.11.1)

### :bug: Fixed bugs

- fix\(NcRichContenteditable\): Also quote ids containing a slash [\#4031](https://github.com/nextcloud/nextcloud-vue/pull/4031) ([nickvergessen](https://github.com/nickvergessen))



\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*
