### PR TITLE
collapse sections by default to make the styleguide a bit lucid

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -45,8 +45,8 @@ module.exports = async () => {
 			},
 		}),
 
-		exampleMode: 'expand',
-		usageMode: 'expand',
+		exampleMode: 'collapse',
+		usageMode: 'collapse',
 
 		components: 'src/components/*/*.vue',
 		getComponentPathLine(componentPath) {


### PR DESCRIPTION
Problem: currently all sections are uncollapsed by default which makes each page very long and you cannot filter easily with your eyes without having to scroll a lot. Solution: collapse all sections by default which allows for easier filtering and scrolling. Then you can still view the sections that you are interested in by clicking the buttons.

One example:
| Before | After |
|---|---|
| ![nextcloud-vue-components netlify app_](https://github.com/nextcloud/nextcloud-vue/assets/42591237/a9fbced9-7110-4c54-abc1-93326061659b) |  ![deploy-preview-4152--nextcloud-vue-components netlify app_](https://github.com/nextcloud/nextcloud-vue/assets/42591237/092e97e7-ed65-4a14-84a9-34ab22f345d7) |