### PR TITLE
fix: Avoid showing the reference list if no results were found

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="widgets--list" :class="{'icon-loading': loading }">
-		<div v-for="reference in displayedReferences" :key="reference.openGraphObject.id">
+	<div v-if="isVisible" class="widgets--list" :class="{'icon-loading': loading }">
+		<div v-for="reference in displayedReferences" :key="reference?.openGraphObject?.id">
 			<NcReferenceWidget :reference="reference" />
 		</div>
 	</div>
@@ -38,6 +38,9 @@ export default {
 		}
 	},
 	computed: {
+		isVisible() {
+			return this.loading || this.referenceData
+		},
 		values() {
 			return this.referenceData
 				? this.referenceData


### PR DESCRIPTION
Fixes https://github.com/nextcloud/text/issues/3824

When there is no result for the references we should hide the container and also not fail early on trying to access an undefined object.