### PR TITLE
Remove unused props and directives of NcResource

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -55,8 +55,6 @@ export default {
 			class="related-resources__entry"
 			:icon="resource.icon"
 			:title="resource.title"
-			:subtitle="resource.subtitle"
-			:tooltip="resource.tooltip"
 			:url="resource.url" />
 	</div>
 </template>

--- a/src/components/NcRelatedResourcesPanel/NcResource.vue
+++ b/src/components/NcRelatedResourcesPanel/NcResource.vue
@@ -38,7 +38,6 @@
 
 <script>
 import NcButton from '../NcButton/index.js'
-import Tooltip from '../../directives/Tooltip/index.js'
 
 import { t } from '../../l10n.js'
 
@@ -49,10 +48,6 @@ export default {
 		NcButton,
 	},
 
-	directives: {
-		Tooltip,
-	},
-
 	props: {
 		icon: {
 			type: String,
@@ -61,14 +56,6 @@ export default {
 		title: {
 			type: String,
 			required: true,
-		},
-		subtitle: {
-			type: String,
-			default: null,
-		},
-		tooltip: {
-			type: String,
-			default: null,
 		},
 		url: {
 			type: String,


### PR DESCRIPTION
Since https://github.com/nextcloud/nextcloud-vue/pull/3236 the `subtitle` and `tooltip` prop and the `tooltip` directive of `NcResource` are unused. This PR removes them completely now.