### PR TITLE
[stable8] chore(docs): add missing backports around supported versions and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 | Version        | Target                | Documentation                                         |
 |----------------|-----------------------|-------------------------------------------------------|
-| v9.x [main]    | Nextcloud 32+ (Vue 3) | https://nextcloud-vue-components.netlify.app          |
+| v9.x [main]    | Nextcloud 31+ (Vue 3) | https://nextcloud-vue-components.netlify.app          |
 | v8.x [stable8] | Nextcloud 28+ (Vue 2) | https://stable8--nextcloud-vue-components.netlify.app |
 | v7.x [stable7] | Nextcloud 25 - 27     | https://stable7--nextcloud-vue-components.netlify.app |
 | v6.x [stable6] | Nextcloud 24 - 25     | https://stable6--nextcloud-vue-components.netlify.app |

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -92,7 +92,7 @@ module.exports = async () => {
 				name: 'Versions',
 				sections: [
 					{
-						name: 'v9 (Nextcloud 30+ on Vue 3)',
+						name: 'v9 (Nextcloud 31+ on Vue 3)',
 						href: 'https://nextcloud-vue-components.netlify.app',
 					},
 					{


### PR DESCRIPTION
### ☑️ Resolves
- Partial manual backport of: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6697/
- Partial manual backport of: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7287/
- Partial manual backport of (the last commit): https://github.com/nextcloud-libraries/nextcloud-vue/pull/7353/
- Note, some changes were backported in commits:
  - https://github.com/nextcloud-libraries/nextcloud-vue/commit/7ba00f8f187522cd3427d88367682bcc818251a1
  - https://github.com/nextcloud-libraries/nextcloud-vue/commit/5a2c048ac07fb553162def7f7bb5a112b72f8302
  - https://github.com/nextcloud-libraries/nextcloud-vue/commit/014c93d63c9e581d44f73f68722510c3b73d6bed