### PR TITLE
Improve `NcSettingsSelectGroup` - Convert to `NcSelect`

### DIFF
--- a/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
+++ b/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
@@ -55,6 +55,7 @@ section * {
 		<NcSelect :value="inputValue"
 			:options="groupsArray"
 			:placeholder="placeholder || label"
+			:filter-by="filterGroups"
 			:input-id="id"
 			:limit="5"
 			label="displayname"
@@ -241,6 +242,17 @@ export default {
 				showError(t('Unable to search the group'))
 			}
 			return false
+		},
+
+		/**
+		 * Custom filter function for `NcSelect` to filter by ID *and* display name
+		 *
+		 * @param {object} option One of the groups
+		 * @param {string} label The label property of the group
+		 * @param {string} search The current search string
+		 */
+		filterGroups(option, label, search) {
+			return `${label || ''} ${option.id}`.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) > -1
 		},
 
 		/**

--- a/styleguide/global.requires.js
+++ b/styleguide/global.requires.js
@@ -3,7 +3,40 @@ import 'core-js/stable'
 /* eslint-disable-next-line */
 import 'regenerator-runtime/runtime'
 import Vue from 'vue'
-import VTooltip from './../src/directives/Tooltip'
+import VTooltip from './../src/directives/Tooltip/index.js'
+
+import axios from '@nextcloud/axios'
+
+const USER_GROUPS = [
+	{ id: 'admin', displayname: 'The administrators' },
+	{ id: 'accounting', displayname: 'Accounting team' },
+	{ id: 'developer', displayname: 'Engineering team' },
+	{ id: 'support', displayname: 'Support crew' },
+	{ id: 'users', displayname: 'users' },
+]
+
+/**
+ * Mock some requests for docs
+ *
+ * @param {object} error Axios error
+ */
+function mockRequests(error) {
+	const { request } = error
+	let data = null
+
+	// Mock requesting groups
+	const requestGroups = request.responseURL.match(/cloud\/groups\/details\?search=([^&]*)&limit=\d+$/)
+	if (requestGroups) {
+		data = { groups: USER_GROUPS.filter(e => !requestGroups[1] || e.displayname.startsWith(requestGroups[1]) || e.id.startsWith(requestGroups[1])) }
+	}
+
+	if (data) {
+		return Promise.resolve({ data: { ocs: { data } } })
+	}
+	return Promise.reject(error)
+}
+
+axios.interceptors.response.use((r) => r, e => mockRequests(e))
 
 /**
  * From server util.js


### PR DESCRIPTION
Adding documentation, move to NcSelect and drop unused property
* Moved from deprecated `NcMultiselect` to `NcSelect` (Ref: https://github.com/nextcloud/nextcloud-vue/issues/3743 )
* Debounce search API calls (200ms) to prevent spamming the API while typing
* Cache empty search groups (the ones loaded when the search dropdown is opened) for current page
* Load display names of initial groups (those which were given through the `value` property).
* Removed unused `hint` property
* Added `placeholder` property and added a hidden label element
      The `label` property is still used for the placeholder for backwards compatibility.
* Added documentation for the events and added an example (Add axios mocking so we can emulate querying for groups on the netlify docs)