### PR TITLE
fix(styleguide): Fix URL replacement to not be 404

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -36,7 +36,7 @@ module.exports = async () => {
 				proxy: {
 					// redirect to the guest avatar endpoint
 					'/index.php/avatar': {
-						target: 'https://nextcloud.com/wp-content/themes/next/assets/img/common/nextcloud-square-logo.png',
+						target: 'https://raw.githubusercontent.com/nextcloud/promo/master/nextcloud-icon.png',
 						changeOrigin: true,
 						ignorePath: true,
 						secure: false,

--- a/styleguide/global.requires.js
+++ b/styleguide/global.requires.js
@@ -46,7 +46,7 @@ window.OC = {
 		}
 	},
 	generateUrl() {
-		return 'https://nextcloud.com/wp-content/themes/next/assets/img/common/nextcloud-square-logo.png'
+		return 'https://raw.githubusercontent.com/nextcloud/promo/master/nextcloud-icon.png'
 	},
 	getLanguage() {
 		return 'en'


### PR DESCRIPTION
https://nextcloud.com/wp-content/themes/next/assets/img/common/nextcloud-square-logo.png is 404 since the website redesign.