### PR TITLE
fix(NcSelect): Styles on state change

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1019,7 +1019,7 @@ body {
 		border-bottom-color: transparent;
 	}
 
-	&:not(.vs--open) .vs__dropdown-toggle:hover:not([disabled]) {
+	&:not(.vs--disabled, .vs--open) .vs__dropdown-toggle:hover {
 		border-color: var(--color-primary-element);
 	}
 

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1014,7 +1014,7 @@ body {
 		margin-right: 2px;
 	}
 
-	&.vs--open .vs__dropdown-toggle:not([disabled]) {
+	&.vs--open .vs__dropdown-toggle {
 		border-color: var(--color-primary-element);
 		border-bottom-color: transparent;
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Regression from https://github.com/nextcloud/nextcloud-vue/pull/4079
- Fix styles with placement set to top and hover color when disabled

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/8cc5f692-8fe6-4afc-863d-7d0d7fb196ac) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/e18baf76-4ba2-4a72-ac75-91223c5b0191)
![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/7b449879-5714-4cea-b83f-a4749d61cee7) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/fe292651-ce15-4e96-a1fb-a50cafffd299)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable