### PR TITLE
fix(NcAppContentDetailsToggle): Hide navigation toggle on mobile

### DIFF
--- a/src/components/NcAppContent/NcAppContentDetailsToggle.vue
+++ b/src/components/NcAppContent/NcAppContentDetailsToggle.vue
@@ -6,14 +6,18 @@
 <script setup lang="ts">
 import { mdiArrowRight } from '@mdi/js'
 import { emit } from '@nextcloud/event-bus'
-import { onBeforeUnmount, watch } from 'vue'
+import { onBeforeUnmount, onMounted, watch } from 'vue'
 import { useIsMobile } from '../../composables/useIsMobile/index.js'
 import { t } from '../../l10n.ts'
 import NcButton from '../NcButton/index.ts'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/index.ts'
 
 const isMobile = useIsMobile()
-watch(isMobile, toggleAppNavigationButton, { immediate: true })
+watch(isMobile, toggleAppNavigationButton)
+
+onMounted(() => {
+	toggleAppNavigationButton(isMobile.value)
+})
 
 onBeforeUnmount(() => {
 	if (isMobile.value) {


### PR DESCRIPTION
On mobile, the navigation toggle (`NcAppNavigationToggle`) needs to get hidden when the app details toggle (`NcAppContentDetailsToggle`) is shown.

The code to do this was broken, as the watcher got triggered before the navigation toggle was fully mounted, so `document.querySelector()` didn't find the corresponding element.

Required to fix https://github.com/nextcloud/collectives/issues/2059

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
