### PR TITLE
Fix padding in the 'any link' preview component (smart picker)

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -127,6 +127,7 @@ export default {
 	display: flex;
 	flex-direction: column;
 	overflow-y: auto;
+	padding: 0 16px 16px 16px;
 
 	.input-wrapper {
 		width: 100%;


### PR DESCRIPTION
The surrounding Smart Picker modal does not have padding anymore.