### PR TITLE
fix(utils): legacy version detection

### DIFF
--- a/src/utils/legacy.ts
+++ b/src/utils/legacy.ts
@@ -3,4 +3,5 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export const isLegacy = Number.parseInt(window.OC?.config.version.split('.')[0] ?? '32') < 32
+const version = window.OC?.config?.version?.split('.')[0] || '32.0.0'
+export const isLegacy = Number.parseInt(version) < 32


### PR DESCRIPTION
See https://github.com/nextcloud/server/pull/54497#issuecomment-3200538375
"Regression" from https://github.com/nextcloud-libraries/nextcloud-vue/pull/7283