### PR TITLE
[stable7] fix(NcSettingsSelectGroup): Fix `this.getValueObject is not a function`

### DIFF
--- a/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
+++ b/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
@@ -111,9 +111,6 @@ export default {
 	},
 	computed: {
 		inputValue() {
-			return this.getValueObject()
-		},
-		getValueObject() {
 			return this.value.filter((group) => group !== '' && typeof group !== 'undefined').map(
 				(id) => {
 					if (typeof this.groups[id] === 'undefined') {


### PR DESCRIPTION
### ☑️ Resolves

* Fixes the error `this.getValueObject is not a function`

The value object is a computed property, so do not use parenthesis. The name was quite misleading and only used for the `inputValue` so just merged it.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
