### PR TITLE
Add focus-visible style for NcCheckboxRadioSwitch

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -583,6 +583,10 @@ export default {
 		height: var(--icon-size);
 	}
 
+	&__input:focus-visible + label {
+		outline: 2px solid var(--color-primary-element) !important;
+	}
+
 	&__label {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Improve accesibility by making focus indicator visible.

Resolves : https://github.com/nextcloud/photos/issues/1671

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="352" alt="7f1a8522565d214125291c78487d02e1" src="https://user-images.githubusercontent.com/1315170/222541851-9c3b9487-c3c7-405d-b90b-572dca55e02b.png"> | ![Screenshot from 2023-06-09 16-59-51](https://github.com/nextcloud/nextcloud-vue/assets/14317775/995ffbc9-a7ca-4b9f-ba8c-b64e26f9c530)



### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
