### PR TITLE
Fix NcListItem wrong bold class

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -244,7 +244,7 @@
 
 							<!-- Second line, subtitle and counter -->
 							<div class="line-two"
-								:class="{'line-one--bold': bold}">
+								:class="{'line-two--bold': bold}">
 								<span v-if="hasSubtitle" class="line-two__subtitle">
 									<!-- @slot Slot for the second line of the component -->
 									<slot name="subtitle" />


### PR DESCRIPTION
Because
https://github.com/nextcloud/nextcloud-vue/blob/14e2c5bd0593cf87568c92acc01f898b55b8fe7f/src/components/NcListItem/NcListItem.vue#L710-L717