### PR TITLE
NcAppSidebar: fix tabs with css icon

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -57,7 +57,7 @@
 				</span>
 				<template #icon>
 					<NcVNodes :vnodes="tab.renderIcon()">
-						<span :class="tab.icon" />
+						<span class="app-sidebar-tabs__tab-icon" :class="tab.icon" />
 					</NcVNodes>
 				</template>
 			</NcCheckboxRadioSwitch>
@@ -284,6 +284,13 @@ export default {
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			text-align: center;
+		}
+
+		&-icon {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			background-size: 20px;
 		}
 	}
 

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -56,7 +56,9 @@
 					{{ tab.name }}
 				</span>
 				<template #icon>
-					<NcVNodes :vnodes="tab.renderIcon()" />
+					<NcVNodes :vnodes="tab.renderIcon()">
+						<span :class="tab.icon" />
+					</NcVNodes>
 				</template>
 			</NcCheckboxRadioSwitch>
 		</nav>

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -41,8 +41,6 @@
 </template>
 
 <script>
-import { h } from 'vue'
-
 export default {
 	name: 'NcAppSidebarTab',
 
@@ -126,12 +124,12 @@ export default {
 		},
 
 		/**
-		 * Render tab's icon from slot or icon prop
+		 * Render tab's icon slot if any
 		 *
-		 * @return {import('vue').VNode|import('vue').VNode[]}
+		 * @return {import('vue').VNode[]}
 		 */
 		renderIcon() {
-			return this.$slots.icon || this.$scopedSlots.icon?.() || h('span', { staticClass: this.icon })
+			return this.$scopedSlots.icon?.()
 		},
 	},
 }


### PR DESCRIPTION
## Resolves

This PR resolves two different problems in `NcSidebarTab` with CSS icon. I combined them together into 1 PR because they both required to be fixed to resolve the problem.

### 1. Resolves rendering by `OCA.Files.Sidebar`

Fixes: https://github.com/nextcloud/server/issues/38229
Regression of: https://github.com/nextcloud/nextcloud-vue/pull/3891

The icon is rendered by `NcAppSidebarTab.renderIcon()` in `NcAppSidebarTabs`. It seems to me when it is used with `OCA.Files.Sidebar` (and maybe `LegacyView`), `Tabs` and `Tab` components are rendered by different Vue copies on the page (on my instance [24 different copies of Vue are bundled](https://github.com/nextcloud/server/assets/25978914/8177014c-cfe6-453c-8b80-937168c204ce)). 

As a result, when `NcAppSidebarTab.renderIcon()` is called in `NcAppSidebarTabs`'s rendering, it doesn't know about the rendering. `NcAppSidebarTab.renderIcon()` creates `VNode` in one Vue copy, but is used in rendering in another Vue copy. It fails, because for `NcAppSidebarTab.renderIcon()` there is no rendering in the first Vue copy.

In this PR rendering of the icon is simplified. `NcAppSIdebarTab.renderIcon()` is used ONLY to render the slot's icon. CSS icon is rendered by `NcSidebarTabs` directly as a fallback. Then it works fine in different contexts.

P.S. To fix the mentioned issue this PR should be manually backported: https://github.com/nextcloud/nextcloud-vue/pull/4112

### 2. Resolves losing CSS icon

Fixes the problem that causes the problem fixed in: https://github.com/nextcloud/activity/pull/1154
Also fix: https://github.com/nextcloud/activity/pull/1167
Regression of: https://github.com/nextcloud/nextcloud-vue/pull/3945

During the update to the new design with `NcCheckboxRadioSwitch`, styles for CSS icons were lost. Span with CSS icon had width 0.

This PR returns the styles with the default size 20px as used in `NcCheckboxRadioSwitch`.