### PR TITLE
Remove excludeClickOutsideClasses from clickOutsideOptions

### DIFF
--- a/src/mixins/clickOutsideOptions/index.js
+++ b/src/mixins/clickOutsideOptions/index.js
@@ -36,7 +36,7 @@ export default {
 			const excludedQuerySelectors = Array.isArray(this.excludeClickOutsideSelectors)
 				? this.excludeClickOutsideSelectors
 				: [this.excludeClickOutsideSelectors]
-			
+
 			return { ignore: excludedQuerySelectors }
 		},
 	},

--- a/src/mixins/clickOutsideOptions/index.js
+++ b/src/mixins/clickOutsideOptions/index.js
@@ -30,31 +30,14 @@ export default {
 			type: [String, Array],
 			default: () => [],
 		},
-
-		/**
-		 * A class-name or an array of class-names
-		 * to be ignored when clicking outside
-		 * an element
-		 *
-		 * @deprecated since 7.9.0, use `excludeClickOutsideSelectors` instead
-		 */
-		excludeClickOutsideClasses: {
-			type: [String, Array],
-			default: () => [],
-		},
 	},
 	computed: {
 		clickOutsideOptions() {
 			const excludedQuerySelectors = Array.isArray(this.excludeClickOutsideSelectors)
 				? this.excludeClickOutsideSelectors
 				: [this.excludeClickOutsideSelectors]
-
-			// TODO: Drop if prop is removed
-			const excludeClickOutsideClasses = Array.isArray(this.excludeClickOutsideClasses)
-				? this.excludeClickOutsideClasses
-				: [this.excludeClickOutsideClasses]
-
-			return { ignore: [...excludedQuerySelectors, ...excludeClickOutsideClasses.map(cls => `.${cls}`)] }
+			
+			return { ignore: excludedQuerySelectors }
 		},
 	},
 }


### PR DESCRIPTION
This removes the deprecated `excludeClickOutsideClasses` from the `clickOutsideOptions` mixin.