### PR TITLE
fix(cypress): Escape glob pattern in cypress script to remove warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "styleguide:build": "vue-styleguidist build",
     "cypress": "TZ=UTC cypress run --component",
     "cypress:gui": "TZ=UTC cypress open --component",
-    "cypress:update-snapshots": "TZ=UTC cypress run --component --spec cypress/visual/**/*.cy.js --env type=base --config screenshotsFolder=cypress/snapshots/base"
+    "cypress:update-snapshots": "TZ=UTC cypress run --component --spec \"cypress/visual/**/*.cy.js\" --env type=base --config screenshotsFolder=cypress/snapshots/base"
   },
   "main": "dist/index.cjs",
   "exports": {


### PR DESCRIPTION
### ☑️ Resolves

Currently cypress reports a warning because the glob pattern in the update script is not escaped, this simply fixes the warning. No logic / functional changes.

![image](https://github.com/nextcloud/nextcloud-vue/assets/1855448/80646082-60b3-43bd-bfdd-2972a8d61b9c)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
