### PR TITLE
fix(NcSelect): Disabled colors

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -955,11 +955,11 @@ body {
 	--vs-line-height: var(--default-line-height);
 
 	/* Disabled State */
-	--vs-state-disabled-bg: var(--color-background-dark);
+	--vs-state-disabled-bg: var(--color-background-hover);
 	--vs-state-disabled-color: var(--color-text-maxcontrast);
 	--vs-state-disabled-controls-color: var(--color-text-maxcontrast);
 	--vs-state-disabled-cursor: not-allowed;
-	--vs-disabled-bg: var(--color-background-dark);
+	--vs-disabled-bg: var(--color-background-hover);
 	--vs-disabled-color: var(--color-text-maxcontrast);
 	--vs-disabled-cursor: not-allowed;
 
@@ -1025,6 +1025,11 @@ body {
 	}
 
 	&.vs--disabled {
+		.vs__search,
+		.vs__selected {
+			color: var(--color-text-maxcontrast);
+		}
+
 		.vs__clear,
 		.vs__deselect {
 			display: none;


### PR DESCRIPTION
### ☑️ Resolves

- Lighten the disabled background and text colors slightly to distinguish the disabled state from the regular state

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/9b7b9816-f1dc-4422-bc98-a2e94bf673e4) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/24800714/51db8e75-75aa-4c3c-b6a8-9ab498ebb4b4)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable