### PR TITLE
fix: Ensure `extract-l10n` extracts strings from properties

### DIFF
--- a/build/extract-l10n.js
+++ b/build/extract-l10n.js
@@ -1,28 +1,33 @@
-const { GettextExtractor, JsExtractors } = require('gettext-extractor');
+const { GettextExtractor, JsExtractors, HtmlExtractors } = require('gettext-extractor')
 
-let extractor = new GettextExtractor();
+const extractor = new GettextExtractor()
 
-extractor
-    .createJsParser([
-        JsExtractors.callExpression('t', {
-            arguments: {
-                text: 0,
-            }
-        }),
-        JsExtractors.callExpression('n', {
-            arguments: {
-                text: 0,
-                textPlural: 1,
-            }
-        }),
-    ])
-    .parseFilesGlob('./src/**/*.@(ts|js|vue)');
+const jsParser = extractor.createJsParser([
+	JsExtractors.callExpression('t', {
+		arguments: {
+			text: 0,
+		},
+	}),
+	JsExtractors.callExpression('n', {
+		arguments: {
+			text: 0,
+			textPlural: 1,
+		},
+	}),
+])
+	.parseFilesGlob('./src/**/*.@(ts|js)')
+
+extractor.createHtmlParser([
+	HtmlExtractors.embeddedJs('*', jsParser),
+	HtmlExtractors.embeddedAttributeJs(/:[a-z]+/, jsParser),
+])
+	.parseFilesGlob('./src/**/*.vue')
 
 // remove references to avoid conflicts
 extractor.getMessages().forEach((msg) => {
-    msg.references = [];
-});
-      
-extractor.savePotFile('./l10n/messages.pot');
+	msg.references = []
+})
 
-extractor.printStats();
+extractor.savePotFile('./l10n/messages.pot')
+
+extractor.printStats()

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -50,6 +50,9 @@ msgstr ""
 msgid "Choose"
 msgstr ""
 
+msgid "Clear search"
+msgstr ""
+
 msgid "Clear text"
 msgstr ""
 
@@ -135,6 +138,9 @@ msgid "No results"
 msgstr ""
 
 msgid "Objects"
+msgstr ""
+
+msgid "Open contact menu"
 msgstr ""
 
 msgid "Open link to \"{resourceName}\""

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "cypress-visual-regression": "^3.0.0",
         "eslint-plugin-cypress": "^2.11.1",
         "file-loader": "^6.2.0",
-        "gettext-extractor": "^3.5.4",
+        "gettext-extractor": "^3.7.2",
         "gettext-parser": "^7.0.0",
         "glob": "^10.0.0",
         "jest": "^29.0.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cypress-visual-regression": "^3.0.0",
     "eslint-plugin-cypress": "^2.11.1",
     "file-loader": "^6.2.0",
-    "gettext-extractor": "^3.5.4",
+    "gettext-extractor": "^3.7.2",
     "gettext-parser": "^7.0.0",
     "glob": "^10.0.0",
     "jest": "^29.0.1",


### PR DESCRIPTION
### ☑️ Resolves

* Resolves #2062 

There are still some (two at this moment) string which can not be extracted because they are used within properties like `:aria-label="t(...)"`.
To resolve this we need to use the HTML extractor on vue SFC files.

The huge diff is from applying our code style rules (tab vs spaces).

*BTW I tried `gettext-extractor-vue` written by the gitlab team, but that does not work as it converts all `t()` calls to `_t()` or different (compile the SFC), so the extractor does not know which strings to extract.*

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
