### PR TITLE
fix(NcSelect): Fix disabled state of NcSelect with dark mode

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -945,6 +945,9 @@ body {
 	--vs-state-disabled-color: var(--color-text-maxcontrast);
 	--vs-state-disabled-controls-color: var(--color-text-maxcontrast);
 	--vs-state-disabled-cursor: not-allowed;
+	--vs-disabled-bg: var(--color-background-dark);
+	--vs-disabled-color: var(--color-text-maxcontrast);
+	--vs-disabled-cursor: not-allowed;
 
 	/* Borders */
 	--vs-border-color: var(--color-border-maxcontrast);
@@ -998,13 +1001,13 @@ body {
 		margin-right: 2px;
 	}
 
-	&.vs--open .vs__dropdown-toggle {
-		border-color: var(--color-primary);
+	&.vs--open .vs__dropdown-toggle:not([disabled]) {
+		border-color: var(--color-primary-element);
 		border-bottom-color: transparent;
 	}
 
-	&:not(.vs--open) .vs__dropdown-toggle:hover {
-		border-color: var(--color-primary);
+	&:not(.vs--open) .vs__dropdown-toggle:hover:not([disabled]) {
+		border-color: var(--color-primary-element);
 	}
 
 	&--no-wrap {
@@ -1019,7 +1022,7 @@ body {
 			.vs__dropdown-toggle {
 				border-radius: 0 0 var(--vs-border-radius) var(--vs-border-radius);
 				border-top-color: transparent;
-				border-bottom-color: var(--color-primary);
+				border-bottom-color: var(--color-primary-element);
 			}
 		}
 	}


### PR DESCRIPTION
Before | After
---|---
Background is not our background color and therefor also used in dark mode | background is our color variable so perfectly fine in dark mode
![grafik](https://github.com/nextcloud/nextcloud-vue/assets/213943/54b73990-2bae-49b9-8c01-e60d38a17187) | ![Bildschirmfoto vom 2023-05-10 09-57-25](https://github.com/nextcloud/nextcloud-vue/assets/213943/0b1dd931-db16-47c0-84a5-c9ce0e47abdb)
![Bildschirmfoto vom 2023-05-10 10-08-40](https://github.com/nextcloud/nextcloud-vue/assets/213943/fac634f0-1661-4177-a20d-f7324fac6383) | ![Bildschirmfoto vom 2023-05-10 10-09-31](https://github.com/nextcloud/nextcloud-vue/assets/213943/b304fe5b-4266-439b-8fd2-11a3580bacc3)



