### PR TITLE
fix(NcAvatar): migrate from deprecated `showUserStatus` prop

### DIFF
--- a/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
+++ b/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
@@ -25,7 +25,7 @@ This component is meant to be used inside a DashboardWidget component.
 					:url="avatarUrl"
 					:user="avatarUsername"
 					:is-no-user="avatarIsNoUser"
-					:show-user-status="!gotOverlayIcon" />
+					:hide-status="gotOverlayIcon" />
 			</slot>
 			<img v-if="overlayIconUrl"
 				class="item-icon"

--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -245,7 +245,7 @@ watch([() => props.displayName, () => props.user], () => {
 					:style="avatarStyle"
 					:disable-tooltip="true"
 					:disable-menu="true"
-					:show-user-status="showUserStatus"
+					:hide-status="!showUserStatus"
 					class="user-bubble__avatar" />
 
 				<!-- Name -->


### PR DESCRIPTION
### ☑️ Resolves

- Minor regression

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="272" alt="2025-06-17_19h01_24" src="https://github.com/user-attachments/assets/4b2dac22-b3f8-4c00-9c85-b79a2e9a9a11" /> | <img width="273" alt="2025-06-17_19h03_14" src="https://github.com/user-attachments/assets/32f41265-5fd3-438a-8c26-2439a1ae0a5b" />


### 🚧 Tasks

- [ ] test Dashboard component

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
