### PR TITLE
NcAppSidebarTabs: fix rendering tabs with CSS icon in `OCA.Files.Sidebar`

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -49,7 +49,9 @@
 						role="tab"
 						@click.prevent="setActive(tab.id)">
 						<span class="app-sidebar-tabs__tab-icon">
-							<NcVNodes :vnodes="tab.renderIcon()" />
+							<NcVNodes :vnodes="tab.renderIcon()">
+								<span :class="tab.icon" />
+							</NcVNodes>
 						</span>
 						{{ tab.name }}
 					</a>

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -41,8 +41,6 @@
 </template>
 
 <script>
-import { h } from 'vue'
-
 export default {
 	name: 'NcAppSidebarTab',
 
@@ -126,12 +124,12 @@ export default {
 		},
 
 		/**
-		 * Render tab's icon from slot or icon prop
+		 * Render tab's icon slot if any
 		 *
-		 * @return {import('vue').VNode|import('vue').VNode[]}
+		 * @return {import('vue').VNode[]}
 		 */
 		renderIcon() {
-			return this.$slots.icon || this.$scopedSlots.icon?.() || h('span', { staticClass: this.icon })
+			return this.$scopedSlots.icon?.()
 		},
 	},
 }


### PR DESCRIPTION
Partial backport of https://github.com/nextcloud/nextcloud-vue/pull/4111

Second problem is not relevant to `stable7` and cannot be backported.