### PR TITLE
chore(docs): correct min supported Nextcloud version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@
 
 | Version        | Target                | Documentation                                         |
 |----------------|-----------------------|-------------------------------------------------------|
-| v9.x [main]    | Nextcloud 30+ (Vue 3) | https://nextcloud-vue-components.netlify.app          |
+| v9.x [main]    | Nextcloud 31+ (Vue 3) | https://nextcloud-vue-components.netlify.app          |
 | v8.x [stable8] | Nextcloud 28+ (Vue 2) | https://stable8--nextcloud-vue-components.netlify.app |
 | v7.x [stable7] | Nextcloud 25 - 27     | https://stable7--nextcloud-vue-components.netlify.app |
 | v6.x [stable6] | Nextcloud 24 - 25     | https://stable6--nextcloud-vue-components.netlify.app |


### PR DESCRIPTION
### ☑️ Resolves

- Correct `docs/index.md` to be up to date with README.md, missing changes from:
  - https://github.com/nextcloud-libraries/nextcloud-vue/pull/7287
  - https://github.com/nextcloud-libraries/nextcloud-vue/pull/7353
- Alternative: use `README.md` as `index.md`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1015" height="490" alt="image" src="https://github.com/user-attachments/assets/c25491ec-7856-4020-9219-9ef22128420b" /> | <img width="1004" height="488" alt="image" src="https://github.com/user-attachments/assets/d3f65d47-7c5f-4327-a5aa-ea464b682779" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
