### PR TITLE
fix: make property "force-title" work

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -153,11 +153,11 @@ export default {
 </script>
 ```
 
-### Multiple actions with 2 items inline AND forced names
+### Multiple actions with 2 items inline AND forced titles
 
 ```vue
 <template>
-	<NcActions :force-name="true" :inline="2">
+	<NcActions :force-title="true" :inline="2">
 		<NcActionButton @click="showMessage('Add')">
 			<template #icon>
 				<Plus :size="20" />
@@ -623,9 +623,9 @@ export default {
 		},
 
 		/**
-		 * Force the name to show for single actions
+		 * Force the title to show for single actions
 		 */
-		forceName: {
+		forceTitle: {
 			type: Boolean,
 			default: false,
 		},
@@ -996,11 +996,11 @@ export default {
 
 			const text = action?.componentOptions?.children?.[0]?.text?.trim?.()
 			const ariaLabel = action?.componentOptions?.propsData?.ariaLabel || text
-			const buttonText = this.forceName ? text : ''
+			const buttonText = this.forceTitle ? text : ''
 
 			let title = action?.componentOptions?.propsData?.title
 			// Show a default title for single actions if none is present
-			if (!(this.forceName || title)) {
+			if (!(this.forceTitle || title)) {
 				title = text
 			}
 


### PR DESCRIPTION
- "name" and "title" were mixed up, so no titles were shown even if option "force-names" was set

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="412" alt="SCR-20230525-mfxw" src="https://github.com/nextcloud/nextcloud-vue/assets/55329475/71fa1cba-1feb-4e5d-84c8-69ce62e2febd"> | <img width="412" alt="SCR-20230525-mfnv" src="https://github.com/nextcloud/nextcloud-vue/assets/55329475/863d1d56-2c6d-4e02-b470-8a5b666bd953">



### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
