### PR TITLE
fix: Revert updating `string-length` to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 				"remark-parse": "^10.0.1",
 				"remark-rehype": "^10.1.0",
 				"splitpanes": "^2.4.1",
-				"string-length": "^6.0.0",
+				"string-length": "^5.0.1",
 				"striptags": "^3.2.0",
 				"tributejs": "^5.1.3",
 				"unified": "^10.1.2",
@@ -5848,6 +5848,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"node_modules/blob-util": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -6671,6 +6681,14 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/char-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+			"integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
 		"node_modules/character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -6752,6 +6770,20 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
@@ -10903,6 +10935,13 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
+		},
 		"node_modules/filesize": {
 			"version": "8.0.7",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
@@ -11531,6 +11570,25 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+			"deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"nan": "^2.12.1"
+			},
+			"engines": {
+				"node": ">= 4.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
@@ -14451,6 +14509,20 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/jest-leak-detector": {
@@ -17462,6 +17534,13 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
+		},
+		"node_modules/nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.4",
@@ -21917,14 +21996,15 @@
 			}
 		},
 		"node_modules/string-length": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-6.0.0.tgz",
-			"integrity": "sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+			"integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
 			"dependencies": {
-				"strip-ansi": "^7.1.0"
+				"char-regex": "^2.0.0",
+				"strip-ansi": "^7.0.1"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -29490,7 +29570,7 @@
 			"version": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#46d9bf85c257e824f2ecd2d2afc76c2e41dffc19",
 			"integrity": "sha512-KseLhvnKvVPqpQOJa1sOYG8p7sPJ3RsRnb+X6spUJqgVc70ha9Ize9amrqah0qMI6cgKrBkxqmpcakfXp7JV9A==",
 			"dev": true,
-			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#46d9bf85c257e824f2ecd2d2afc76c2e41dffc19",
+			"from": "@nextcloud/webpack-vue-config@github:nextcloud/webpack-vue-config#master",
 			"requires": {}
 		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -31579,6 +31659,16 @@
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"blob-util": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -32236,6 +32326,11 @@
 				}
 			}
 		},
+		"char-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+			"integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw=="
+		},
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -32290,6 +32385,13 @@
 				"readdirp": "~3.6.0"
 			},
 			"dependencies": {
+				"fsevents": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+					"dev": true,
+					"optional": true
+				},
 				"glob-parent": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -35513,6 +35615,13 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
+		},
 		"filesize": {
 			"version": "8.0.7",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
@@ -36014,6 +36123,17 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
+		},
+		"fsevents": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"nan": "^2.12.1"
+			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -38163,6 +38283,15 @@
 				"jest-worker": "^29.5.0",
 				"micromatch": "^4.0.4",
 				"walker": "^1.0.8"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"jest-leak-detector": {
@@ -40387,6 +40516,13 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
+		},
+		"nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"dev": true,
+			"optional": true
 		},
 		"nanoid": {
 			"version": "3.3.4",
@@ -43861,11 +43997,12 @@
 			}
 		},
 		"string-length": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-6.0.0.tgz",
-			"integrity": "sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+			"integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
 			"requires": {
-				"strip-ansi": "^7.1.0"
+				"char-regex": "^2.0.0",
+				"strip-ansi": "^7.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"remark-parse": "^10.0.1",
 		"remark-rehype": "^10.1.0",
 		"splitpanes": "^2.4.1",
-		"string-length": "^6.0.0",
+		"string-length": "^5.0.1",
 		"striptags": "^3.2.0",
 		"tributejs": "^5.1.3",
 		"unified": "^10.1.2",


### PR DESCRIPTION
### ☑️ Resolves

* Reverts: https://github.com/nextcloud/nextcloud-vue/pull/4178

`Intl.Segmenter` is not supported by Firefox (113) and only planned for later 2023, there is also no easy polyfill available. Blocked by Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1423593

You can test this by opening the documentation on master using firefox, it wont load.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
