### PR TITLE
fix(NcAppSidebar): remove custom styles from close button

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1310,16 +1310,6 @@ $top-buttons-spacing: $app-navigation-padding; // align with app navigation
 			z-index: 100;
 			top: $top-buttons-spacing;
 			inset-inline-end: $top-buttons-spacing;
-			width: var(--default-clickable-area);
-			height: var(--default-clickable-area);
-			opacity: $opacity_normal;
-			border-radius: calc(var(--default-clickable-area) / 2);
-			&:hover,
-			&:active,
-			&:focus {
-				opacity: $opacity_full;
-				background-color: $action-background-hover;
-			}
 		}
 
 		// Compact mode only affects a sidebar with a figure


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/6392
- Also make the button less rounded, inline with other buttons

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
