### PR TITLE
Fix regression of click-outside-options mixin not working since using `@vueuse`

### DIFF
--- a/src/mixins/clickOutsideOptions/index.js
+++ b/src/mixins/clickOutsideOptions/index.js
@@ -54,7 +54,7 @@ export default {
 				? this.excludeClickOutsideClasses
 				: [this.excludeClickOutsideClasses]
 
-			return { ignored: [...excludedQuerySelectors, ...excludeClickOutsideClasses.map(cls => `.${cls}`)] }
+			return { ignore: [...excludedQuerySelectors, ...excludeClickOutsideClasses.map(cls => `.${cls}`)] }
 		},
 	},
 }


### PR DESCRIPTION
There is a regression since we switched to `@vueuse` for the click outside trigger, as the option for ignored selectors is not called `ignored` but `ignore`.

So currently the `exclude-click-outside-selectors` option does not work.