### PR TITLE
fix(NcModal): fix focus-trap fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "emoji-mart-vue-fast": "^15.0.0",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
-        "focus-trap": "^7.1.0",
+        "focus-trap": "^7.4.3",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "node-polyfill-webpack-plugin": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "emoji-mart-vue-fast": "^15.0.0",
     "escape-html": "^1.0.3",
     "floating-vue": "^1.0.0-beta.19",
-    "focus-trap": "^7.1.0",
+    "focus-trap": "^7.4.3",
     "linkify-string": "^4.0.0",
     "md5": "^2.3.0",
     "node-polyfill-webpack-plugin": "^2.0.1",

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -180,7 +180,8 @@ export default {
 			role="dialog"
 			aria-modal="true"
 			:aria-labelledby="'modal-name-' + randId"
-			:aria-describedby="'modal-description-' + randId">
+			:aria-describedby="'modal-description-' + randId"
+			tabindex="-1">
 			<!-- Header -->
 			<transition name="fade-visibility" appear>
 				<div class="modal-header">
@@ -707,11 +708,14 @@ export default {
 			// wait until all children are mounted and available in the DOM before focusTrap can be added
 			await this.$nextTick()
 
-			// Init focus trap
-			this.focusTrap = createFocusTrap(contentContainer, {
+			const options = {
 				allowOutsideClick: true,
+				fallbackFocus: contentContainer,
 				trapStack: getTrapStack(),
-			})
+			}
+
+			// Init focus trap
+			this.focusTrap = createFocusTrap(contentContainer, options)
 			this.focusTrap.activate()
 		},
 		clearFocusTrap() {


### PR DESCRIPTION
Fix #4265 

Sometimes the content is empty or not ready yet.

> `fallbackFocus` {HTMLElement | SVGElement | string | () => HTMLElement | SVGElement | string}: By default, an error will be thrown if the focus trap contains no elements in its tab order. With this option you can specify a fallback element to programmatically receive focus if no other tabbable elements are found. For example, you may want a popover's <div> to receive focus if the popover's content includes no tabbable elements. Make sure the fallback element has a negative tabindex so it can be programmatically focused. The option value can be a DOM node, a selector string (which will be passed to document.querySelector() to find the DOM node), or a function that returns any of these.
