### PR TITLE
feat(NcCheckboxRadioSwitch): Add support for a description field

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -19,6 +19,7 @@
 			class="checkbox-content__icon"
 			:class="{
 				'checkbox-content__icon--checked': isChecked,
+				'checkbox-content__icon--has-description': !isButtonType && $slots.description,
 				[iconClass]: true,
 			}"
 			:aria-hidden="true"
@@ -39,9 +40,18 @@
 			</slot>
 		</span>
 
-		<span v-if="$slots.default" class="checkbox-content__text" :class="[textClass]">
-			<!-- @slot The checkbox/radio label -->
-			<slot />
+		<span class="checkbox-content__wrapper">
+			<span
+				v-if="$slots.default"
+				:id="labelId"
+				class="checkbox-content__text"
+				:class="textClass">
+				<!-- @slot The checkbox/radio label -->
+				<slot />
+			</span>
+			<span v-if="!isButtonType && $slots.description" :id="descriptionId" class="checkbox-content__description">
+				<slot name="description" />
+			</span>
 		</span>
 	</span>
 </template>
@@ -143,6 +153,22 @@ export default {
 			type: Number,
 			default: 24,
 		},
+
+		/**
+		 * Label id attribute
+		 */
+		labelId: {
+			type: String,
+			required: true,
+		},
+
+		/**
+		 * Description id attribute
+		 */
+		descriptionId: {
+			type: String,
+			required: true,
+		},
 	},
 
 	computed: {
@@ -199,8 +225,11 @@ export default {
 	// but restrict to content so plain checkboxes / radio switches do not expand
 	max-width: fit-content;
 
-	&__text {
+	&__wrapper {
 		flex: 1 0;
+	}
+
+	&__text {
 
 		&:empty {
 			// hide text if empty to ensure checkbox outline is a circle instead of oval
@@ -214,10 +243,24 @@ export default {
 		margin-block: calc((var(--default-clickable-area) - 2 * var(--default-grid-baseline) - var(--icon-height)) / 2) auto;
 	}
 
+	&-checkbox:not(&--button-variant) &__icon--has-description,
+	&-radio:not(&--button-variant) &__icon--has-description,
+	&-switch:not(&--button-variant) &__icon--has-description {
+		display: flex;
+		align-items: center;
+		margin-block-end: 0;
+		align-self: start;
+	}
+
 	&__icon > * {
 		width: var(--icon-size);
 		height: var(--icon-height);
 		color: var(--color-primary-element);
+	}
+
+	&__description {
+		display: block;
+		color: var(--color-text-maxcontrast);
 	}
 
 	&--button-variant {

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -22,6 +22,10 @@ Note: All generic attributes on the component, except `class` and `style`, are p
 		<NcCheckboxRadioSwitch v-model="sharingEnabled">
 			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
 		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" description="The description">
+			Enable sharing with description
+		</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -233,6 +237,16 @@ export default {
 		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
 			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
 		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" description="Instead you can use a description as a prop which can also be a long multiline text, that will be wrapped in a second row.">
+			Enable sharing.
+		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
+			Enable sharing.
+			<template #description>
+				Or you can use a description as slot which can also be a <strong>long multiline text</strong>, that will be wrapped in a second row.
+			</template>
+		</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -276,7 +290,8 @@ export default {
 		<input
 			v-if="!isButtonType"
 			:id="id"
-			:aria-labelledby="!isButtonType && !ariaLabel ? `${id}-label` : null"
+			:aria-labelledby="!isButtonType && !ariaLabel ? labelId : null"
+			:aria-describedby="!isButtonType && (description || $slots.description) ? descriptionId : null"
 			:aria-label="ariaLabel || undefined"
 			class="checkbox-radio-switch__input"
 			:disabled="disabled"
@@ -298,11 +313,20 @@ export default {
 			:button-variant="buttonVariant"
 			:is-checked="isChecked"
 			:loading="loading"
+			:description="description"
+			:label-id="labelId"
+			:description-id="descriptionId"
 			:icon-size
 			@click="onToggle">
 			<template #icon>
 				<!-- @slot The checkbox/radio icon, you can use it for adding an icon to the button variant -->
 				<slot name="icon" />
+			</template>
+			<template v-if="$slots.description || description" #description>
+				<!-- @slot The checkbox/radio/switch description, you can use it for adding a more complex description element as opposed to the description prop -->
+				<slot name="description">
+					{{ description }}
+				</slot>
 			</template>
 
 			<template v-if="!!$slots.default" #default>
@@ -478,9 +502,26 @@ export default {
 			type: [String, Array, Object],
 			default: '',
 		},
+
+		/**
+		 * Description
+		 *
+		 * This is unsupported when using button has type.
+		 */
+		description: {
+			type: String,
+			default: null,
+		},
 	},
 
 	emits: ['update:modelValue'],
+
+	setup() {
+		return {
+			labelId: createElementId(),
+			descriptionId: createElementId(),
+		}
+	},
 
 	computed: {
 		isButtonType() {

--- a/tests/unit/components/NcCheckboxRadioSwitch/checkbox.spec.ts
+++ b/tests/unit/components/NcCheckboxRadioSwitch/checkbox.spec.ts
@@ -44,8 +44,8 @@ describe('NcCheckboxRadioSwitch', () => {
 			},
 		})
 
-		expect(wrapper.find('input').attributes('aria-labelledby')).toBe('test-id-label')
-		expect(wrapper.findComponent({ name: 'NcCheckboxContent' }).attributes('id')).toBe('test-id-label')
+		const labelById = wrapper.find('input').attributes('aria-labelledby')
+		expect(wrapper.findComponent({ name: 'NcCheckboxContent' }).find('#' + labelById).exists()).toBe(true)
 	})
 
 	it('does not set id on button content', () => {
@@ -61,5 +61,21 @@ describe('NcCheckboxRadioSwitch', () => {
 
 		expect(wrapper.find('input').exists()).toBe(false)
 		expect(wrapper.findComponent({ name: 'NcCheckboxContent' }).attributes('id')).toBe(undefined)
+	})
+
+	it('sets aria-describedby attribute correctly', () => {
+		const wrapper = mount(NcCheckboxRadioSwitch, {
+			props: {
+				description: 'My description',
+			},
+			slots: {
+				default: 'Test',
+			},
+		})
+
+		const describedById = wrapper.find('input').attributes('aria-describedby')
+		const descriptionElement = wrapper.findComponent({ name: 'NcCheckboxContent' }).find('#' + describedById)
+		expect(descriptionElement.exists()).toBe(true)
+		expect(descriptionElement.text()).toContain('My description')
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

- Related #7120

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="836" height="200" alt="image" src="https://github.com/user-attachments/assets/adf8c114-0871-439f-8cb0-10c7b952c9d3" /> | <img width="836" height="275" alt="image" src="https://github.com/user-attachments/assets/df09d939-69fc-499e-922c-52ecdc9b6351" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
