### PR TITLE
[stable8] fix: migrate from _oc_config to initial state

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -535,9 +535,13 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 </template>
 
 <script>
+import { loadState } from '@nextcloud/initial-state'
 import NcActions from '../NcActions/index.js'
 import NcCounterBubble from '../NcCounterBubble/index.js'
 import NcVNodes from '../NcVNodes/index.js'
+
+const [major] = loadState('core', 'config', { version: '30.0' }).version.split('.', 2) ?? []
+const isLegacy = major && Number.parseInt(major) < 30
 
 export default {
 	name: 'NcListItem',
@@ -694,9 +698,6 @@ export default {
 	],
 
 	setup() {
-		const [major] = window._oc_config?.version.split('.', 2) ?? []
-		const isLegacy = major && Number.parseInt(major) < 30
-
 		return {
 			isLegacy,
 		}

--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -63,9 +63,14 @@ This component is to be used in the settings section of nextcloud.
 </template>
 
 <script>
+import { loadState } from '@nextcloud/initial-state'
 import { t } from '../../l10n.js'
 
 import HelpCircle from 'vue-material-design-icons/HelpCircle.vue'
+
+// Overwrite this on Nextcloud 30+ to always limit the width
+const [major] = loadState('core', 'config', { version: '30.0' }).version.split('.', 2) ?? []
+const isLegacy = major && Number.parseInt(major) < 30
 
 export default {
 	name: 'NcSettingsSection',
@@ -110,12 +115,7 @@ export default {
 
 	computed: {
 		forceLimitWidth() {
-			if (this.limitWidth) {
-				return true
-			}
-			// Overwrite this on Nextcloud 30+ to always limit the width
-			const [major] = window._oc_config?.version.split('.', 2) ?? []
-			return major && Number.parseInt(major) >= 30
+			return this.limitWidth || !isLegacy
 		},
 
 		hasDescription() {


### PR DESCRIPTION
### ☑️ Resolves

- Fix checking values on non-web clients (Talk Desktop)

### 🖼️ Screenshots

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
