### PR TITLE
[stable8] fix(NcCheckboxRadioSwitch): ensure component has correct box sizing

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -672,10 +672,15 @@ export default {
 	align-items: center;
 	color: var(--color-main-text);
 	background-color: transparent;
+	box-sizing: border-box;
 	font-size: var(--default-font-size);
 	line-height: var(--default-line-height);
 	padding: 0;
 	position: relative;
+
+	* {
+		box-sizing: border-box;
+	}
 
 	&__input {
 		position: absolute;


### PR DESCRIPTION
### ☑️ Resolves

- Resolves https://github.com/nextcloud-libraries/nextcloud-vue/issues/7187

On v9 this is fixed as all containers already have `box-sizing: boder-box` but on v8 we need to manually ensure this.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
