### PR TITLE
Replace `<p>` with `<span>` to ignore unneeded margin below

### DIFF
--- a/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
+++ b/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
@@ -52,9 +52,9 @@ This component is meant to be used inside a DashboardWidget component.
 				<h3 :title="mainText">
 					{{ mainText }}
 				</h3>
-				<p class="message" :title="subText">
+				<span class="message" :title="subText">
 					{{ subText }}
-				</p>
+				</span>
 			</div>
 			<NcActions v-if="gotMenu" :force-menu="forceMenu">
 				<!-- @slot This slot can be used to provide actions for each dashboard widget item. -->


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/36978
* Fix https://github.com/nextcloud/server/issues/39064

### 🖼️ Screenshots

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![image](https://github.com/nextcloud/activity/assets/6078378/2aca6e5f-6b77-46b2-8348-0056854e7529) | ![Screenshot from 2023-06-29 11-04-42](https://github.com/nextcloud/activity/assets/6078378/e4c77bd2-88fb-4802-9f51-c850d9047cbb)
| ![user status](https://github.com/nextcloud/server/assets/6078378/ac67292a-28cf-455a-b337-82398c6c465d) | ![user status2](https://github.com/nextcloud/server/assets/6078378/005b3581-6808-4b99-86a2-6e26bf999388)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
