### PR TITLE
chore(deps): Bump @nextcloud/vue-select from 3.22.2 to 3.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@nextcloud/l10n": "^2.0.1",
         "@nextcloud/logger": "^2.2.1",
         "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue-select": "^3.21.2",
+        "@nextcloud/vue-select": "^3.23.0",
         "@skjnldsv/sanitize-svg": "^1.0.2",
         "@vueuse/components": "^10.0.2",
         "@vueuse/core": "^10.1.2",
@@ -3307,9 +3307,9 @@
       }
     },
     "node_modules/@nextcloud/vue-select": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.22.2.tgz",
-      "integrity": "sha512-nDtoFowunZIaiq5N28Qvbq2CkUWEbvLrj41OYQx8/qw7Dpmm2bOUKAqjUrr8H1NdoNpCN7VyL5gyoWvwC3m+WQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.23.0.tgz",
+      "integrity": "sha512-TerpWxDtbdwda32xtrLcqN8CjcQwVwCrEdHIHIAPQ2y3Ktl/dcjQxGn0onRZqk9+4ZxPGMYdX7LIWRKCHUlrmQ==",
       "peerDependencies": {
         "vue": "2.x"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@nextcloud/l10n": "^2.0.1",
     "@nextcloud/logger": "^2.2.1",
     "@nextcloud/router": "^2.0.0",
-    "@nextcloud/vue-select": "^3.21.2",
+    "@nextcloud/vue-select": "^3.23.0",
     "@skjnldsv/sanitize-svg": "^1.0.2",
     "@vueuse/components": "^10.0.2",
     "@vueuse/core": "^10.1.2",

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -779,6 +779,15 @@ export default {
 		},
 
 		/**
+		 * If false, the focused dropdown option will not be reset when filtered
+		 * options change
+		 */
+		resetFocusOnOptionsChange: {
+			type: Boolean,
+			default: true,
+		},
+
+		/**
 		 * Enable the user selector with avatars
 		 *
 		 * Objects must contain the data expected by the
@@ -1040,6 +1049,10 @@ body {
 		.vs__selected-options {
 			flex-wrap: nowrap;
 			overflow: auto;
+			min-width: unset;
+			.vs__selected {
+				min-width: unset;
+			}
 		}
 	}
 
@@ -1060,20 +1073,6 @@ body {
 		// Hide search from dom if unused to prevent unneeded flex wrap
 		.vs__selected ~ .vs__search[readonly] {
 			position: absolute;
-		}
-	}
-
-	/**
-	 * Fix overlow of selected options
-	 * There is an upstream pull request, if it is merged and released remove this fix
-	 * https://github.com/sagalbot/vue-select/pull/1756
-	 */
-	&:not(.select--no-wrap) {
-		.vs__selected-options {
-			min-width: 0;
-			.vs__selected {
-				min-width: 0;
-			}
 		}
 	}
 


### PR DESCRIPTION
### Summary

- Bump to https://github.com/nextcloud-deps/vue-select/releases/tag/v3.23.0
- Document new prop
- Fix styles

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable