### PR TITLE
fix(NcModal): correctly handle when trying to activate non-existing focus-trap

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -345,6 +345,7 @@ import Timer from '../../utils/Timer.js'
 import Close from 'vue-material-design-icons/Close.vue'
 import Pause from 'vue-material-design-icons/Pause.vue'
 import Play from 'vue-material-design-icons/Play.vue'
+import { useTrapStackControl } from '../../composables/useTrapStackControl.js'
 
 export default {
 	name: 'NcModal',
@@ -552,7 +553,6 @@ export default {
 			slideshowTimeout: null,
 			iconSize: 24,
 			focusTrap: null,
-			externalFocusTrapStack: [],
 			randId: createElementId(),
 			internalShow: true,
 		}
@@ -614,6 +614,10 @@ export default {
 				this.focusTrap.updateContainerElements([contentContainer, ...elements])
 			}
 		},
+	},
+
+	created() {
+		useTrapStackControl(() => this.showModal)
 	},
 
 	beforeMount() {
@@ -825,11 +829,6 @@ export default {
 				setReturnFocus: this.setReturnFocus,
 			}
 
-			// Deactivate other focus traps to unlock modal elements
-			this.externalFocusTrapStack = [...options.trapStack]
-			for (const trap of this.externalFocusTrapStack) {
-				trap.deactivate()
-			}
 			// Init focus trap
 			this.focusTrap = createFocusTrap([contentContainer, ...this.additionalTrapElements], options)
 			this.focusTrap.activate()
@@ -840,10 +839,6 @@ export default {
 			}
 			this.focusTrap?.deactivate()
 			this.focusTrap = null
-			for (const trap of this.externalFocusTrapStack) {
-				trap.activate()
-			}
-			this.externalFocusTrapStack = []
 		},
 
 	},


### PR DESCRIPTION
### ☑️ Resolves

- Fix handling of focus trap stack, if there are several
- Fix issue when trying to activate non-existing focus-trap
- Copied form NcEmojiPicker
- Tested in Talk

### 🖼️ Screenshots

Before

<img width="280" alt="image" src="https://github.com/user-attachments/assets/2ffa8d7a-bee1-4ce7-9cc6-3588b2069c50" />

After

https://github.com/user-attachments/assets/8b5ab329-67ea-4ed3-b747-fa894f86e91d

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
