### PR TITLE
fix(userstatus): Fix colors of user status icons

### DIFF
--- a/src/assets/status-icons/user-status-away.svg
+++ b/src/assets/status-icons/user-status-away.svg
@@ -1,5 +1,5 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 	<path fill="none" d="M-4-4h24v24H-4z" />
-	<path fill="var(--color-warning)" d="M6.9.1C3 .6-.1 4-.1 8c0 4.4 3.6 8 8 8 4 0 7.4-3 8-6.9-1.2 1.3-2.9 2.1-4.7 2.1-3.5 0-6.4-2.9-6.4-6.4 0-1.9.8-3.6 2.1-4.7z" />
+	<path fill="#f4a331" d="M6.9.1C3 .6-.1 4-.1 8c0 4.4 3.6 8 8 8 4 0 7.4-3 8-6.9-1.2 1.3-2.9 2.1-4.7 2.1-3.5 0-6.4-2.9-6.4-6.4 0-1.9.8-3.6 2.1-4.7z" />
 </svg>

--- a/src/assets/status-icons/user-status-dnd.svg
+++ b/src/assets/status-icons/user-status-dnd.svg
@@ -1,6 +1,6 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 	<path fill="none" d="M-4-4h24v24H-4V-4z" />
-	<path fill="var(--color-error)" d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8z" />
+	<path fill="#ed484c" d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8z" />
 	<path fill="#fdffff" d="M5 6.5h6c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5H5c-.8 0-1.5-.7-1.5-1.5S4.2 6.5 5 6.5z" />
 </svg>

--- a/src/assets/status-icons/user-status-online.svg
+++ b/src/assets/status-icons/user-status-online.svg
@@ -1,4 +1,4 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<path fill="var(--color-success)" d="M4.8 11.2h6.4V4.8H4.8v6.4zM8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8z" />
+	<path fill="#49B382" d="M4.8 11.2h6.4V4.8H4.8v6.4zM8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8z" />
 </svg>


### PR DESCRIPTION
All the status colors are slightly off. Most noticable on away in bright mode.

### 🖼️ Screenshots

Bright | Dark
---|---
![Bildschirmfoto vom 2024-01-22 10-05-00](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/927fc998-f8c0-44d5-a7d8-9336128204de) | ![Bildschirmfoto vom 2024-01-22 09-59-15](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/25758570-ddaa-4e06-a6f8-7bb012fb0cb7)
![Bildschirmfoto vom 2024-01-22 10-05-09](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/1274df06-8be2-4b58-b4d6-d3e59d914b29)| ![Bildschirmfoto vom 2024-01-22 10-01-04](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/7adfc5f5-dd54-4472-8146-66dfd985fc95)
![Bildschirmfoto vom 2024-01-22 10-05-15](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/62e8b702-f83c-4ec5-8794-adf5d1fbfb59) | ![Bildschirmfoto vom 2024-01-22 10-01-11](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/36a36cb0-c4ea-42da-8e66-959396c0a675)

If the colors are not okay, we need to change them in the original SVGs which are the ones used all over the place:
https://github.com/nextcloud/server/tree/4a08736a9bc0ff0bb2dced31c1cd2585e42d3972/apps/user_status/img
But they need to work with dark and bright mode at the same time.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
