### PR TITLE
[stable8] fix(NcAppContentDetailsToggle): Hide navigation toggle on mobile

### DIFF
--- a/src/components/NcAppContent/NcAppContentDetailsToggle.vue
+++ b/src/components/NcAppContent/NcAppContentDetailsToggle.vue
@@ -49,12 +49,13 @@ export default {
 	},
 
 	watch: {
-		isMobile: {
-			immediate: true,
-			handler() {
-				this.toggleAppNavigationButton(this.isMobile)
-			},
+		isMobile: function() {
+			this.toggleAppNavigationButton(this.isMobile)
 		},
+	},
+
+	mounted() {
+		this.toggleAppNavigationButton(this.isMobile)
 	},
 
 	beforeDestroy() {


### PR DESCRIPTION
On mobile, the navigation toggle (`NcAppNavigationToggle`) needs to get hidden when the app details toggle (`NcAppContentDetailsToggle`) is shown.

The code to do this was broken, as the watcher got triggered before the navigation toggle was fully mounted, so `document.querySelector()` didn't find the corresponding element.

Required to fix https://github.com/nextcloud/collectives/issues/2059

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
