### PR TITLE
[stable8] fix(utils): legacy check syntax

### DIFF
--- a/src/utils/legacy.ts
+++ b/src/utils/legacy.ts
@@ -1,6 +1,7 @@
-/*
+/**
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export const isLegacy32 = Number.parseInt(window.OC?.config.version.split('.')[0] ?? '0') < 32
+const version = window.OC?.config?.version?.split('.')[0] || '32'
+export const isLegacy32 = Number.parseInt(version) < 32


### PR DESCRIPTION
Backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/7313