### PR TITLE
fix(NcCounterBubble): also shorten in German

### DIFF
--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -162,12 +162,20 @@ const props = withDefaults(defineProps<{
 	type: '',
 })
 
+// Special case: browsers do not shorten numbers in German
+// Fallback to English to have 2K instead of 2048
+// TODO: what about Italian with the same issue?
+let locale = getCanonicalLocale()
+if (locale === 'de' || locale === 'de-DE') {
+	locale = 'en'
+}
+
 const humanizedCount = computed(() => {
 	if (props.raw) {
 		return props.count.toString()
 	}
 
-	const formatter = new Intl.NumberFormat(getCanonicalLocale(), {
+	const formatter = new Intl.NumberFormat(locale, {
 		notation: 'compact',
 		compactDisplay: 'short',
 	})


### PR DESCRIPTION
### ☑️ Resolves

- Browsers decided that in German numbers should not be shortened like `2048` should be `2048` instead of `2K` in English
- This PR uses English style instead of German to shorten the number in German
- ⚠️ Same problem in Italian. Shall we do the same?

Before | After
-- | --
<img width="41" height="25" alt="image" src="https://github.com/user-attachments/assets/5d3cfefd-0e8b-4f08-800c-4eb4da0b13cb" /> | <img width="34" height="25" alt="image" src="https://github.com/user-attachments/assets/b99bb502-a1df-48b4-9720-d21583d69d46" />


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
