### PR TITLE
fix(actions): use pointer cursor for action button text

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -567,7 +567,13 @@ export default {
 @include action--disabled;
 @include action-item('button');
 
-.action-button__pressed-icon {
-	margin-inline: auto calc($icon-margin * -1);
+.action-button {
+	&__pressed-icon {
+		margin-inline: auto calc($icon-margin * -1);
+	}
+
+	* {
+		cursor: pointer;
+	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Fixes https://github.com/nextcloud/server/blob/7be047a5c08d4401899d38c9a7d7ebdb6d8e78b2/core/css/styles.scss#L22 changing the text span to a default cursor.

This can be seen in recent deployments of Talk, Mail, etc. You get a pointer when hovering over actions but not when you reach the text element, then it changes back to the default.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
not screenshotable | not screenshotable

### 🚧 Tasks

- [x] Do

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
