### PR TITLE
Fix missing language for scss style

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -239,7 +239,7 @@ export default {
 	},
 }
 </script>
-<style scoped>
+<style lang="scss" scoped>
 /* stylelint-disable-next-line scss/at-import-partial-extension */
 @import './richtext.scss';
 


### PR DESCRIPTION
### ☑️ Resolves

The style part is written as scss but the language attribute was missing.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
