### PR TITLE
Input Fields and RichContenteditable: add focus and select methods

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -293,6 +293,24 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Focus the input element
+		 *
+		 * @public
+		 */
+		focus() {
+			this.$refs.input.focus()
+		},
+
+		/**
+		 * Select all the text in the input
+		 *
+		 * @public
+		 */
+		select() {
+			this.$refs.input.select()
+		},
+
 		handleInput(event) {
 			this.$emit('update:value', event.target.value)
 		},

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -246,6 +246,24 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Focus the input element
+		 *
+		 * @public
+		 */
+		focus() {
+			this.$refs.inputField.focus()
+		},
+
+		/**
+		 * Select all the text in the input
+		 *
+		 * @public
+		 */
+		select() {
+			this.$refs.inputField.select()
+		},
+
 		handleInput(event) {
 			/**
 			 * Triggers when the value inside the password field is

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -484,6 +484,15 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Focus the richContenteditable
+		 *
+		 * @public
+		 */
+		focus() {
+			this.$refs.contenteditable.focus()
+		},
+
 		getLink(item) {
 			// there is no way to get a tribute result asynchronously
 			// so we immediately insert a node and replace it when the result comes

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -189,6 +189,24 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Focus the input element
+		 *
+		 * @public
+		 */
+		focus() {
+			this.$refs.inputField.focus()
+		},
+
+		/**
+		 * Select all the text in the input
+		 *
+		 * @public
+		 */
+		select() {
+			this.$refs.inputField.select()
+		},
+
 		handleInput(event) {
 			this.$emit('update:value', event.target.value)
 		},


### PR DESCRIPTION
## The problem

`NcInputField`, `NcTextField`, and `NcPassowrdField` are wrappers on native `input` proxying native attributes and events. But native `HtmlInputElement` also has public methods. At least 2 of them are commonly used: [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) and [select](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/select).

Currently, it is possible to use them only by DOM selectors or long path throw formally internal properties by `$refs` (they are not part of publicly documented API).

## PR

This PR:
- Adds `focus` and `select` public methods to all `Nc*Field` with documentation
- Adds `focus` public method to `NcRichContentEditable` with documentation

Before 😭                                                  | After 😸
-----------------------------------------------------------|------------------------------
`this.$refs.someInput.$refs.inputField.$refs.input.focus()` | `this.$ref.someInput.focus()`
`this.$refs.someInput.$el.querySelector('input').select()`  | `this.$ref.someInput.select()`

## Documentation example

![image](https://github.com/nextcloud/nextcloud-vue/assets/25978914/d173eb6b-750e-46b0-bf77-5f913126b3c6)