### PR TITLE
Add aria-expanded to settings accordion button

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -143,6 +143,9 @@ msgstr ""
 msgid "Open navigation"
 msgstr ""
 
+msgid "Open settings menu"
+msgstr ""
+
 msgid "Password is secure"
 msgstr ""
 

--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -27,6 +27,9 @@
 		<div id="app-settings__header">
 			<button class="settings-button"
 				type="button"
+				:aria-expanded="open ? 'true' : 'false'"
+				aria-controls="app-settings__content"
+				:aria-label="ariaLabel"
 				@click="toggleMenu">
 				<Cog class="settings-button__icon" :size="20" />
 				<span class="settings-button__label">{{ title }}</span>
@@ -76,6 +79,9 @@ export default {
 				this.closeMenu,
 				this.clickOutsideOptions,
 			]
+		},
+		ariaLabel() {
+			return t('Open settings menu')
 		},
 	},
 	methods: {


### PR DESCRIPTION
Mark settings button that triggers the expand/collaps of the side nav settings with aria-expanded attribute to improve accesibility.

Resolves : https://github.com/nextcloud/server/issues/37136