### PR TITLE
8.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.0.0-beta.1",
+  "version": "8.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.0.0-beta.1",
+      "version": "8.0.0-beta.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.0.0-beta.1",
+  "version": "8.0.0-beta.2",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## What's Changed
* Add focus-visible style for NcCheckboxRadioSwitch by @Fenn-CS in https://github.com/nextcloud/nextcloud-vue/pull/4176
* adjust border-radius of ncpopover by @szaimen in https://github.com/nextcloud/nextcloud-vue/pull/4237
* Append custom aria-describedby to input field by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4225
* Automated styling update from server by @nextcloud-command in https://github.com/nextcloud/nextcloud-vue/pull/4186
* chore: update node engines to next LTS by @nextcloud-command in https://github.com/nextcloud/nextcloud-vue/pull/4244
* chore: update workflows from templates by @nextcloud-command in https://github.com/nextcloud/nextcloud-vue/pull/4172
* docs: Add stable documentation links to the readme by @juliushaertl in https://github.com/nextcloud/nextcloud-vue/pull/4227
* enh(NcSelect): Keep dropdown open while loading by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4209
* Fix missing language for scss style by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4250
* Fix NcModal does set the background color but not the text color by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4221
* Fix padding in the 'any link' preview component (smart picker) by @julien-nc in https://github.com/nextcloud/nextcloud-vue/pull/4248
* fix progress-bar on chromium browsers by @szaimen in https://github.com/nextcloud/nextcloud-vue/pull/4238
* Fix Typescript support (config and babel support for transpiling) by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4249
* fix: Ensure `extract-l10n` extracts strings from properties by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4274
* Fix: Leftovers of `name` prop migration + fix `@` in user ids (richEditor) by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4222
* fix: Remove leftovers of hammerJS by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4213
* fix: Revert updating `string-length` to v6 by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4226
* fix(docs): Add links to documentation for older versions by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4275
* fix(NcActionInput): Show trailing button even for empty input by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4251
* fix(NcModal): fix focus-trap fallback by @skjnldsv in https://github.com/nextcloud/nextcloud-vue/pull/4266
* fix(NcProviderList): Add padding around provider list by @juliushaertl in https://github.com/nextcloud/nextcloud-vue/pull/4175
* fix(NcSelect): Adapt to NcListItemIcon by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4210
* fix(NcSelect): Disabled colors by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4217
* fix(NcSelect): Hide clear and deselect when disabled by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4212
* fix(NcSelect): Styles on state change by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4211
* Improve `NcSettingsSelectGroup` - Convert to `NcSelect` by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4120
* Increase input field helper text contrast by @Pytal in https://github.com/nextcloud/nextcloud-vue/pull/4188
* NcAppNavigationCaption: Align actions with other navigation action by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4220
* NcDatetime: New component for displaying timestamps as time relative from now by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4219
* NcDatetimePicker: Make sure all l10n strings are extracted by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4272
* Prevent tabbing into closed navigation by @PVince81 in https://github.com/nextcloud/nextcloud-vue/pull/3114
* Remove deprecated `NcMultiselect` and `NcMultiselectTags` components by @susnux in https://github.com/nextcloud/nextcloud-vue/pull/4281
* Use `display: flex` in app-content-list on mobile as well by @mejo- in https://github.com/nextcloud/nextcloud-vue/pull/4182
* Use NcSelect in NcRichtext by @julien-nc in https://github.com/nextcloud/nextcloud-vue/pull/4247


**Full Changelog**: https://github.com/nextcloud/nextcloud-vue/compare/v8.0.0-beta.1...v8.0.0-beta.2