### PR TITLE
fix(cypress): Add declaration for `mount` command

### DIFF
--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -20,13 +20,15 @@ import { mount } from '@cypress/vue2'
 // your custom command.
 // Alternatively, can be defined in cypress/support/component.d.ts
 // with a <reference path="./component" /> at the top of your spec.
-// declare global {
-// 	namespace Cypress {
-// 		interface Chainable {
-// 			mount: typeof mount
-// 		}
-// 	}
-// }
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace Cypress {
+		interface Chainable {
+			mount: typeof mount
+		}
+	}
+}
 
 // Example use:
 // cy.mount(MyComponent)


### PR DESCRIPTION
### ☑️ Resolves

Fixes this error thrown when running cypress:
```
ERROR in nextcloud-vue/cypress/support/component.ts
./cypress/support/component.ts 33:21-28
[tsl] ERROR in nextcloud-vue/cypress/support/component.ts(33,22)
      TS2345: Argument of type '"mount"' is not assignable to parameter of type 'keyof Chainable<any>'.
```

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
