### PR TITLE
[next] chore(Nc*Field): icon slot change note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
   - `NcTextArea`
   - `NcTextField`
   - `NcTimezonePicker`
+* The leading icon slot was changed from `#default` to `#icon` in `Nc*Field` components:
+  - `NcInputField`
+  - `NcTextField`
+  - `NcPasswordField`
 * The `exact` prop was removed. This affects the following components:
   - `NcActionRouter`
   - `NcAppNavigationItem`

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -52,7 +52,7 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 
 			<!-- Leading icon -->
 			<div v-show="!!$slots.icon" class="input-field__icon input-field__icon--leading">
-				<!-- Leading material design icon in the text field, set the size to 18 -->
+				<!-- @slot Leading icon, set the size to 18 -->
 				<slot name="icon" />
 			</div>
 

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -105,7 +105,7 @@ export default {
 		@trailing-button-click="togglePasswordVisibility"
 		@update:model-value="handleInput">
 		<template v-if="!!$slots.icon" #icon>
-			<!-- Default slot for the leading icon -->
+			<!-- @slot Leading icon -->
 			<slot name="icon" />
 		</template>
 		<template #trailing-button-icon>

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -129,7 +129,7 @@ export default {
 		ref="inputField"
 		@update:model-value="handleInput">
 		<template v-if="!!$slots.icon" #icon>
-			<!-- Default slot for the leading icon -->
+			<!-- @slot Leading icon -->
 			<slot name="icon" />
 		</template>
 


### PR DESCRIPTION
### ☑️ Resolves

- `#default` slot was changed to `#icon` long time agon during Vue 3 migration
- Adding it to the CHANGELOG and updating docs

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
