### PR TITLE
fix(NcFormGroup): decrease gap between label and content

### DIFF
--- a/src/components/NcFormGroup/NcFormGroup.vue
+++ b/src/components/NcFormGroup/NcFormGroup.vue
@@ -105,7 +105,8 @@ const hasContentOnly = () => hideLabel && (!hasDescription() || hideDescription)
 	display: flex;
 	flex-direction: column;
 	gap: var(--form-group-content-gap);
-	margin-block-start: calc(4 * var(--default-grid-baseline));
+	margin-block-start: calc(2.5 * var(--default-grid-baseline));
+
 	&.formGroup__content_only {
 		margin-block-start: 0;
 	}


### PR DESCRIPTION
### ☑️ Resolves

- A minor bug
- The gap is `16px`
- In the design it was the gap between **the text baseline** and the content
- In the implementation it is a gap between **the text block** (including lint-height) and the content

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="814" height="214" alt="image" src="https://github.com/user-attachments/assets/bebfd1fc-c2dd-4ddf-904b-ede28a4dea32" /> | <img width="812" height="206" alt="image" src="https://github.com/user-attachments/assets/b2f8aa38-c094-4930-b264-f1b2e5c7c349" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
