### PR TITLE
fix: revert renaming template refs resulting in a breaking change

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -187,7 +187,7 @@ const setHasAppNavigation = inject(
 	false,
 )
 
-const appNavigationContainer = useTemplateRef('appNavigationContainer')
+const appNavigationContainerElement = useTemplateRef('appNavigationContainer')
 const isMobile = useIsMobile()
 const open = ref(!isMobile.value)
 
@@ -213,9 +213,9 @@ onMounted(() => {
 		open: open.value,
 	})
 
-	focusTrap = createFocusTrap(appNavigationContainer.value!, {
+	focusTrap = createFocusTrap(appNavigationContainerElement.value!, {
 		allowOutsideClick: true,
-		fallbackFocus: appNavigationContainer.value!,
+		fallbackFocus: appNavigationContainerElement.value!,
 		trapStack: getTrapStack(),
 		escapeDeactivates: false,
 	})

--- a/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
+++ b/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
@@ -193,7 +193,7 @@ const { focused: inputHasFocus } = useFocusWithin(inputElement)
 /** Timeout used to define when the search input is fully expanded */
 const transitionTimeout = Number.parseInt(window.getComputedStyle(window.document.body).getPropertyValue('--animation-quick')) || 100
 
-const actionsContainer = useTemplateRef('actionsContainer')
+const actionsContainerElement = useTemplateRef('actionsContainer')
 const hasActions = () => !!slots.actions?.({})
 const showActions = ref(true)
 const timeoutId = ref()
@@ -219,7 +219,7 @@ function onCloseSearch() {
 	model.value = ''
 	if (hasActions()) {
 		showActions.value = true
-		nextTick(() => actionsContainer.value?.querySelector('button')?.focus())
+		nextTick(() => actionsContainerElement.value?.querySelector('button')?.focus())
 	}
 }
 </script>

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -329,8 +329,8 @@ const emit = defineEmits<{
 	'update:timezoneId': [string]
 }>()
 
-const target = useTemplateRef('target')
-const picker = useTemplateRef('picker')
+const targetElement = useTemplateRef('target')
+const pickerInstance = useTemplateRef('picker')
 
 /**
  * Mapping of the model-value prop to the format expected by the library.
@@ -573,7 +573,7 @@ const ariaLabels = computed(() => ({
  * This is used by the confirmation button if `confirmation` was set.
  */
 function selectDate() {
-	picker.value!.selectDate()
+	pickerInstance.value!.selectDate()
 }
 
 /**
@@ -581,7 +581,7 @@ function selectDate() {
  * This is used by the confirmation button if `confirmation` was set.
  */
 function cancelSelection() {
-	picker.value!.closeMenu()
+	pickerInstance.value!.closeMenu()
 }
 </script>
 
@@ -604,7 +604,7 @@ function cancelSelection() {
 			:now-button-label="t('Now')"
 			:select-text="t('Pick')"
 			six-weeks="fair"
-			:teleport="appendToBody ? (target || undefined) : false"
+			:teleport="appendToBody ? (targetElement || undefined) : false"
 			text-input
 			:week-num-name
 			:week-numbers="showWeekNumber ? { type: 'iso' } : undefined"

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -360,12 +360,12 @@ const slots = defineSlots<{
 /**
  * The dialog wrapper element
  */
-const wrapper = useTemplateRef('wrapper')
+const wrapperElement = useTemplateRef('wrapper')
 
 /**
  * We use the dialog width to decide if we collapse the navigation (flex direction row)
  */
-const { width: dialogWidth } = useElementSize(wrapper, { width: 900, height: 0 })
+const { width: dialogWidth } = useElementSize(wrapperElement, { width: 900, height: 0 })
 
 /**
  * Whether the navigation is collapsed due to dialog and window size
@@ -400,7 +400,7 @@ const navigationAriaLabelledbyAttr = computed(() => {
 	return props.navigationAriaLabelledby || navigationId
 })
 
-const dialogElement = useTemplateRef<HTMLDivElement | HTMLFormElement>('dialogElement')
+const dialogRootElement = useTemplateRef<HTMLDivElement | HTMLFormElement>('dialogElement')
 /**
  * The HTML element to use for the dialog wrapper - either form or plain div
  */
@@ -449,8 +449,8 @@ function handleButtonClose(button: NcDialogButtonProps, result: unknown) {
 	// Skip close on submit if invalid dialog
 	if (button.type === 'submit'
 		&& dialogTagName.value === 'form'
-		&& 'reportValidity' in dialogElement.value!
-		&& !dialogElement.value.reportValidity()) {
+		&& 'reportValidity' in dialogRootElement.value!
+		&& !dialogRootElement.value.reportValidity()) {
 		return
 	}
 	handleClosing(result)

--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -142,17 +142,17 @@ const isOpened = ref(open)
 const wrapperTag = computed(() => isNav ? 'nav' : 'div')
 
 /** The menu content container element */
-const contentContainer = useTemplateRef('contentContainer')
+const contentContainerElement = useTemplateRef('contentContainer')
 /** The overall header menu wrapping element (<nav> or <div>) */
-const headerMenu = useTemplateRef<HTMLElement>('headerMenu')
+const headerMenuElement = useTemplateRef<HTMLElement>('headerMenu')
 /** The menu trigger button */
-const triggerButton = useTemplateRef('triggerButton')
+const triggerButtonInstance = useTemplateRef('triggerButton')
 
 // Handle click outside of the menu -> should close the menu
 const ignore = computed(() => Array.isArray(excludeClickOutsideSelectors)
 	? excludeClickOutsideSelectors
 	: excludeClickOutsideSelectors.split(' '))
-onClickOutside(headerMenu, () => setMenuState(false), { ignore })
+onClickOutside(headerMenuElement, () => setMenuState(false), { ignore })
 
 // Pressing escape should close the menu
 useHotKey('Escape', () => setMenuState(false), { prevent: true })
@@ -213,7 +213,7 @@ function onFocusOut(event: FocusEvent) {
 		return
 	}
 
-	if (headerMenu.value?.contains(event.relatedTarget)) {
+	if (headerMenuElement.value?.contains(event.relatedTarget)) {
 		setMenuState(false)
 	}
 }
@@ -231,10 +231,10 @@ async function addFocusTrap() {
 	}
 
 	// Init focus trap
-	focusTrap.value = createFocusTrap(contentContainer.value!, {
+	focusTrap.value = createFocusTrap(contentContainerElement.value!, {
 		allowOutsideClick: true,
 		trapStack: getTrapStack(),
-		fallbackFocus: triggerButton.value?.$el,
+		fallbackFocus: triggerButtonInstance.value?.$el,
 	})
 	focusTrap.value.activate()
 }

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -159,7 +159,7 @@ defineExpose({
 
 const attrs = useAttrs()
 
-const input = useTemplateRef('input')
+const inputElement = useTemplateRef('input')
 
 const hasTrailingIcon = computed(() => props.showTrailingButton || props.success)
 
@@ -191,7 +191,7 @@ const ariaDescribedby = computed(() => {
  * @public
  */
 function focus(options?: FocusOptions) {
-	input.value!.focus(options)
+	inputElement.value!.focus(options)
 }
 
 /**
@@ -200,7 +200,7 @@ function focus(options?: FocusOptions) {
  * @public
  */
 function select() {
-	input.value!.select()
+	inputElement.value!.select()
 }
 
 /**

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -206,7 +206,7 @@ interface PasswordPolicy {
 const { password_policy: passwordPolicy } = getCapabilities() as { password_policy?: PasswordPolicy }
 
 // internal state
-const inputField = useTemplateRef('inputField')
+const inputFieldInstance = useTemplateRef('inputField')
 
 const internalHelpMessage = ref('')
 const isValid = ref<boolean>()
@@ -273,7 +273,7 @@ function toggleVisibility() {
  * @public
  */
 function focus(options?: FocusOptions) {
-	inputField.value!.focus(options)
+	inputFieldInstance.value!.focus(options)
 }
 
 /**
@@ -282,7 +282,7 @@ function focus(options?: FocusOptions) {
  * @public
  */
 function select() {
-	inputField.value!.select()
+	inputFieldInstance.value!.select()
 }
 </script>
 

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -188,7 +188,7 @@ defineExpose({
 	select,
 })
 
-const inputField = useTemplateRef('inputField')
+const inputFieldInstance = useTemplateRef('inputField')
 
 const defaultTrailingButtonLabels = {
 	arrowEnd: t('Save changes'),
@@ -212,7 +212,7 @@ const propsToForward = computed<NcInputFieldProps>(() => {
  * @public
  */
 function focus(options?: FocusOptions) {
-	inputField.value!.focus(options)
+	inputFieldInstance.value!.focus(options)
 }
 
 /**
@@ -221,6 +221,6 @@ function focus(options?: FocusOptions) {
  * @public
  */
 function select() {
-	inputField.value!.select()
+	inputFieldInstance.value!.select()
 }
 </script>


### PR DESCRIPTION
### ☑️ Resolves

- Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/7239
  - PR was merged with unresolved active discussion
- Though we may call it not an explicit public API, it is used in apps and unneeded changes. The initial issue could be fixed by renaming internal variables instead.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
