### PR TITLE
fix(docs): Add links to documentation for older versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,7 @@
 [![npm last version](https://img.shields.io/npm/v/@nextcloud/vue.svg?style=flat-square)](https://www.npmjs.com/package/@nextcloud/vue)
-[![travis build status](https://img.shields.io/travis/com/nextcloud/nextcloud-vue/master.svg?style=flat-square)](https://travis-ci.com/nextcloud/nextcloud-vue)
+[![build status](https://img.shields.io/github/actions/workflow/status/nextcloud/nextcloud-vue/node.yml?style=flat-square)](https://github.com/nextcloud/nextcloud-vue/actions/workflows/node.yml?query=branch%3Amaster)
 [![Dependabot status](https://img.shields.io/badge/Dependabot-enabled-brightgreen.svg?longCache=true&style=flat-square&logo=dependabot)](https://dependabot.com)
-[![Codacy Badge](https://img.shields.io/codacy/grade/57e9764b68904cbf8f9e050c33340ab4.svg?style=flat-square)](https://app.codacy.com/app/nextcloud/nextcloud-vue)
-[![Code coverage](https://img.shields.io/codecov/c/github/nextcloud/nextcloud-vue.svg?style=flat-square)](https://codecov.io/gh/nextcloud/nextcloud-vue/)
+[![Test status](https://img.shields.io/github/actions/workflow/status/nextcloud/nextcloud-vue/npm-test.yml?style=flat-square&label=Test%20status)](https://github.com/nextcloud/nextcloud-vue/actions/workflows/npm-test.yml?query=branch%3Amaster)
 [![irc](https://img.shields.io/badge/IRC-%23nextcloud--dev%20on%20freenode-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=nextcloud-dev)
 
 This repo contains the various Vue.js components that Nextcloud uses for its internal design and structure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "vue-eslint-parser": "^9.0.3",
         "vue-styleguidist": "~4.72.0",
         "vue-template-compiler": "^2.7.14",
+        "webpack-merge": "^5.9.0",
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
@@ -7199,7 +7200,6 @@
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -7214,7 +7214,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -7227,7 +7226,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21304,7 +21302,6 @@
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -21317,7 +21314,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26830,7 +26826,6 @@
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.9.0.tgz",
       "integrity": "sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
@@ -27104,8 +27099,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/with": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "vue-eslint-parser": "^9.0.3",
     "vue-styleguidist": "~4.72.0",
     "vue-template-compiler": "^2.7.14",
+    "webpack-merge": "^5.9.0",
     "webpack-node-externals": "^3.0.0"
   },
   "jest": {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -62,6 +62,20 @@ module.exports = async () => {
 				usageMode: 'hide',
 			},
 			{
+				name: 'Latest version',
+				href: 'https://nextcloud-vue-components.netlify.app',
+				sections: [
+					{
+						name: 'v7.x (Nextcloud 25 - 27)',
+						href: 'https://stable7--nextcloud-vue-components.netlify.app',
+					},
+					{
+						name: 'v6.x (Nextcloud 24 - 25)',
+						href: 'https://stable6--nextcloud-vue-components.netlify.app',
+					},
+				],
+			},
+			{
 				name: 'Directives',
 				content: 'docs/directives.md',
 			},


### PR DESCRIPTION
### ☑️ Resolves

* Fix #3374

Adds links to documentation for older versions on the styleguide, also fixes the dead badges on the index of the styleguide page (we do not use travis anymore).

### 🖼️ Screenshots

![image](https://github.com/nextcloud/nextcloud-vue/assets/1855448/8f3aafde-8daf-4d13-8362-71da8ccb6dd2)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
