### PR TITLE
docs: fix CSS Modules support in Styleguidist

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -34,6 +34,14 @@ const sassLoader = {
 	},
 }
 
+const cssLoaderOptions = {
+	modules: {
+		namedExport: false,
+		// Same as in Vite
+		localIdentName: '_[local]_[hash:base64:5]',
+	},
+}
+
 webpackRules.RULE_SCSS = {
 	test: /\.scss$/,
 	oneOf: [
@@ -43,12 +51,7 @@ webpackRules.RULE_SCSS = {
 				'style-loader',
 				{
 					loader: 'css-loader',
-					options: {
-						modules: {
-							// Same as in Vite
-							localIdentName: '_[local]_[hash:base64:5]',
-						},
-					},
+					options: cssLoaderOptions,
 				},
 				'resolve-url-loader',
 				sassLoader,
@@ -74,12 +77,7 @@ webpackRules.RULE_CSS = {
 				'style-loader',
 				{
 					loader: 'css-loader',
-					options: {
-						modules: {
-							// Same as in Vite
-							localIdentName: '_[local]_[hash:base64:5]',
-						},
-					},
+					options: cssLoaderOptions,
 				},
 				'resolve-url-loader',
 			],


### PR DESCRIPTION
### ☑️ Resolves

- Split from https://github.com/nextcloud-libraries/nextcloud-vue/pull/7330
- CSS Modules doesn't work in styleguidist

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="897" height="892" alt="image" src="https://github.com/user-attachments/assets/e90c7a42-19b8-465a-ad0a-0eec7cec8a4b" /> | <img width="863" height="1145" alt="image" src="https://github.com/user-attachments/assets/e484c998-6b4d-4da6-aa55-477c71355f9e" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
