### PR TITLE
chore(docs): update docs link titles

### DIFF
--- a/styleguide.config.cjs
+++ b/styleguide.config.cjs
@@ -92,20 +92,12 @@ module.exports = async () => {
 				name: 'Versions',
 				sections: [
 					{
-						name: 'next v9.x (Nextcloud 31+ on Vue 3)',
+						name: 'v9 (Nextcloud 31+ on Vue 3)',
 						href: 'https://nextcloud-vue-components.netlify.app',
 					},
 					{
-						name: 'current v8.x (Nextcloud 28+ on Vue 2)',
+						name: 'v8 (Nextcloud 28+ on Vue 2)',
 						href: 'https://stable8--nextcloud-vue-components.netlify.app',
-					},
-					{
-						name: 'v7.x (Nextcloud 25 - 27)',
-						href: 'https://stable7--nextcloud-vue-components.netlify.app',
-					},
-					{
-						name: 'v6.x (Nextcloud 24 - 25)',
-						href: 'https://stable6--nextcloud-vue-components.netlify.app',
 					},
 				],
 			},


### PR DESCRIPTION
### ☑️ Resolves

- v6 and v7 are unmaintained for a long time now, having these links in the main menu doesn't seem necessary
  - If we still want to have the links available, we can either add them to README of the corresponding branches or list all the old links in "Other versions"
- v9 is not `next` anymore, but the current latest
- v8 is not `current` anymore but so called `stable` (actually, also current, but for Vue 2 apps)
- Removed `.x` to make it simpler and shorter

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="262" height="464" alt="image" src="https://github.com/user-attachments/assets/15016904-f48f-4d27-a5a3-10f97a71e9cf" /> | <img width="262" height="358" alt="image" src="https://github.com/user-attachments/assets/3807b8b4-199a-4d1d-91fd-b01d8780d09b" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
