### PR TITLE
fix: Remove leftovers of hammerJS

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -113,8 +113,6 @@ export default {
 		})
 	},
 	unmounted() {
-		this.mc.off('swipeleft swiperight')
-		this.mc.destroy()
 		unsubscribe('toggle-navigation', this.toggleNavigationByEventBus)
 	},
 

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -546,13 +546,12 @@ export default {
 	},
 	beforeDestroy() {
 		window.removeEventListener('keydown', this.handleKeydown)
-		this.mc.off('swipeleft swiperight')
-		this.mc.destroy()
+		this.mc.stop()
 	},
 	mounted() {
 		// init clear view
 		this.useFocusTrap()
-		useSwipe(this.$refs.mask, {
+		this.mc = useSwipe(this.$refs.mask, {
 			onSwipeEnd: this.handleSwipe,
 		})
 


### PR DESCRIPTION
### ☑️ Resolves

```
[Vue warn]: Error in beforeDestroy hook: "TypeError: this.mc is null"
```

This code was used by hammerJS but is not required anymore since we migrated to vueuse.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
