### PR TITLE
Fix NcModal does set the background color but not the text color

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -915,6 +915,7 @@ export default {
 		transition: transform 300ms ease;
 		border-radius: var(--border-radius-large);
 		background-color: var(--color-main-background);
+		color: var(--color-main-text);
 		box-shadow: 0 0 40px rgba(0, 0, 0, .2);
 		&__close {
 			position: absolute;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #2405

As it sets the background color it should also set the foreground color as it can not assume the default will match the contrast criteria.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/nextcloud-vue/assets/1855448/1daeddc3-c5a4-4bc8-86cf-f48d250b14e1) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/1855448/256eca54-ce18-4362-bf18-a8f18086ed62)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
