### PR TITLE
Migrate building CommonJS module entrypoint to vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@nextcloud/eslint-config": "^8.3.0-beta.0",
         "@nextcloud/stylelint-config": "^2.3.1",
         "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#master",
-        "@susnux/nextcloud-vite-config": "^1.0.0-beta.13",
+        "@susnux/nextcloud-vite-config": "^1.0.0-beta.15",
         "@vue/test-utils": "^1.3.0",
         "@vue/tsconfig": "^0.4.0",
         "@vue/vue2-jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "cypress:gui": "TZ=UTC cypress open --component",
     "cypress:update-snapshots": "TZ=UTC cypress run --component --spec cypress/visual/**/*.cy.js --env type=base --config screenshotsFolder=cypress/snapshots/base"
   },
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     },
     "./dist/": "./dist/"
   },
@@ -103,7 +103,7 @@
     "@nextcloud/eslint-config": "^8.3.0-beta.0",
     "@nextcloud/stylelint-config": "^2.3.1",
     "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#master",
-    "@susnux/nextcloud-vite-config": "^1.0.0-beta.13",
+    "@susnux/nextcloud-vite-config": "^1.0.0-beta.15",
     "@vue/test-utils": "^1.3.0",
     "@vue/tsconfig": "^0.4.0",
     "@vue/vue2-jest": "^29.0.0",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -15,7 +15,7 @@ module.exports = async () => {
 		module: {
 			// Ignore eslint
 			rules: base.module.rules.filter(
-				rule => rule.use !== 'eslint-loader'
+				rule => rule.use !== 'eslint-loader',
 			),
 		},
 	})
@@ -41,6 +41,11 @@ module.exports = async () => {
 						ignorePath: true,
 						secure: false,
 					},
+				},
+			},
+			resolve: {
+				alias: {
+					vue: 'vue/dist/vue.js',
 				},
 			},
 		}),

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -66,8 +66,8 @@ export default defineConfig((env) => {
 		},
 		// For backwards compatibility we include the css within the js files
 		inlineCSS: true,
-		// Disable polyfills
-		coreJS: false,
+		// Build CommonJS files for backwards compatibility
+		libraryFormats: ['es', 'cjs'],
 		replace: {
 			PRODUCTION: JSON.stringify(env.mode === 'production'),
 			SCOPE_VERSION,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,6 @@ console.info('This build version hash is', versionHash, '\n')
 
 webpackConfig.entry = {
 	install: path.join(__dirname, 'src', 'install.js'),
-	index: path.join(__dirname, 'src', 'index.js'),
 
 	...globSync('src/components/*/index.js').reduce((acc, item) => {
 		const name = item


### PR DESCRIPTION
### ☑️ Resolves

* Follow up on #4276 

This uses vite also for the CommonJS module entry point (index).
* Much faster build time (18% faster)¹
* Much smaller output asset: 400kB (vite) vs 1'020kB (webpack)

I tested it with the *text* app, looks good, the js assets of the text app will shrink in total by 254kB with the vite version.

¹ Run time on my system (using `time npm run build`):
```
before:  npm run build  131,93s user 7,69s system 29,180 total
after:   npm run build  117,00s user 6,73s system 23,918 total
```
### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
