### PR TITLE
chore(NcCheckboxRadioSwitch): deprecate button variant in favor of `NcRadioGroup`

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -76,7 +76,68 @@ export default {
 </script>
 ```
 
-### Standard radio set with alternative button style
+### Standard checkbox set
+```vue
+<template>
+	<div>
+		<NcCheckboxRadioSwitch :disabled="true" v-model="sharingPermission" value="r" name="sharing_permission">Permission read</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="w" name="sharing_permission">Permission write</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="d" name="sharing_permission">Permission delete</NcCheckboxRadioSwitch>
+		<br>
+		sharingPermission: {{ sharingPermission }}
+	</div>
+</template>
+<script>
+export default {
+	data() {
+		return {
+			sharingPermission: ['r', 'd'],
+		}
+	}
+}
+</script>
+```
+
+### Standard switch
+```vue
+<template>
+	<div>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">Enable sharing</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
+			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
+		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" description="Instead you can use a description as a prop which can also be a long multiline text, that will be wrapped in a second row.">
+			Enable sharing.
+		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
+			Enable sharing.
+			<template #description>
+				Or you can use a description as slot which can also be a <strong>long multiline text</strong>, that will be wrapped in a second row.
+			</template>
+		</NcCheckboxRadioSwitch>
+		<br>
+		sharingEnabled: {{ sharingEnabled }}
+	</div>
+</template>
+<script>
+export default {
+	data() {
+		return {
+			sharingEnabled: true,
+		}
+	},
+}
+</script>
+```
+
+### Deprecated button variants
+⚠️ Warning the button variant is deprecated ⚠️
+The button variant does not provide proper grouping,
+to overcome this and other limitations we now provide `NcRadioGroup` instead.
+
+#### Standard radio set with alternative button style
 ```vue
 <template>
 	<div>
@@ -136,7 +197,7 @@ export default {
 </script>
 ```
 
-### Radio set with button style and icons
+#### Radio set with button style and icons
 ```vue
 <template>
 	<div>
@@ -205,63 +266,6 @@ export default {
 }
 </script>
 ```
-
-### Standard checkbox set
-```vue
-<template>
-	<div>
-		<NcCheckboxRadioSwitch :disabled="true" v-model="sharingPermission" value="r" name="sharing_permission">Permission read</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch v-model="sharingPermission" value="w" name="sharing_permission">Permission write</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch v-model="sharingPermission" value="d" name="sharing_permission">Permission delete</NcCheckboxRadioSwitch>
-		<br>
-		sharingPermission: {{ sharingPermission }}
-	</div>
-</template>
-<script>
-export default {
-	data() {
-		return {
-			sharingPermission: ['r', 'd'],
-		}
-	}
-}
-</script>
-```
-
-### Standard switch
-```vue
-<template>
-	<div>
-		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">Enable sharing</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
-			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
-		</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" description="Instead you can use a description as a prop which can also be a long multiline text, that will be wrapped in a second row.">
-			Enable sharing.
-		</NcCheckboxRadioSwitch>
-
-		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
-			Enable sharing.
-			<template #description>
-				Or you can use a description as slot which can also be a <strong>long multiline text</strong>, that will be wrapped in a second row.
-			</template>
-		</NcCheckboxRadioSwitch>
-		<br>
-		sharingEnabled: {{ sharingEnabled }}
-	</div>
-</template>
-<script>
-export default {
-	data() {
-		return {
-			sharingEnabled: true,
-		}
-	},
-}
-</script>
-```
-
 </docs>
 
 <template>
@@ -410,6 +414,8 @@ export default {
 
 		/**
 		 * Toggle the alternative button style
+		 *
+		 * @deprecated - Use `NcRadioGroup` instead
 		 */
 		buttonVariant: {
 			type: Boolean,
@@ -421,6 +427,7 @@ export default {
 		 * If so they will be grouped horizontally or vertically
 		 *
 		 * @type {'no'|'horizontal'|'vertical'}
+		 * @deprecated - Use `NcRadioGroup` instead
 		 */
 		buttonVariantGrouped: {
 			type: String,


### PR DESCRIPTION
### ☑️ Resolves

As discussed [here](https://github.com/nextcloud-libraries/nextcloud-vue/issues/7399) the current styles do look great, also this component does not provide proper grouping of the buttons and have quite complex styles.
Additionally the components overall complexity was increased a lot with the button variant.

Instead we should deprecate this and recommend using the radio group with radio group buttons.

Note that we cannot remove it today as the sidebar relies on it (and heavily restyles it) so we would need to adjust that.
Or probably just create a small component for the tab switcher instead based on the correct design.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
