### PR TITLE
Fix alignment of nav contents

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -174,7 +174,7 @@ export default {
 	}
 
 	//list of navigation items
-	& > ul,
+	&__content > ul,
 	&__list {
 		position: relative;
 		height: 100%;


### PR DESCRIPTION
Padding was only applicable to the list, but should apply to the footer too.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![footer-before](https://github.com/nextcloud/nextcloud-vue/assets/10709794/a1ecc231-9b21-4f29-a195-13863cc3bdf1) | ![footer_after](https://github.com/nextcloud/nextcloud-vue/assets/10709794/089980f4-c7d2-4035-8740-0204eb2fc90f)

