### PR TITLE
fix(NcProviderList): Add padding around provider list

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
@@ -102,9 +102,7 @@ export default {
 .provider-list {
 	width: 100%;
 	min-height: 350px;
-	// multiselect dropdown is wider than the select input
-	// this avoids overflow
-	padding-right: 2px;
+	padding: 0 16px 16px 16px;
 	display: flex;
 	flex-direction: column;
 


### PR DESCRIPTION
Since the padding on the modal itself was removed it should still be added to the provider list when opening the picker with `getLinkWithPicker` 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-06-02 at 15 44 28](https://github.com/nextcloud/nextcloud-vue/assets/3404133/cd5f38d7-4847-4185-a7f3-7b6a752ee4d2) | ![Screenshot 2023-06-02 at 15 44 22](https://github.com/nextcloud/nextcloud-vue/assets/3404133/5efa878d-5f28-46e0-bc12-ed1b3c6eb316)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
