### PR TITLE
ci: sync stable branch translations

### DIFF
--- a/.github/workflows/sync-l10n.yml
+++ b/.github/workflows/sync-l10n.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Sync stable branch translations
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  server-styling-update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: main
+
+      - name: Checkout stable branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: stable-branch
+          ref: stable8
+
+      - name: Merge translations
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          # combine entries
+          mkdir merged-entries
+          for f in stable-branch/l10n/*.pot; do
+            [ "$f" = "messages.pot" ] && continue
+            msgcat -o "merged-entries/$(basename $f)" --use-first "main/l10n/$(basename $f)" "$f"
+          done
+          # update the stable one with all needed translations
+          for f in merged-entries/*.pot; do
+            msgmerge -N "$f" "stable-branch/l10n/messages.pot" > "stable-branch/l10n/$(basename $f)"
+          done
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          path: stable-branch
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          commit-message: "chore(l10n): sync translations with main branch"
+          committer: GitHub <noreply@github.com>
+          author: nextcloud-command <nextcloud-command@users.noreply.github.com>
+          signoff: true
+          branch: automated/noid/stable-translations-update
+          title: 'Automated merge of translations'
+          add-paths: l10n
+          body: |
+            Auto-generated merge of the translations from main branch.
+          labels: |
+            3. to review
+            l10n


### PR DESCRIPTION
### ☑️ Resolves

Only main branch will be localized by Transifex.
To also update the stable branch with translations we need to synchronize them.

This actions does following:
- clone both branches
- combine po files from both branches for each language
- check the stable branch po template which messages are needed
- copy needed messaged from the combined po file (use the main if the translation differ)

This works locally, but I am not sure if the msgcat and msgmerge commands are installed on the runner.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
