### PR TITLE
perf(NcEmojiPicker): decrease mounting time and memory by moving large constants initialization and storing out from instance's reactive data

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -189,6 +189,29 @@ import { t } from '../../l10n.js'
 import { Picker, Emoji, EmojiIndex } from 'emoji-mart-vue-fast'
 import data from 'emoji-mart-vue-fast/data/all.json'
 
+// Shared emoji index for all NcEmojiPicker instances
+// Will be initialized on the first NcEmojiPicker creating
+let emojiIndex
+
+const i18n = {
+	search: t('Search emoji'),
+	notfound: t('No emoji found'),
+	categories: {
+		search: t('Search results'),
+		recent: t('Frequently used'),
+		smileys: t('Smileys & Emotion'),
+		people: t('People & Body'),
+		nature: t('Animals & Nature'),
+		foods: t('Food & Drink'),
+		activity: t('Activities'),
+		places: t('Travel & Places'),
+		objects: t('Objects'),
+		symbols: t('Symbols'),
+		flags: t('Flags'),
+		custom: t('Custom'),
+	},
+}
+
 export default {
 	name: 'NcEmojiPicker',
 	components: {
@@ -261,28 +284,23 @@ export default {
 		'select-data',
 		'unselect',
 	],
+
+	setup() {
+		// If this is the first instance of NcEmojiPicker - setup EmojiIndex
+		if (!emojiIndex) {
+			emojiIndex = new EmojiIndex(data)
+		}
+
+		return {
+			// Non-reactive constants
+			emojiIndex,
+			i18n,
+		}
+	},
+
 	data() {
 		return {
-			emojiIndex: new EmojiIndex(data),
 			search: '',
-			i18n: {
-				search: t('Search emoji'),
-				notfound: t('No emoji found'),
-				categories: {
-					search: t('Search results'),
-					recent: t('Frequently used'),
-					smileys: t('Smileys & Emotion'),
-					people: t('People & Body'),
-					nature: t('Animals & Nature'),
-					foods: t('Food & Drink'),
-					activity: t('Activities'),
-					places: t('Travel & Places'),
-					objects: t('Objects'),
-					symbols: t('Symbols'),
-					flags: t('Flags'),
-					custom: t('Custom'),
-				},
-			},
 			open: false,
 		}
 	},


### PR DESCRIPTION
### ☑️ Resolves

- Resolves: `NcEmojiPicker` mounts very slow.

### 📝 PR

`i18n` and `emojiIndex` are not a part of `NcEmojiPicker`'s data. They never change and are not reactive state but just constants. However, they were defined in the `data`. So each time `NcEmojiPicker` instance is created:
1. new copies of `emojiIndex` with constructor `new EmojiIndex` and `i18n` were created
2. they became reactive: Vue recursively loops over each property, re-defined them and create associated `Dep` + `Observer` instances for reactivity.

While for `i18n` it's slightly noticeable (`0.1ms` finally), `emojiIndex` is very huge (with about 1MB data).

### 🖼️ Result

Moving constants from `data` outside the component decreases mounting time and allocating memory.

Metric | 🐌 Before | 🏎️ After
---|---|---
**Mount time** | `40 - 42 ms` per instance | `0.90 - 0.98 ms` per instance
**Memory** | `1.325 MB` per instance | `0.073 MB` per instance + 1 MB shared
**Allocation sampling** | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2aaf9295-14ed-4b27-9dee-906d046d3c65) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/461ccefa-bf54-4a4d-aec5-a1ec7a988ab3)

`40ms` may sound nothing. But it multiplies on instances count. So mounting 100 pickers was **4 seconds** of blocking time.

It also saves about `1.3 MB RAM` per instance. Also sounds small, but it is **130 MB** per tab with 100 pickers.

Example: Conversations in Talk with many messages with reactions.

### Alternative solution

Initialization of `emojiIndex` was moved to `setup` with a check if it was initialized before. So the  index is not initialized before the first instance mounting.

We can move it to the module, so index will be ready before the first instance is mounted.

### P.S.

`NcPicker` is still super slow on opening and it is still > 1MB in the bundle.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable