### PR TITLE
feat(NcChip): add error, success and warning variants

### DIFF
--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -250,12 +250,12 @@ const hasIcon = () => Boolean(props.iconPath || props.iconSvg || !!slots.icon)
 
 	&--no-actions &__text {
 		// If there are no actions we need to add some padding to ensure the text is not cut-off
-		padding-inline-end: calc(1.5 * var(--default-grid-baseline));
+		padding-inline-end: calc(2 * var(--default-grid-baseline));
 	}
 
 	&--no-icon &__text {
 		// Add some more space to the border
-		padding-inline-start: calc(1.5 * var(--default-grid-baseline));
+		padding-inline-start: calc(2 * var(--default-grid-baseline));
 	}
 
 	&__text {


### PR DESCRIPTION
### ☑️ Resolves

- **Add warning, error and success variants** (I initially  needed it in Talk https://github.com/nextcloud/spreed/pull/16137, but it makes sense in other several use cases (see examples)) 
- **Add padding when there is no icon:** the curvy edge doesn't leave enough visual space for text.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1779" height="312" alt="image" src="https://github.com/user-attachments/assets/3fd30617-beb9-4539-9238-89dcbfa95ff7" /> | <img width="1752" height="316" alt="image" src="https://github.com/user-attachments/assets/1179484e-b2d9-4e02-93bb-3bcd3365ecff" />


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
