### PR TITLE
fix(NcButton): ensure that the component also works without vue-router

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -434,7 +434,7 @@ td.row-size {
 
 <script setup lang="ts">
 import type { Slot } from 'vue'
-import type { RouteLocation } from 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
 
 import { computed, inject, toRef } from 'vue'
 import { routerKey, useLink } from 'vue-router'
@@ -535,7 +535,7 @@ interface NcButtonProps {
 	 *
 	 * Note: This takes precedence over the href attribute.
 	 */
-	to?: string|RouteLocation
+	to?: string|RouteLocationRaw
 
 	/**
 	 * Specifies the button native type
@@ -605,16 +605,14 @@ defineSlots<{
 
 // Make sure the component also works if the app does not use any router
 // And if the app uses a router we need to make sure a `to` prop was passed to use to router
-const routerLink = computed(() => (
-	inject(routerKey, null) !== null && props.to
-		? useLink({ to: toRef(() => props.to!) })
-		: undefined
-))
+const routerLink = inject(routerKey, null) !== null
+	? useLink({ to: toRef(() => props.to!) })
+	: undefined
 
 /**
  * If this is a link (<a>) element
  */
-const isLink = computed(() => props.href)
+const isLink = computed(() => props.href || routerLink?.href)
 
 /**
  * If the button has a pressed state (only if not a link)
@@ -655,7 +653,7 @@ const ncPopoverTriggerAttrs = computed(() => getNcPopoverTriggerAttrs())
  */
 const linkAttrs = computed(() => ({
 	role: 'button',
-	href: props.href || '#',
+	href: routerLink?.href.value || props.href || '#',
 	target: props.target,
 	rel: 'nofollow noreferrer noopener',
 	download: props.download || null,
@@ -679,7 +677,10 @@ function onClick(event: MouseEvent) {
 	}
 	// We have to both navigate and emit the click event
 	emit('click', event)
-	routerLink.value?.navigate(event)
+	if (routerLink) {
+		event.preventDefault()
+		routerLink.navigate(event)
+	}
 }
 </script>
 

--- a/tests/unit/components/NcButton/routerLink.spec.ts
+++ b/tests/unit/components/NcButton/routerLink.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { shallowMount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+import { createRouter, createWebHistory } from 'vue-router'
+import NcButton from '../../../../src/components/NcButton/NcButton.vue'
+
+describe('NcButton as router link', () => {
+	test('It is rendered as router link when router is provided', () => {
+		const router = getRouter()
+
+		const wrapper = shallowMount(NcButton, {
+			props: {
+				to: { name: 'test' },
+			},
+			global: {
+				plugins: [router],
+			},
+		})
+
+		const link = wrapper.find('a')
+		expect(link.exists()).toBe(true)
+		expect(link.attributes('href')).toBe('/test-url')
+	})
+
+	test('It is rendered as router link even if a href is passed', () => {
+		const router = getRouter()
+
+		const wrapper = shallowMount(NcButton, {
+			props: {
+				href: '/some-other',
+				to: { name: 'test' },
+			},
+			global: {
+				plugins: [router],
+			},
+		})
+
+		const link = wrapper.find('a')
+		expect(link.exists()).toBe(true)
+		expect(link.attributes('href')).toBe('/test-url')
+	})
+
+	test('If no router is registered a router location will just be a plain button', () => {
+		const wrapper = shallowMount(NcButton, {
+			props: {
+				to: { name: 'test' },
+			},
+		})
+
+		const link = wrapper.find('a')
+		const button = wrapper.find('button')
+		expect(link.exists()).toBe(false)
+		expect(button.exists()).toBe(true)
+		expect(button.attributes('href')).toBeUndefined()
+		expect(button.attributes('to')).toBeUndefined()
+	})
+
+	test('If no router is registered the router location is ignored and the href is used', () => {
+		const wrapper = shallowMount(NcButton, {
+			props: {
+				href: '/some-other',
+				to: { name: 'test' },
+			},
+		})
+
+		const link = wrapper.find('a')
+		expect(link.exists()).toBe(true)
+		expect(link.attributes('href')).toBe('/some-other')
+	})
+
+	test('If no router is registered a plain link still works', () => {
+		const wrapper = shallowMount(NcButton, {
+			props: {
+				href: '/some-other',
+			},
+		})
+
+		const link = wrapper.find('a')
+		expect(link.exists()).toBe(true)
+		expect(link.attributes('href')).toBe('/some-other')
+	})
+})
+
+/**
+ * Get a very simple router for testing
+ */
+function getRouter() {
+	return createRouter({
+		history: createWebHistory(),
+		routes: [{
+			name: 'root',
+			path: '/',
+			component: {
+				template: 'Root',
+			},
+		},
+		{
+			name: 'test',
+			path: '/test-url',
+			component: {
+				template: 'Hello world!',
+			},
+		}],
+	})
+}


### PR DESCRIPTION
### ☑️ Resolves

- tested alternative to #7100 

1. Make the component properly work without vue-router (useLink must be used in setup context not in computed). We can always assume that a router does not exist if it is not available in setup context (it cannot be registered later).
2. Make sure a router link is also just an `a` element.
3. Ensure the behavior is the same as on v8: If a `to` is provided it has precedence over a `href` prop.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
