### PR TITLE
Set double outline to buttons in focus state

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -505,6 +505,7 @@ export default {
 
 	&:focus-visible {
 		outline: 2px solid var(--color-main-text) !important;
+		box-shadow: 0 0 0 4px var(--color-main-background) !important;
 		&.button-vue--vue-tertiary-on-primary {
 			outline: 2px solid var(--color-primary-element-text);
 			border-radius: var(--border-radius);


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/nextcloud-vue/issues/4193
* Fix https://github.com/nextcloud/text/issues/3860

### 🖼️ Screenshots

🏚️ Before 
![image](https://github.com/nextcloud/nextcloud-vue/assets/6078378/a69227ca-8b0f-457c-adff-995f7a432c42)


🏡 After

![Screenshot from 2023-07-10 16-00-16](https://github.com/nextcloud/nextcloud-vue/assets/6078378/f3c0af4a-8352-49db-bc9a-9d0564628863)
![Screenshot from 2023-07-10 15-59-28](https://github.com/nextcloud/nextcloud-vue/assets/6078378/3486d76f-46c0-4546-aa4c-1dcc381e5d70)
![Screenshot from 2023-07-10 15-41-07](https://github.com/nextcloud/nextcloud-vue/assets/6078378/f4d9bf34-093b-47d9-b155-65e42ee8a3fe)
![Screenshot from 2023-07-10 15-36-30](https://github.com/nextcloud/nextcloud-vue/assets/6078378/68cdaef6-6fe5-4f51-a8c1-4c024bee9b3e)
![Screenshot from 2023-07-10 10-32-22](https://github.com/nextcloud/nextcloud-vue/assets/6078378/47a0bd23-38c5-4ce9-a188-a7364c4e9321)
![Screenshot from 2023-07-10 10-31-43](https://github.com/nextcloud/nextcloud-vue/assets/6078378/42987e7b-ad59-4c5b-97a4-67fbf46769c9)
![Screenshot from 2023-07-04 09-04-14](https://github.com/nextcloud/nextcloud-vue/assets/6078378/14f250a4-983e-4694-b2c6-8eb38f97bc5f)
![Screenshot from 2023-07-03 17-42-59](https://github.com/nextcloud/nextcloud-vue/assets/6078378/ec6bb6d3-554a-4ad7-b3aa-dc1eaba8ba5d)
![Screenshot from 2023-07-03 17-27-30](https://github.com/nextcloud/nextcloud-vue/assets/6078378/03763f38-5259-48c6-a9a1-21a5fc436c8e)
![Screenshot from 2023-07-03 17-19-16](https://github.com/nextcloud/nextcloud-vue/assets/6078378/a3cd9701-8b26-4df7-85da-4dd3b5f41a41)
![Screenshot from 2023-07-10 16-15-58](https://github.com/nextcloud/nextcloud-vue/assets/6078378/852c005e-d15e-44ce-82e6-8bff716d15ae)
![Screenshot from 2023-07-10 16-15-31](https://github.com/nextcloud/nextcloud-vue/assets/6078378/d2d4ea1a-7bba-47b5-b4a0-01f04fcafdfa)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
