### PR TITLE
fix(NcEmojiPicker): arrow navigation

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -139,7 +139,7 @@ This component allows the user to pick an emoji.
 			v-bind="$attrs"
 			@keydown.native.tab.prevent="handleTabNavigationSkippingEmojis"
 			@select="select">
-			<template #searchTemplate="slotProps">
+			<template #searchTemplate="{ onSearch }">
 				<div class="search__wrapper">
 					<NcTextField ref="search"
 						class="search"
@@ -155,8 +155,8 @@ This component allows the user to pick an emoji.
 						@keydown.down="callPickerArrowHandlerWithScrollFix('onArrowDown', $event)"
 						@keydown.up="callPickerArrowHandlerWithScrollFix('onArrowUp', $event)"
 						@keydown.enter="$refs.picker.onEnter"
-						@trailing-button-click="clearSearch(); slotProps.onSearch(search);"
-						@update:value="slotProps.onSearch(search)" />
+						@trailing-button-click="clearSearch(); onSearch('');"
+						@update:value="onSearch(search)" />
 					<NcColorPicker palette-only
 						:container="container"
 						:palette="skinTonePalette"
@@ -359,10 +359,7 @@ export default {
 
 		clearSearch() {
 			this.search = ''
-			const input = this.$refs.search?.$refs.inputField?.$refs.input
-			if (input) {
-				input.focus()
-			}
+			this.$refs.search.focus()
 		},
 
 		/**
@@ -575,15 +572,13 @@ export default {
 </style>
 
 <style scoped lang="scss">
-.search {
-	&__wrapper {
-		display: flex;
-		flex-direction: row;
-		gap: var(--default-grid-baseline);
-		align-items: end;
-		padding-block: var(--default-grid-baseline);
-		padding-inline: calc(2 * var(--default-grid-baseline));
-	}
+.search__wrapper {
+	display: flex;
+	flex-direction: row;
+	gap: var(--default-grid-baseline);
+	align-items: end;
+	padding-block: var(--default-grid-baseline);
+	padding-inline: calc(2 * var(--default-grid-baseline));
 }
 
 .row-selected {


### PR DESCRIPTION
## Improving `NcEmojiPicker`: part 2 of 3

### ☑️ Resolves

- Part 1: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6465
- Fix: https://github.com/nextcloud-libraries/nextcloud-vue/issues/1360
- `emoji-mart-vue-fast` has arrow navigation, but:
  - It doesn't work for a custom search field
  - It has a bug: scrolling to wrong positions and breaking on switch between sections

This PR:
- Adds arrow navigation using `emoji-mart-vue-fast` handlers with a custom fix
- Makes sure TAB navigation doesn't go over 1000 emojis

Note: selecting the category tab only scrolls and doesn't select the first emoji in the category. Also not implemented by upstream.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![arrow-before](https://github.com/user-attachments/assets/d1c26b46-331e-40d6-8d69-de66d75b5f39) | ![arrow-after](https://github.com/user-attachments/assets/b2737513-0068-4a7f-b49e-e9f0d0f7a163)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
