### PR TITLE
fix(NcRadioGroupButton): scope expensive CSS selectors

### DIFF
--- a/src/components/NcRadioGroupButton/NcRadioGroupButton.vue
+++ b/src/components/NcRadioGroupButton/NcRadioGroupButton.vue
@@ -102,11 +102,11 @@ function onUpdate() {
 		cursor: pointer;
 	}
 
-	:has(&__label) {
+	&:has(&__label) {
 		padding-inline: calc(var(--radio-group-button--padding) + var(--border-radius-element));
 	}
 
-	:has(&__icon) {
+	&:has(&__icon) {
 		padding-inline-start: var(--radio-group-button--padding);
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

- Noticed then checking Performance tab in DevTools:
  - Styles are `module` for this component, therefore css selectors work differently
  - PR changes sounds valid for this exact case

### 🖼️ Screenshots

<img width="506" height="128" alt="image" src="https://github.com/user-attachments/assets/7e9b37b3-2c9b-4576-aa38-fa72011d8969" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
