### PR TITLE
Don't force modal to fill space on mobile

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -955,10 +955,11 @@ export default {
 		.modal-container {
 			max-width: initial;
 			width: 100%;
-			max-height: initial;
-			height: calc(100% - var(--header-height));
+			max-height: calc(100% - var(--header-height));
+			height: unset;
 			position: absolute;
-			top: $header-height;
+			top: unset;
+			bottom: 0;
 			border-radius: 0;
 		}
 	}


### PR DESCRIPTION
Don't have a working dev environment for this repo, so didn't test this directly.

@nextcloud/designers 

| Before | After |
| ------------- | ------------- |
| ![localhost_8035_index php_apps_memories_ (1)](https://github.com/nextcloud/nextcloud-vue/assets/10709794/2e1f8c93-e6ea-4b89-897d-b72c0b312ebd) | ![localhost_8035_index php_apps_memories_](https://github.com/nextcloud/nextcloud-vue/assets/10709794/95c7b9f2-caf0-4871-84a2-adb09ffc1051) |