### PR TITLE
fix(NcRichContenteditable): respect forward slash as user mention character

### DIFF
--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -32,7 +32,7 @@ const MENTION_START = '(?:^|\\s)'
 // Anything that is not text or end-of-line. Non-capturing group
 const MENTION_END = '(?:[^a-z]|$)'
 export const USERID_REGEX = new RegExp(`${MENTION_START}(@[a-zA-Z0-9_.@\\-']+)(${MENTION_END})`, 'gi')
-export const USERID_REGEX_WITH_SPACE = new RegExp(`${MENTION_START}(@&quot;[a-zA-Z0-9 _.@\\-']+&quot;)(${MENTION_END})`, 'gi')
+export const USERID_REGEX_WITH_SPACE = new RegExp(`${MENTION_START}(@&quot;[a-zA-Z0-9 _/.@\\-']+&quot;)(${MENTION_END})`, 'gi')
 
 export default {
 	props: {


### PR DESCRIPTION
### ☑️ Resolves

- During text parsing, user mentions wrapped with double quotes (@"user@nextcloud.com" or @"space user") handled differently from unwrapped.
- There are cases mention could contain forward slash character (@"group/talk"), regex should respect that character correctly
- Otherwise two following complex mention match groups treated as one

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-02-28 17-47-22](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/4f4cde73-51e5-4e7c-9c6a-4c635aa4a8e7) | ![Screenshot from 2024-02-28 17-48-15](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/d591f539-306f-432f-9b92-d6a2defc6ca0)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
