### PR TITLE
fix(NcAvatar): make min status size visually accessible

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -976,16 +976,14 @@ export default {
 		// - ⏹️ Best-fit: the status icon is as large as possible without exceeding the avatar box
 		// See PR for math explanation: PR #6004
 		--avatar-status-size-orbital: calc(var(--avatar-size) * (1 - 1 / sqrt(2)));
-		// Limit the status icon size to the status of a small clickable avatar
+		// Limit the status icon size to minimum font size to keep it readable
 		// Ideally avatars with a smaller should not be used with the status icon at all
-		--avatar-status-size-min: calc(var(--default-clickable-area) * (1 - 1 / sqrt(2)));
+		--avatar-status-size-min: var(--font-size-small);
 		--avatar-status-size: max(var(--avatar-status-size-orbital), var(--avatar-status-size-min));
-		// Because the status icon size is limited, smaller avatar requires a position offset to keep the status icon orbital
-		--avatar-status-icon-position: min(0px, (var(--avatar-status-size-orbital) - var(--avatar-status-size)) / 2);
 		box-sizing: border-box;
 		position: absolute;
-		inset-inline-end: var(--avatar-status-icon-position);
-		inset-block-end: var(--avatar-status-icon-position);
+		inset-inline-end: 0;
+		inset-block-end: 0;
 		height: var(--avatar-status-size);
 		width: var(--avatar-status-size);
 		line-height: 1;


### PR DESCRIPTION
### ☑️ Resolves

- With size below 14px, it becomes visually hard to see emoji. 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="113" height="123" alt="image" src="https://github.com/user-attachments/assets/b8d66f09-a626-4fdd-9eaa-b0341e74bbdf" /> | <img width="126" height="116" alt="image" src="https://github.com/user-attachments/assets/3b83eab6-27b0-4993-ad15-13444abefec4" />
<img  height="230" alt="image" src="https://github.com/user-attachments/assets/5b8469bf-90e5-464c-a5e3-954e0aa89523" />| <img  height="230" alt="image" src="https://github.com/user-attachments/assets/c88506ec-2713-429a-8d2d-9969658ca155" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
