### PR TITLE
fix(NcRichText): start heading from h4

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -546,6 +546,13 @@ export default {
 			delete props.children
 
 			if (!String(type).startsWith('#')) {
+				// <h1>..<h3> headings are used on the page for semantic structure
+				// Using them for user content leads to accessibility issues
+				// Levelling down headings to start from <h4>
+				if (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(String(type))) {
+					type = `h${Math.min(+String(type)[1] + 3, 6)}`
+				}
+
 				let nestedNode = null
 				if (this.useExtendedMarkdown) {
 					if (String(type) === 'code' && !rehypeHighlight.value
@@ -681,8 +688,16 @@ export default {
 		font-weight: bold;
 	}
 
-	h1 {
-		font-size: 30px;
+	h4 {
+		font-size: 20px;
+	}
+
+	h5 {
+		font-size: 18px;
+	}
+
+	h6 {
+		font-size: 15px;
 	}
 
 	ul, ol {

--- a/tests/component/components/NcRichText/markown-rendering.spec.ts
+++ b/tests/component/components/NcRichText/markown-rendering.spec.ts
@@ -110,12 +110,12 @@ test.describe('headings', () => {
 			},
 		})
 
-		await expect(component.getByRole('heading', { level: 1 })).toHaveText('heading 1')
-		await expect(component.getByRole('heading', { level: 2 })).toHaveText('heading 2')
-		await expect(component.getByRole('heading', { level: 3 })).toHaveText('heading 3')
-		await expect(component.getByRole('heading', { level: 4 })).toHaveText('heading 4')
-		await expect(component.getByRole('heading', { level: 5 })).toHaveText('heading 5')
-		await expect(component.getByRole('heading', { level: 6 })).toHaveText('heading 6')
+		await expect(component.getByText('heading 1')).toHaveJSProperty('tagName', 'H4')
+		await expect(component.getByText('heading 2')).toHaveJSProperty('tagName', 'H5')
+		await expect(component.getByText('heading 3')).toHaveJSProperty('tagName', 'H6')
+		await expect(component.getByText('heading 4')).toHaveJSProperty('tagName', 'H6')
+		await expect(component.getByText('heading 5')).toHaveJSProperty('tagName', 'H6')
+		await expect(component.getByText('heading 6')).toHaveJSProperty('tagName', 'H6')
 	})
 
 	test('ignore heading (with hash (#) syntax padded to the text)', async ({ mount }) => {
@@ -138,7 +138,7 @@ test.describe('headings', () => {
 			},
 		})
 
-		await expect(component.getByRole('heading', { level: 1 })).toHaveText('heading 1')
+		await expect(component.getByText('heading 1')).toHaveJSProperty('tagName', 'H4')
 	})
 
 	test('render heading 2 (with dash (-) syntax on the next line)', async ({ mount }) => {
@@ -149,7 +149,7 @@ test.describe('headings', () => {
 			},
 		})
 
-		await expect(component.getByRole('heading', { level: 2 })).toHaveText('heading 2')
+		await expect(component.getByText('heading 2')).toHaveJSProperty('tagName', 'H5')
 	})
 })
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/7743
- Level down headings (-3 levels)
- Also, keep it small visually, so users don't feel they need to use low-level heading just because 1-3 levels are too large

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="816" height="530" alt="image" src="https://github.com/user-attachments/assets/b52356f1-e59e-469c-bde6-2105452a2f16" /> | <img width="816" height="435" alt="image" src="https://github.com/user-attachments/assets/bbc577b0-eb8e-4915-894e-f22fd85c55e3" />
<img width="616" height="188" alt="image" src="https://github.com/user-attachments/assets/e53ae947-9dfb-4d78-8beb-5d617916c458" /> | <img width="599" height="193" alt="image" src="https://github.com/user-attachments/assets/e01a5cfe-bf9f-491c-be83-e738844de7c7" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
