### PR TITLE
`NcActionLink` - provide download attributes for single action button in `NcAction`

### DIFF
--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -26,20 +26,50 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 
 ```
 <template>
-	<NcActions>
-		<NcActionLink href="https://nextcloud.com">
-			<template #icon>
-				<OpenInNew :size="20" />
-			</template>
-			Nextcloud website
-		</NcActionLink>
-	</NcActions>
+	<div style="display: flex; align-items: center;">
+		<NcActions>
+			<NcActionLink href="https://nextcloud.com">
+				<template #icon>
+					<OpenInNew :size="20" />
+				</template>
+				Nextcloud website
+			</NcActionLink>
+		</NcActions>
+
+		<NcActions>
+			<NcActionLink href="https://www.gnu.org/licenses/gpl.odt"
+				  download="AGPL License text.odt">
+				<template #icon>
+					<Download :size="20" />
+				</template>
+				Download AGPL license text
+			</NcActionLink>
+		</NcActions>
+
+		<NcActions>
+			<NcActionLink href="https://nextcloud.com">
+				<template #icon>
+					<OpenInNew :size="20" />
+				</template>
+				Nextcloud website
+			</NcActionLink>
+			<NcActionLink href="https://www.gnu.org/licenses/gpl.odt"
+				  download="AGPL License text.odt">
+				<template #icon>
+					<Download :size="20" />
+				</template>
+				Download AGPL license text
+			</NcActionLink>
+		</NcActions>
+	</div>
 </template>
 <script>
+import Download from 'vue-material-design-icons/Download'
 import OpenInNew from 'vue-material-design-icons/OpenInNew'
 
 export default {
 	components: {
+		Download,
 		OpenInNew,
 	},
 }

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -268,6 +268,14 @@ export default {
 		},
 
 		/**
+		 * Providing the download attribute with href downloads file when clicking.
+		 */
+		download: {
+			type: String,
+			default: null,
+		},
+
+		/**
 		 * Providing the to attribute turns the button component into a `router-link`
 		 * element. Takes precedence over the href attribute.
 		 */
@@ -336,6 +344,9 @@ export default {
 					type: this.href ? null : this.nativeType,
 					role: this.href ? 'button' : null,
 					href: (!this.to && this.href) ? this.href : null,
+					target: (!this.to && this.href) ? '_self' : null,
+					rel: (!this.to && this.href) ? 'nofollow noreferrer noopener' : null,
+					download: (!this.to && this.href && this.download) ? this.download : null,
 					...this.$attrs,
 				},
 				on: {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4262 

To reproduce:
* Link vue-lib to Viewer app
* Left only Download button (NcActionLink) in `Viewer.vue` file https://github.com/nextcloud/viewer/blob/master/src/views/Viewer.vue#L95 
* Compile JS code
* Open NC instance
* Create a text file in Talk app chat
* Try to download it

### 🖼️ Screenshots

| 🏡 After
|---| 
| ![image](https://github.com/nextcloud/nextcloud-vue/assets/93392545/9018a6ae-c701-4b60-ba56-ddd6fb5cba04) |



### 🚧 Tasks

- [ ] Manual testing for shared files
- [ ] Code review 
- [ ] Example of downloaded file - feel free to suggest something different

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
