### PR TITLE
feat(NcRadioGroup): deprecate `labelHidden` prop in favor of `hideLabel`

### DIFF
--- a/src/components/NcRadioGroup/NcRadioGroup.vue
+++ b/src/components/NcRadioGroup/NcRadioGroup.vue
@@ -16,14 +16,21 @@ const modelValue = defineModel<string>({ required: false, default: '' })
 defineProps<{
 	/**
 	 * Label of the radio group (accessible name).
-	 * It can be hidden visually if needed using `hidden-label` prop.
+	 * It can be hidden visually if needed using `hide-label` prop.
 	 */
 	label: string
 
 	/**
 	 * If set the label of the button group will not be shown visually but only for accessibility purposes.
+	 *
+	 * @deprecated Use `hide-label` instead.
 	 */
 	labelHidden?: boolean
+
+	/**
+	 * If set the label of the button group will not be shown visually but only for accessibility purposes.
+	 */
+	hideLabel?: boolean
 
 	/**
 	 * Optional visual description of the radio group.
@@ -75,7 +82,7 @@ function onUpdate(value: string) {
 	<NcFormGroup
 		:label
 		:description
-		:hide-label="labelHidden">
+		:hide-label="labelHidden || hideLabel">
 		<NcFormBox v-if="buttonVariant" row>
 			<slot />
 		</NcFormBox>
@@ -140,7 +147,7 @@ The radio group also allows to create a button like styling together with the `N
 	<div>
 		<h4>With text labels</h4>
 		<div style="max-width: 400px">
-			<NcRadioGroup v-model="alignment" label="Example alignment" label-hidden>
+			<NcRadioGroup v-model="alignment" label="Example alignment" hide-label>
 				<NcRadioGroupButton label="Start" value="start" />
 				<NcRadioGroupButton label="Center" value="center" />
 				<NcRadioGroupButton label="End" value="end" />
@@ -151,7 +158,7 @@ The radio group also allows to create a button like styling together with the `N
 
 		<h4>With icons</h4>
 		<div style="max-width: 250px">
-			<NcRadioGroup v-model="alignment" label="Example alignment with icons" label-hidden>
+			<NcRadioGroup v-model="alignment" label="Example alignment with icons" hide-label>
 				<NcRadioGroupButton aria-label="Start" value="start">
 					<template #icon>
 						<NcIconSvgWrapper directional :path="mdiAlignHorizontalLeft" />


### PR DESCRIPTION
### ☑️ Resolves

For consistency with other components.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
