### PR TITLE
fix(NcDateTimePicker): adjust input padding inline end

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -580,7 +580,7 @@ function cancelSelection() {
 			:aria-labels
 			:auto-apply="!confirm"
 			class="vue-date-time-picker"
-			:class="{ "vue-date-time-picker--clearable": clearable }"
+			:class="{ 'vue-date-time-picker--clearable': clearable }"
 			:cancel-text="t('Cancel')"
 			:clearable
 			:day-names


### PR DESCRIPTION
### ☑️ Resolves

- Adjusts the inline end padding for the `NcDateTimePicker` input field, so that less space is wasted if no clearable button is present.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="162" height="50" alt="grafik" src="https://github.com/user-attachments/assets/f77b7931-f3c8-4b28-b64e-88e46181c7f7" /> | <img width="162" height="50" alt="grafik" src="https://github.com/user-attachments/assets/e6929c98-1079-45ad-ad1b-26cd5f3c89e9" />
<img width="162" height="50" alt="grafik" src="https://github.com/user-attachments/assets/fdcfcb94-4b86-40ca-8da5-ac2603f6353a" /> | <img width="162" height="50" alt="grafik" src="https://github.com/user-attachments/assets/70554453-f98c-4c3c-a1a6-0a7075dc93cf" />


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
