### PR TITLE
[stable8] feat(NcModal): add new `closeButtonOutside` prop and deprecated `closeButtonContained`

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -268,7 +268,7 @@ export default {
 
 						<!-- Close modal -->
 						<NcButton
-							v-if="!noClose && canClose && !closeButtonContained"
+							v-if="!noClose && canClose && closeButtonOutside && !closeButtonContained"
 							:aria-label="closeButtonAriaLabel"
 							class="header-close"
 							variant="tertiary"
@@ -316,7 +316,7 @@ export default {
 						</div>
 						<!-- Close modal -->
 						<NcButton
-							v-if="!noClose && canClose && closeButtonContained"
+							v-if="!noClose && canClose && !closeButtonOutside && closeButtonContained"
 							:aria-label="closeButtonAriaLabel"
 							class="modal-container__close"
 							variant="tertiary"
@@ -533,8 +533,23 @@ export default {
 		},
 
 		/**
+		 * Pass in `true` if you want the modal 'close' button to be displayed
+		 * outside the modal boundaries, in the top right corner of the window.
+		 *
+		 * @default false
+		 * @since 8.32.0
+		 */
+		closeButtonOutside: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Pass in false if you want the modal 'close' button to be displayed
-		 * outside the modal boundaries, in the top right corner of the window
+		 * outside the modal boundaries, in the top right corner of the window.
+		 *
+		 * @default true
+		 * @deprecated 8.32.0 - Use `closeButtonOutside` instead
 		 */
 		closeButtonContained: {
 			type: Boolean,


### PR DESCRIPTION
### ☑️ Resolves

- Backport of #6719 
- For forward compatibility
- Different from original, please double-check