### PR TITLE
chore(NcActions): fix type annotation of `NodeList`

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1421,7 +1421,7 @@ export default {
 		},
 
 		/**
-		 * @return {NodeListOf<HTMLElement>}
+		 * @return {NodeList<HTMLElement>}
 		 */
 		getFocusableMenuItemElements() {
 			return this.$refs.menu.querySelectorAll(focusableSelector)


### PR DESCRIPTION
### ☑️ Resolves

Just a small fix to get rid of ESLint warning (unknown type `NodeListOf` because its called `NodeList`).

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
