### PR TITLE
fix progress-bar on chromium browsers

### DIFF
--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -113,7 +113,7 @@ export default {
 	// Browser specific rules
 	&::-webkit-progress-bar {
 		height: var(--progress-bar-height);
-		background-color: var(--color-background-dark)
+		background-color: transparent;
 	}
 	&::-webkit-progress-value {
 		background: var(--gradient-primary-background);

--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -113,6 +113,7 @@ export default {
 	// Browser specific rules
 	&::-webkit-progress-bar {
 		height: var(--progress-bar-height);
+		background-color: var(--color-background-dark)
 	}
 	&::-webkit-progress-value {
 		background: var(--gradient-primary-background);


### PR DESCRIPTION
Close https://github.com/nextcloud/nextcloud-vue/issues/4199

| Browser | Before | After |
|---|---|---|
| Chromium | ![image](https://github.com/nextcloud/nextcloud-vue/assets/42591237/10d857df-98f8-4b3b-9590-d1c115ae2650) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/42591237/e40a703d-1782-4d5b-a0b4-e48e0c645949) |
| Firefox | ![image](https://github.com/nextcloud/nextcloud-vue/assets/42591237/d96d6591-3334-45ce-81ea-a232b28437cd) | ![image](https://github.com/nextcloud/nextcloud-vue/assets/42591237/ea7ba5ad-3dbc-4344-b32d-c26878875c78) |