### PR TITLE
chore(docs): do not minimize docs and add examples code highlight

### DIFF
--- a/styleguide.config.cjs
+++ b/styleguide.config.cjs
@@ -39,7 +39,7 @@ module.exports = async () => {
 		styleguideDir: 'styleguide/build',
 
 		pagePerSection: true,
-		minimize: true,
+		minimize: false,
 		verbose: false,
 
 		webpackConfig: merge(newConfig, {


### PR DESCRIPTION
### ☑️ Resolves

- Bring back code highlighting on production styleguide build

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
11 MB | 17 MB (bigger, but not important for docs)
Very slow Netlify build | Slightly slow Netlify build
<img width="847" height="782" alt="image" src="https://github.com/user-attachments/assets/11f62afc-e80f-4e00-85aa-470a95acf145" /> | <img width="852" height="719" alt="image" src="https://github.com/user-attachments/assets/12a26c7f-ccd1-45c5-af5f-d122f2e8ef32" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
