### PR TITLE
fix(NcActionInput): register used NcColorPicker component

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -240,6 +240,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 </template>
 
 <script>
+import NcColorPicker from '../NcColorPicker/index.js'
 import NcDateTimePicker from '../NcDateTimePicker/index.js'
 import NcDateTimePickerNative from '../NcDateTimePickerNative/index.js'
 import NcPasswordField from '../NcPasswordField/index.js'
@@ -253,6 +254,7 @@ export default {
 	name: 'NcActionInput',
 
 	components: {
+		NcColorPicker,
 		NcDateTimePicker,
 		NcDateTimePickerNative,
 		NcPasswordField,


### PR DESCRIPTION


### ☑️ Resolves

- resolves https://github.com/nextcloud-libraries/nextcloud-vue/issues/6930

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
