### PR TITLE
target=_blank in NcSettingsSection.vue

### DIFF
--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -50,7 +50,9 @@ This component is to be used in the settings section of nextcloud.
 				class="settings-section__info"
 				role="note"
 				:aria-label="docTitleTranslated"
-				:title="docTitleTranslated">
+				:title="docTitleTranslated"
+				target="_blank"
+				rel="noreferrer nofollow">
 				<HelpCircle :size="20" />
 			</a>
 		</h2>


### PR DESCRIPTION
open external documentation in new window; the link should not pass any referrer information to the linked page, and should not be followed by search engine bots for the purpose of indexing