### PR TITLE
release: v7.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v7.11.2](https://github.com/nextcloud/nextcloud-vue/tree/v7.11.2) (2023-05-05)
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.11.1...v7.11.2)
+
+### :bug: Fixed bugs
+
+- fix: Fix regression to still display references [\#4039](https://github.com/nextcloud/nextcloud-vue/pull/4039) ([juliushaertl](https://github.com/juliushaertl))
+- fix: Avoid showing the reference list if no results were found [\#4036](https://github.com/nextcloud/nextcloud-vue/pull/4036) ([juliushaertl](https://github.com/juliushaertl))
+- fix\(NcAppNavigation\): fix flex element styles causing resizing sidebar [\#4035](https://github.com/nextcloud/nextcloud-vue/pull/4035) ([ShGKme](https://github.com/ShGKme))
+
 ## [v7.11.1](https://github.com/nextcloud/nextcloud-vue/tree/v7.11.1) (2023-05-04)
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.11.0...v7.11.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.11.1",
+	"version": "7.11.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.11.1",
+			"version": "7.11.2",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.11.1",
+	"version": "7.11.2",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
# Changelog

## [v7.11.2](https://github.com/nextcloud/nextcloud-vue/tree/v7.11.2) (2023-05-05)

[Full Changelog](https://github.com/nextcloud/nextcloud-vue/compare/v7.11.1...v7.11.2)

### :bug: Fixed bugs

- fix: Fix regression to still display references [\#4039](https://github.com/nextcloud/nextcloud-vue/pull/4039) ([juliushaertl](https://github.com/juliushaertl))
- fix: Avoid showing the reference list if no results were found [\#4036](https://github.com/nextcloud/nextcloud-vue/pull/4036) ([juliushaertl](https://github.com/juliushaertl))
- fix\(NcAppNavigation\): fix flex element styles causing resizing sidebar [\#4035](https://github.com/nextcloud/nextcloud-vue/pull/4035) ([ShGKme](https://github.com/ShGKme))
