### PR TITLE
fix(NcListItem) - define a single place for NcActions to render

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -267,7 +267,8 @@
 						</div>
 
 						<!-- Actions -->
-						<div v-show="displayActionsOnHoverFocus && !forceDisplayActions"
+						<div v-if="!forceDisplayActions"
+							v-show="displayActionsOnHoverFocus"
 							class="list-item-content__actions"
 							@click.prevent.stop="">
 							<NcActions ref="actions"
@@ -279,7 +280,7 @@
 						</div>
 					</div>
 					<!-- Actions -->
-					<div v-show="forceDisplayActions"
+					<div v-if="forceDisplayActions"
 						class="list-item-content__actions"
 						@click.prevent.stop="">
 						<NcActions ref="actions"


### PR DESCRIPTION
### ☑️ Resolves

* Fix #3889 
* I've noticed, that we may render two NcActions component in one NcListItem, but hide one of them with `display: none`
* Because of that, and because of behaviour of `handleTab()` method in NcListItem, we couldn't focus one of the two available action menus
* Not sure, that behaviour now is align with a11y requirements, but at least actions are accessible

### 🖼️ Screenshots

🏚️ Before

https://github.com/nextcloud/nextcloud-vue/assets/93392545/8ea06a24-f030-438a-b0c7-1bdb02e23a53

🏡 After

https://github.com/nextcloud/nextcloud-vue/assets/93392545/e54af34f-64d2-4b15-ae18-4c8fb5072b08

### 🚧 Tasks

- [ ] Code review
- [ ] Manual testing

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
