### PR TITLE
refactor: replace deprecated CSS variables and legacy fallbacks

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -13,7 +13,7 @@
 	min-height: var(--default-clickable-area);
 	transition: background-color var(--animation-quick) ease-in-out;
 	transition: background-color 200ms ease-in-out;
-	border-radius: var(--border-radius-element, var(--border-radius-pill));
+	border-radius: var(--border-radius-element);
 
 	&-wrapper {
 		position: relative;
@@ -120,7 +120,7 @@
 		&:focus-visible {
 			box-shadow: 0 0 0 4px var(--color-main-background);
 			outline: 2px solid var(--color-main-text);
-			border-radius: var(--border-radius-element, var(--border-radius-pill));
+			border-radius: var(--border-radius-element);
 		}
 	}
 }

--- a/src/assets/inputs.scss
+++ b/src/assets/inputs.scss
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 @use './variables.scss' as *;
-/**
- * color-text-lighter		normal state
- * color-text-lighter		active state
- * color-text-maxcontrast 	disabled state
- */
 
 /* Default global values */
 button:not(.button-vue),
@@ -18,9 +13,9 @@ textarea {
 
 	cursor: text;
 
-	color: var(--color-text-lighter);
+	color: var(--color-main-text);
 	border: 1px solid var(--color-border-dark);
-	border-radius: var(--border-radius);
+	border-radius: var(--border-radius-element);
 	outline: none;
 	background-color: var(--color-main-background);
 
@@ -36,7 +31,7 @@ textarea {
 		}
 
 		&:active {
-			color: var(--color-text-light);
+			color: var(--color-main-text);
 			outline: none;
 			background-color: var(--color-main-background);
 		}

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -151,7 +151,7 @@ export default defineComponent({
 
 			&.action-button--active {
 				background-color: var(--color-primary-element);
-				border-radius: var(--border-radius-large);
+				border-radius: var(--border-radius-element);
 				color: var(--color-primary-element-text);
 
 				&:hover, &:focus, &:focus-within {

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -551,7 +551,7 @@ $input-margin: 4px;
 			&__preview {
 				width: 100%;
 				height: 36px;
-				border-radius: var(--border-radius-large);
+				border-radius: var(--border-radius-element);
 				border: 2px solid var(--color-border-maxcontrast);
 				box-shadow: none !important;
 			}

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1948,10 +1948,10 @@ export default {
 // We overwrote the popover base class, so we can style
 // the popover__inner for actions only.
 .v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__wrapper {
-	border-radius: var(--border-radius-large);
+	border-radius: var(--border-radius-element);
 
 	.v-popper__inner {
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 		padding: 4px;
 		max-height: calc(100vh - var(--header-height));
 		overflow: auto;

--- a/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
+++ b/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
@@ -245,10 +245,5 @@ function onCloseSearch() {
 			margin-inline-start: calc(-1 * var(--default-clickable-area));
 		}
 	}
-
-	&__input {
-		// This is a fallback for legacy version (Nextcloud 29 and older) so that we keep the pill like design there
-		--input-border-radius: var(--border-radius-element, var(--border-radius-pill)) !important;
-	}
 }
 </style>

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -409,7 +409,7 @@ export default {
 		height: var(--default-clickable-area);
 		margin: 4px 0;
 		line-height: var(--default-clickable-area);
-		border-radius: var(--border-radius-element, var(--border-radius-pill));
+		border-radius: var(--border-radius-element);
 		font-weight: bold;
 		padding: 0 calc(4 * var(--default-grid-baseline));
 		cursor: pointer;

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -719,7 +719,7 @@ function onClick(event: MouseEvent) {
 <style lang="scss" scoped>
 .button-vue {
 	--button-size: var(--default-clickable-area);
-	--button-radius: var(--border-radius-element, calc(var(--button-size) / 2));
+	--button-radius: var(--border-radius-element);
 	--button-padding-default: min(calc(var(--default-grid-baseline) + var(--button-radius)), calc(var(--default-grid-baseline) * 4));
 	--button-padding: var(--default-grid-baseline) var(--button-padding-default);
 
@@ -751,12 +751,12 @@ function onClick(event: MouseEvent) {
 
 	// Setup different button sizes
 	&--size-small {
-		--button-size: var(--clickable-area-small, 24px);
-		--button-radius: var(--border-radius); // make the border radius even smaller for small buttons
+		--button-size: var(--clickable-area-small);
+		--button-radius: var(--border-radius-small); // make the border radius even smaller for small buttons
 	}
 
 	&--size-large {
-		--button-size: var(--clickable-area-large, 48px);
+		--button-size: var(--clickable-area-large);
 	}
 
 	// Cursor pointer on element and all children
@@ -881,7 +881,7 @@ function onClick(event: MouseEvent) {
 		box-shadow: 0 0 0 4px var(--color-main-background) !important;
 		&.button-vue--vue-tertiary-on-primary {
 			outline: 2px solid var(--color-primary-element-text);
-			border-radius: var(--border-radius-element, var(--border-radius));
+			border-radius: var(--border-radius-element);
 			background-color: transparent;
 		}
 	}

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -637,7 +637,7 @@ export default {
 .checkbox-radio-switch {
 	--icon-size: v-bind('cssIconSize');
 	--icon-height: v-bind('cssIconHeight');
-	--checkbox-radio-switch--border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
+	--checkbox-radio-switch--border-radius: var(--border-radius-element);
 	// keep inner border width in mind
 	--checkbox-radio-switch--border-radius-outer: calc(var(--checkbox-radio-switch--border-radius) + 2px);
 	// general setup

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -426,12 +426,12 @@ function hexToRGB(hex: string) {
 			background-color: var(--color-main-background);
 
 			.vc-input__input {
-				--input-border-radius: var(--border-radius-element, var(--border-radius-large));
+				--input-border-radius: var(--border-radius-element);
 				--input-border-width-offset: calc(var(--border-width-input-focused, 2px) - var(--border-width-input, 2px));
 				width: 100%;
 				height: var(--default-clickable-area);
 				margin: 0;
-				padding-inline: calc(var(--border-radius-large) + var(--input-border-width-offset));
+				padding-inline: calc(var(--border-radius-element) + var(--input-border-width-offset));
 				padding-block: var(--input-border-width-offset);
 				border: var(--border-width-input, 2px) solid var(--color-border-maxcontrast);
 				border-radius: var(--input-border-radius);
@@ -459,7 +459,7 @@ function hexToRGB(hex: string) {
 				inset-inline: var(--border-width-input-focused, 2px);
 				inset-block-start: calc(-1.5 * var(--font-size-small, 13px) / 2);
 				max-width: fit-content;
-				margin-inline: calc(var(--border-radius-large) - var(--default-grid-baseline));
+				margin-inline: calc(var(--border-radius-element) - var(--default-grid-baseline));
 				margin-block: 0;
 				padding-inline: var(--default-grid-baseline);
 				font-family: var(--font-face);

--- a/src/components/NcContent/NcContent.vue
+++ b/src/components/NcContent/NcContent.vue
@@ -195,7 +195,7 @@ function setAppNavigation(value: boolean): void {
 .vue-skip-actions {
 	&__container {
 		background-color: var(--color-main-background);
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 		padding: 22px;
 	}
 

--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -212,7 +212,7 @@ const originalCountAsTitleIfNeeded = computed(() => {
 	text-align: center;
 	line-height: var(--counter-bubble-height); // Expand line-height to full height to center text vertically
 	padding: 0 calc(1.5 * var(--default-grid-baseline));
-	border-radius: var(--border-radius-pill);
+	border-radius: 0.5lh;
 	background-color: var(--color-primary-element-light);
 	font-weight: bold;
 	color: var(--color-primary-element-light-text);

--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -351,7 +351,7 @@ export default {
 	&:hover,
 	&:focus {
 		background-color: var(--color-background-hover);
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 		color: var(--color-main-text);
 	}
 }

--- a/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
+++ b/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
@@ -188,7 +188,7 @@ export default {
 	&:hover,
 	&:focus {
 		background-color: var(--color-background-hover);
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 	}
 	.item-avatar {
 		position: relative;

--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -263,7 +263,7 @@ function onInput(event: Event): void {
 		width: 100%;
 		flex: 0 0 auto;
 		margin: 0;
-		padding-inline-start: calc(var(--border-radius-large) + var(--input-border-width-offset));
+		padding-inline-start: calc(var(--border-radius-element) + var(--input-border-width-offset));
 		padding-inline-end: calc(var(--default-grid-baseline) + var(--input-border-width-offset));
 		border: var(--border-width-input, 2px) solid var(--color-border-maxcontrast);
 

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -543,7 +543,7 @@ const modalProps = computed(() => ({
 		max-height: 90%;
 		position: relative;
 		top: unset;
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 	}
 }
 </style>

--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -565,7 +565,7 @@ export default {
 		&.emoji-mart-emoji-selected {
 			background-color: var(--color-background-hover) !important;
 			border: none;
-			border-radius: var(--border-radius-element, var(--border-radius-pill));
+			border-radius: var(--border-radius-element);
 			box-shadow: none !important;
 			outline: 2px solid var(--color-primary-element) !important;
 			outline-offset: -2px;

--- a/src/components/NcGuestContent/NcGuestContent.vue
+++ b/src/components/NcGuestContent/NcGuestContent.vue
@@ -52,7 +52,7 @@ onUnmounted(() => {
 	color: var(--color-main-text);
 	background-color: var(--color-main-background);
 	min-width: 0;
-	border-radius: var(--border-radius-large);
+	border-radius: var(--border-radius-element);
 	box-shadow: 0 0 10px var(--color-box-shadow);
 	height: fit-content;
 	padding: 15px;

--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -296,8 +296,7 @@ $externalMargin: 8px;
 		inset-inline-end: 0;
 		box-sizing: border-box;
 		margin: 0 $externalMargin;
-		border-radius: 0 0 var(--border-radius) var(--border-radius);
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 		background-color: var(--color-main-background);
 
 		filter: drop-shadow(0 1px 5px var(--color-box-shadow));

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -282,11 +282,11 @@ function handleInput(event: Event) {
 <style lang="scss" scoped>
 
 .input-field {
-	--input-border-radius: var(--border-radius-element, var(--border-radius-large));
+	--input-border-radius: var(--border-radius-element);
 	// The padding before the input can start (leading button or border)
-	--input-padding-start: var(--border-radius-large);
+	--input-padding-start: var(--border-radius-element);
 	// The padding where the input has to end (trailing button or border)
-	--input-padding-end: var(--border-radius-large);
+	--input-padding-end: var(--border-radius-element);
 	// positional styles
 	position: relative;
 	width: 100%;
@@ -466,7 +466,7 @@ function handleInput(event: Event) {
 
 	&__helper-text-message {
 		padding-block: 4px;
-		padding-inline: var(--border-radius-large);
+		padding-inline: var(--border-radius-element);
 		display: flex;
 		align-items: center;
 		color: var(--color-text-maxcontrast);

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -1016,7 +1016,7 @@ export default {
 		display: flex;
 		padding: 0;
 		transition: transform 300ms ease;
-		border-radius: var(--border-radius-container, var(--border-radius-rounded));
+		border-radius: var(--border-radius-container);
 		background-color: var(--color-main-background);
 		color: var(--color-main-text);
 		box-shadow: 0 0 40px rgba(0, 0, 0, .2);

--- a/src/components/NcNoteCard/NcNoteCard.vue
+++ b/src/components/NcNoteCard/NcNoteCard.vue
@@ -148,7 +148,7 @@ const iconPath = computed(() => {
 	color: var(--color-main-text) !important;
 	background-color: var(--note-background) !important;
 	border-inline-start: var(--default-grid-baseline) solid var(--note-theme);
-	border-radius: var(--border-radius);
+	border-radius: var(--border-radius-small);
 	margin: 1rem 0;
 	padding: var(--note-card-padding);
 	display: flex;

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -651,13 +651,13 @@ $arrow-position: $arrow-width - 1px;
 			 * and then apply scaling, which results in a blurry popover.
 			 */
 			box-shadow: 0 1px 10px var(--color-box-shadow);
-			border-radius: var(--border-radius-large);
+			border-radius: var(--border-radius-element);
 		}
 
 		.v-popper__inner {
 			padding: 0;
 			color: var(--color-main-text);
-			border-radius: var(--border-radius-large);
+			border-radius: var(--border-radius-element);
 			overflow: hidden;
 			background: var(--color-main-background);
 		}

--- a/src/components/NcRelatedResourcesPanel/NcTeamResources.vue
+++ b/src/components/NcRelatedResourcesPanel/NcTeamResources.vue
@@ -194,7 +194,7 @@ export default {
 }
 
 .related-team {
-	border-radius: var(--border-radius-rounded);
+	border-radius: var(--border-radius-container);
 	border: 2px solid var(--color-border-dark);
 	margin-bottom: 6px;
 
@@ -241,7 +241,7 @@ export default {
 			gap: 12px;
 			height: var(--default-clickable-area);
 			align-items: center;
-			border-radius: var(--border-radius-large);
+			border-radius: var(--border-radius-element);
 
 			&:hover {
 				background-color: var(--color-background-hover);

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1020,7 +1020,7 @@ export default {
 		overflow-wrap: break-word;
 		color: var(--color-main-text);
 		border: 2px solid var(--color-border-maxcontrast);
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 		outline: none;
 		background-color: var(--color-main-background);
 		font-family: var(--font-face);
@@ -1065,7 +1065,7 @@ export default {
 			opacity: $opacity_disabled;
 			color: var(--color-text-maxcontrast);
 			border: 2px solid var(--color-background-darker);
-			border-radius: var(--border-radius);
+			border-radius: var(--border-radius-small);
 			background-color: var(--color-background-dark);
 		}
 
@@ -1091,7 +1091,7 @@ export default {
 	margin: var(--default-grid-baseline) 0;
 	padding: var(--default-grid-baseline);
 	color: var(--color-text-maxcontrast);
-	border-radius: var(--border-radius-element, var(--border-radius));
+	border-radius: var(--border-radius-element);
 	background: var(--color-main-background);
 	box-shadow: 0 1px 5px var(--color-box-shadow);
 
@@ -1108,7 +1108,7 @@ export default {
 
 	.tribute-container__item {
 		color: var(--color-text-maxcontrast);
-		border-radius: var(--border-radius-small, var(--border-radius));
+		border-radius: var(--border-radius-small);
 		padding: var(--default-grid-baseline);
 		cursor: pointer;
 		min-height: var(--clickable-area-small, auto);

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -649,7 +649,7 @@ export default {
 	blockquote {
 		padding-inline-start: 13px;
 		border-inline-start: 2px solid var(--color-border-dark);
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 	}
 
 	h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote, pre {

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -926,7 +926,7 @@ body {
 	--vs-border-color: var(--color-border-maxcontrast);
 	--vs-border-width: var(--border-width-input, 2px) !important;
 	--vs-border-style: solid;
-	--vs-border-radius: var(--border-radius-large);
+	--vs-border-radius: var(--border-radius-element);
 
 	/* Component Controls: Clear, Open Indicator */
 	--vs-controls-color: var(--color-main-text);
@@ -1136,7 +1136,7 @@ body {
 	}
 
 	.vs__no-options {
-		color: var(--color-text-lighter) !important;
+		color: var(--color-text-maxcontrast) !important;
 	}
 }
 </style>

--- a/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
+++ b/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
@@ -269,6 +269,6 @@ export default {
 .select-group-error {
 	color: var(--color-error);
 	font-size: 13px;
-	padding-inline-start: var(--border-radius-large);
+	padding-inline-start: var(--border-radius-element);
 }
 </style>

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -265,7 +265,7 @@ function select() {
 .textarea {
 	position: relative;
 	width: 100%;
-	border-radius: var(--border-radius-large);
+	border-radius: var(--border-radius-element);
 	margin-block-start: 6px; // for the label in active state
 	resize: vertical;
 
@@ -289,7 +289,7 @@ function select() {
 		background-color: var(--color-main-background);
 		color: var(--color-main-text);
 		border: var(--border-width-input, 2px) solid var(--color-border-maxcontrast);
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-element);
 
 		cursor: pointer;
 


### PR DESCRIPTION
### ☑️ Resolves

Those variables are deprecated since Nextcloud 30 and the fallbacks are not needed when using Nextcloud 30+.
As this version (v9) only targets Nextcloud 30+ at the moment we do not need them anymore.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
