### PR TITLE
perf(NcEmojiPicker): open x1.5-x2 faster + doesn't impact page loading

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -211,9 +211,23 @@ import NcColorPicker from '../NcColorPicker/NcColorPicker.vue'
 import NcPopover from '../NcPopover/index.js'
 import NcTextField from '../NcTextField/index.js'
 
-// Shared emoji index and skinTone for all NcEmojiPicker instances
-// Will be initialized on the first NcEmojiPicker creating
 let emojiIndex
+
+/**
+ * Initialize shared EmojiIndex if it's not initialized yet
+ */
+function initEmojiIndexIfNeeded() {
+	if (!emojiIndex) {
+		emojiIndex = new EmojiIndex(data)
+	}
+}
+
+// Initializing EmojiIndex may take up to 100ms...
+// - Doing it in module-scope leads to blocking the main thread on page init (unacceptable)
+// - Doing it in setup leads to blocking the thread on the first NcEmojiPicker creating (more or less acceptable)
+// The best - do it in the idle time if possible.
+// This method is not available in Safari - it will load EmojiIndex on the first NcEmojiPicker creating in setup.
+window.requestIdleCallback?.(initEmojiIndexIfNeeded)
 
 const i18n = {
 	search: t('Search emoji'),
@@ -334,10 +348,7 @@ export default {
 		const _log = (...args) => log(id, ...args)
 		_log('setup | start')
 
-		// If this is the first instance of NcEmojiPicker - setup EmojiIndex
-		if (!emojiIndex) {
-			emojiIndex = new EmojiIndex(data)
-		}
+		initEmojiIndexIfNeeded()
 
 		_log('setup | end')
 


### PR DESCRIPTION
## Improving `NcEmojiPicker`: part 3 of 3

### ☑️ Resolves

- Part 2: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6466
- Improve page loading performance - **100ms -> 0ms** (no more blocking)
- Improve opening performance - **x1.5 .. x2**
  - The best we can do with `emoji-mart-vue-fast`
- Occasionally
  - Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/3840

<details>

<summary>🥱 Boring details | Part 1: initial load 👇</summary>

`NcEmojiPicker` requires creating `EmojiIndex` with blocks the main thread for about 100ms or more!

We already improved it by:
- Making it only once (instead of every component instance 😵)
- Making it in `setup` (not blocking initial Nextcloud app loading)

However, it still blocks the main thread app to 100ms once there is the picker on the page...

Improvement (except Safari) - using [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback). 

In the best case - no blocking anymore at all.

In the worth case (it's Safari, or EmojiPicker renders initially) - works as in the past.

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/eff51d48-9e5b-49db-b171-f35c8af7d93a) | ![image](https://github.com/user-attachments/assets/111ad1e1-0a23-4cbe-aa9d-a525343f7e26)

</details>

<details>

<summary>🥱 Boring details | Part 2: opening 👇</summary>

Opening `NcEmojiPicker` is slow... But why? 🤔
- Empty `NcPopover` is quite fast (30ms)
- Raw `emoji-mart-vue-fast` is relatively acceptable (50-60ms)

Empty `NcPopover` | Raw `emoji-mart-vue-fast`
---|---
`~30ms` | `~60ms`
![Empty-NcPopover](https://github.com/user-attachments/assets/6f140c89-a395-41a3-82ff-a7b5adfa18a9) | ![Raw-emoji-mart-vue-fast](https://github.com/user-attachments/assets/d03db7e7-edcc-4fdf-b88d-39e4b330e1f9)

But opening `NcEmojiPicker` = `NcPopover + emoji-mart-vue-fast` is 🐌 SLOW, up to:
- 160ms..200ms - clean open
- 120ms..150ms - quick reopen (optimized by NcPopover)

![image](https://github.com/user-attachments/assets/8715398c-fbe4-4ce2-881b-d9fdce6cffe8)

![NcEmojiPicker](https://github.com/user-attachments/assets/ed43d52a-235f-41aa-9ac6-547d316fd4dc)

It looks like `floating-vue (NcPopover)` first renders everything, when makes it "hiddenly visible) to get size and calculate position, and then renders it visually. It causes unneeded reflow, slightly blocking the process (even on optimized reopening, when everything is in DOM already).

A solution - mount `NcPopover` with dummy empty div with the same size, and then render `emoji-mart-vue-fast` into a prepared container.

![NcEmojiPicker - new](https://github.com/user-attachments/assets/baa2ec34-36eb-437d-980b-9c9d9735c068)

🏚️ Before | 🏡 After
---|---
Clean open | Clean open
200ms | 95ms
![image](https://github.com/user-attachments/assets/fa459a8b-47b9-4d30-9516-045de32a8576) | ![image](https://github.com/user-attachments/assets/9d76f48b-c15e-43ad-b103-599206a42550)
Quick reopen (optimized by NcPopover) | .
100ms (even without Picker mounting!!!) | 65ms full remount
![image](https://github.com/user-attachments/assets/6423db5b-3c96-4148-ab89-0dfeeffe444b) | ![image](https://github.com/user-attachments/assets/6052b043-6232-46fc-976f-23b6e9f70ba4)

</details>

### 🖼️ Screenshots

<details>

<summary>Useless gifs. Better to test in real app like Talk</summary>

🏚️ Before | 🏡 After
---|---
Clean open | .
![before-clean](https://github.com/user-attachments/assets/80f2985a-6369-48ee-95a7-e010dd36b5c3) | ![after-clean](https://github.com/user-attachments/assets/23f25971-711e-41e3-9ac3-c1a483b77b84)
Quick reopen
![before-reopen](https://github.com/user-attachments/assets/9dc6ce74-09b0-403b-9907-fb3983ff4f58) | ![after-reopen](https://github.com/user-attachments/assets/17525269-cd42-4d15-9854-0d0f8e65d2fa)

</details>

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
