### PR TITLE
fix(NcActions): handle expensive height computation by popover library

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1342,7 +1342,6 @@ export default {
 		onOpened() {
 			this.$nextTick(() => {
 				this.focusFirstAction(null)
-				this.resizePopover()
 
 				/**
 				 * Event emitted when the popover menu is opened.
@@ -1360,59 +1359,6 @@ export default {
 			 * This event is emitted after `update:open` was emitted and the closing transition finished.
 			 */
 			this.$emit('closed')
-		},
-
-		/**
-		 * Handle resizing the popover to make sure users can discover there is more to scroll
-		 */
-		resizePopover() {
-			// Get the inner v-popper element that defines the popover height (from floating-vue)
-			const inner = this.$refs.menu.closest('.v-popper__inner')
-			const height = this.$refs.menu.clientHeight
-			const maxMenuHeight = this.getMaxMenuHeight()
-
-			// If the popover height is limited by the max-height (scrollbars shown) limit the height to half of the last element
-			if (height > maxMenuHeight) {
-				// sum of action heights
-				let currentHeight = 0
-				// last action height
-				let actionHeight = 0
-				for (const action of this.$refs.menuList.children) {
-					// If the max height would be overflown by half of the current element,
-					// then we limit the height to the half of the previous element
-					if ((currentHeight + action.clientHeight / 2) > maxMenuHeight) {
-						inner.style.height = `${currentHeight - actionHeight / 2}px`
-						break
-					}
-					// otherwise sum up the height
-					actionHeight = action.clientHeight
-					currentHeight += actionHeight
-				}
-			} else {
-				inner.style.height = 'fit-content'
-			}
-		},
-
-		getMaxMenuHeight() {
-			const { top, bottom } = this.$refs.triggerButton?.$el.getBoundingClientRect() ?? { top: 0, bottom: 0 }
-			const { top: boundaryTop, bottom: boundaryBottom } = this.boundariesElement?.getBoundingClientRect() ?? { top: 0, bottom: window.innerHeight }
-
-			return Math.max(
-				// Either expand to the top
-				Math.min(
-					// max height is the top position of the trigger minus the header height minus the wedge and the padding
-					top - 84,
-					// and also limited to the space in the boundary
-					top - boundaryTop,
-				),
-				// or expand to the bottom
-				Math.min(
-					// the max height is the window height minus current position of the trigger minus the wedge and padding
-					window.innerHeight - bottom - 34,
-					// and limit to the available space in the boundary
-					boundaryBottom - bottom,
-				),
-			)
 		},
 
 		// MENU KEYS & FOCUS MANAGEMENT
@@ -1779,6 +1725,7 @@ export default {
 					shown: this.opened,
 					placement: this.placement,
 					boundary: this.boundariesElement,
+					autoBoundaryMaxSize: true,
 					container: this.container,
 					...this.manualOpen && {
 						triggers: [],
@@ -1848,7 +1795,6 @@ export default {
 		// Mostly used when clicking a menu item
 		this.$nextTick(() => {
 			if (this.opened && this.$refs.menu) {
-				this.resizePopover()
 				const isAnyActive = this.$refs.menu.querySelector('li.active') || []
 				if (isAnyActive.length === 0) {
 					this.focusFirstAction()


### PR DESCRIPTION
### ☑️ Resolves

- Replaces #5806
  - `autoBoundaryMaxSize` lets floating vue resize the popper inner container to the available size
  - drawback - losing feature of showing 50% of last item cropped, if it doesn't fit the screen
  - benefits - no more jumping and second re-render (first by library, then manually by us), no memory leaks

### 🖼️ Screenshots

🏚️ Before

https://github.com/user-attachments/assets/dcfa199e-0612-4ac3-9c01-79fb868b02de

🏡 After

https://github.com/user-attachments/assets/2285e070-38a9-4d0c-9c75-993c95f3930c





### 🚧 Tasks

- [x] Check effect on Memory/Performance
- [ ] Check for side effects

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
