### PR TITLE
fix: Fix regression to still display references

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -39,7 +39,7 @@ export default {
 	},
 	computed: {
 		isVisible() {
-			return this.loading || this.referenceData
+			return this.loading || this.displayedReferences
 		},
 		values() {
 			return this.referenceData


### PR DESCRIPTION
Turns out I messed up testing of #4036 with the case to show references, this is the follow up fix to actually still show the link preview when expected

Before this change the link preview was only shown if the data was provided through the prop, not if it was dynamically fetched from the provided text.