### PR TITLE
chore(deps): externalize `vue-router` by moving from from `devDeps` to `deps`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "vue": "^2.7.16",
         "vue-color": "^2.8.1",
         "vue-frag": "^1.4.3",
+        "vue-router": "^3.6.5",
         "vue2-datepicker": "^3.11.0"
       },
       "devDependencies": {
@@ -93,7 +94,6 @@
         "vite": "^5.0.10",
         "vue-eslint-parser": "^9.0.3",
         "vue-material-design-icons": "^5.2.0",
-        "vue-router": "^3.6.5",
         "vue-styleguidist": "~4.72.0",
         "vue-template-compiler": "^2.7.16",
         "webpack": "^5.88.1",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "vue": "^2.7.16",
     "vue-color": "^2.8.1",
     "vue-frag": "^1.4.3",
+    "vue-router": "^3.6.5",
     "vue2-datepicker": "^3.11.0"
   },
   "engines": {
@@ -152,7 +153,6 @@
     "vite": "^5.0.10",
     "vue-eslint-parser": "^9.0.3",
     "vue-material-design-icons": "^5.2.0",
-    "vue-router": "^3.6.5",
     "vue-styleguidist": "~4.72.0",
     "vue-template-compiler": "^2.7.16",
     "webpack": "^5.88.1",


### PR DESCRIPTION
### ☑️ Resolves

- Partial forwardport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/5672