### PR TITLE
Emit event when NcAppContent list pane is resized

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -206,7 +206,10 @@ export default {
 		},
 	},
 
-	emits: ['update:showDetails'],
+	emits: [
+		'update:showDetails',
+		'resize:list',
+	],
 
 	data() {
 		return {
@@ -302,6 +305,10 @@ export default {
 			const listPaneSize = parseInt(event[0].size, 10)
 			browserStorage.setItem(this.paneConfigID, JSON.stringify(listPaneSize))
 			this.listPaneSize = listPaneSize
+			/**
+			 * Emitted when the list pane is resized by the user
+			 */
+			this.$emit('resize:list', { size: listPaneSize })
 			console.debug('AppContent pane config', listPaneSize)
 		},
 


### PR DESCRIPTION
The upper context sometimes needs to know when the list pane is resized. If, for example, the content of the NcAppContent's default slot needs to be re-rendered or needs to adjust its layout/size.

Concrete use case: GpxPod displays a Maplibre map that:
* reacts if the window is resized :tada: 
* does not react if its container size changes :disappointed: We need to explicitly tell the map component to resize when this happens.

Suggestion: Emit `resize:list` in NcAppContent when Splitpanes (the 'list' slot) is resized by the user.
What do you think?