### PR TITLE
fix(NcResource): Alignment

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcResource.vue
+++ b/src/components/NcRelatedResourcesPanel/NcResource.vue
@@ -87,9 +87,15 @@ export default {
 		justify-content: flex-start !important;
 		padding: 0 !important;
 
-		&:deep(.button-vue__text) {
-			font-weight: normal !important;
-			margin-left: 2px !important;
+		&:deep {
+			.button-vue__wrapper {
+				justify-content: flex-start !important;
+
+				.button-vue__text {
+					font-weight: normal !important;
+					margin-left: 2px !important;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Before | After
--- | ---
![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/8f3e3b65-4f02-419b-8a66-89917b51a05e) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/c3aa892d-5f42-4ed5-852a-f6f3715f61eb)

Alignment changed after https://github.com/nextcloud/nextcloud-vue/pull/3936