### PR TITLE
fix visibility of default counterbubble

### DIFF
--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -89,7 +89,7 @@ export default {
 	border-radius: var(--border-radius-pill);
 	background-color: var(--color-primary-element-light);
 	font-weight: bold;
-	color: var(--color-primary-element);
+	color: var(--color-primary-element-light-text);
 
 	&--highlighted {
 		color: var(--color-primary-element-text);


### PR DESCRIPTION
When choosing e.g. black as primary color in dark mode:

| Before | After |
|---|---|
| ![image](https://github.com/nextcloud/nextcloud-vue/assets/42591237/e9492360-4014-4be0-8fd3-44f8e2e2abca) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/42591237/0c72f1c7-bfbb-4860-9018-5e42dfee4747) |