### PR TITLE
[stable8] prepare release v8.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 # Changelog
 
+## [v8.30.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.29.2) (2025-09-01)
+### 🚀 Enhancements
+* feat(NcPopover): auto return focus to trigger button on close [#5155](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5155) ([ShGKme](https://github.com/ShGKme))
+* feat(NcAssistant*): provide components to for consistant integrations design [#7413](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7413)
+* feat(NcCheckboxRadioSwitch): Add support for a description field [#7395](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7395)
+### Other Changes
+* refactor: migrate reference widget related function to Typescript [#7417](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7417)
+
+
 ## [v8.29.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.29.2) (2025-08-28)
 ### 🐛 Fixed bugs
 * fix(NcUserStatusIcon): legacy 32 check [#7320](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7320) ([skjnldsv](https://github.com/skjnldsv))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.29.2",
+  "version": "8.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.29.2",
+      "version": "8.30.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.29.2",
+  "version": "8.30.0",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.30.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.29.2) (2025-09-01)
### 🚀 Enhancements
* feat(NcPopover): auto return focus to trigger button on close [#5155](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5155) ([ShGKme](https://github.com/ShGKme))
* feat(NcAssistant*): provide components to for consistant integrations design [#7413](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7413)
* feat(NcCheckboxRadioSwitch): Add support for a description field [#7395](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7395)
### Other Changes
* refactor: migrate reference widget related function to Typescript [#7417](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7417)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
