### PR TITLE
Use `display: flex` in app-content-list on mobile as well

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -373,7 +373,7 @@ export default {
 .app-content-wrapper--mobile {
 	&.app-content-wrapper--show-list :deep() {
 		.app-content-list {
-			display: block;
+			display: flex;
 		}
 		.app-content-details {
 			display: none;


### PR DESCRIPTION
We already use `display: flex` for app-content-list if not on mobile, see `core/css/apps.scss` in server repository.

### ☑️ Resolves

This is necessary for using `position: sticky` and `bottom: 0` inside `app-content-list`.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
