### PR TITLE
NcDatetimePicker: Make sure all l10n strings are extracted

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -158,6 +158,24 @@ msgstr ""
 msgid "People & Body"
 msgstr ""
 
+msgid "Pick a date"
+msgstr ""
+
+msgid "Pick a date and a time"
+msgstr ""
+
+msgid "Pick a month"
+msgstr ""
+
+msgid "Pick a time"
+msgstr ""
+
+msgid "Pick a week"
+msgstr ""
+
+msgid "Pick a year"
+msgstr ""
+
 msgid "Pick an emoji"
 msgstr ""
 

--- a/src/components/NcDatetimePicker/NcDatetimePicker.vue
+++ b/src/components/NcDatetimePicker/NcDatetimePicker.vue
@@ -170,6 +170,8 @@ export default {
 </template>
 
 <script>
+import { t } from '../../l10n.js'
+
 import NcTimezonePicker from '../NcTimezonePicker/index.js'
 import NcPopover from '../NcPopover/index.js'
 import l10n from '../../mixins/l10n.js'
@@ -327,21 +329,21 @@ export default {
 		 */
 		defaultPlaceholder() {
 			if (this.type === 'time') {
-				return this.t('Pick a time')
+				return t('Pick a time')
 			}
 			if (this.type === 'month') {
-				return this.t('Pick a month')
+				return t('Pick a month')
 			}
 			if (this.type === 'year') {
-				return this.t('Pick a year')
+				return t('Pick a year')
 			}
 			if (this.type === 'week') {
-				return this.t('Pick a week')
+				return t('Pick a week')
 			}
 			if (this.type === 'date') {
-				return this.t('Pick a date')
+				return t('Pick a date')
 			}
-			return this.t('Pick a date and a time')
+			return t('Pick a date and a time')
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* Resolves #2701

Currently not all strings are extracted (and can not be extracted).
This happens because `this.t(...)` does not work just `t(...)` work for extracting strings.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
