### PR TITLE
Implement app menu new-item action as button not link

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -787,7 +787,7 @@ export default {
 		background-color: var(--color-primary-element) !important;
 
 		// overwrite active text color
-		.app-navigation-entry-link, .app-navigation-entry-div {
+		.app-navigation-entry-link, .app-navigation-entry-button {
 			color: var(--color-primary-element-text) !important;
 		}
 	}
@@ -822,13 +822,13 @@ export default {
 	}
 
 	&:not(.app-navigation-entry--editing) {
-		.app-navigation-entry-link, .app-navigation-entry-div {
+		.app-navigation-entry-link, .app-navigation-entry-button {
 			padding-right: $icon-margin;
 		}
 	}
 
 	// Main entry link
-	.app-navigation-entry-link, .app-navigation-entry-div {
+	.app-navigation-entry-link, .app-navigation-entry-button {
 		z-index: 100; /* above the bullet to allow click*/
 		display: flex;
 		overflow: hidden;

--- a/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
+++ b/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
@@ -69,26 +69,26 @@
 		}"
 		class="app-navigation-entry">
 		<!-- New Item -->
-		<div class="app-navigation-entry-div" @click="handleNewItem">
-			<div :class="{ [icon]: !loading }"
+		<button class="app-navigation-entry-button" @click="handleNewItem">
+			<span :class="{ [icon]: !loading }"
 				class="app-navigation-entry-icon">
 				<NcLoadingIcon v-if="loading" />
 				<slot v-else name="icon" />
-			</div>
+			</span>
 
 			<span v-if="!newItemActive" class="app-navigation-new-item__name" :title="name">
 				{{ name }}
 			</span>
 
 			<!-- new Item input -->
-			<div v-if="newItemActive" class="newItemContainer">
+			<span v-if="newItemActive" class="newItemContainer">
 				<NcInputConfirmCancel ref="newItemInput"
 					v-model="newItemValue"
 					:placeholder="editPlaceholder !== '' ? editPlaceholder : name"
 					@cancel="cancelNewItem"
 					@confirm="handleNewItemDone" />
-			</div>
-		</div>
+			</span>
+		</button>
 	</li>
 </template>
 


### PR DESCRIPTION
`NcAppNavigationNewItem` performs an on-page action and so the correct sematic tag is button.

### ☑️ Resolves

* Fix https://github.com/nextcloud/nextcloud-vue/issues/4108

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![nc-app-nav-new-item-before](https://github.com/nextcloud/nextcloud-vue/assets/14317775/61899fe5-6211-4d86-ba77-f7a988734826) | ![nc-app-nav-new-item-after](https://github.com/nextcloud/nextcloud-vue/assets/14317775/de17c273-85de-457c-b44e-80e020586c2f)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
