### PR TITLE
fix(NcRichContenteditable): keep previous cursor position on focus

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -715,6 +715,12 @@ export default {
 			if (!document.createRange) {
 				return
 			}
+
+			if (window.getSelection().rangeCount > 0
+				&& this.$refs.contenteditable.contains(window.getSelection().getRangeAt(0).commonAncestorContainer)) {
+				return
+			}
+
 			const range = document.createRange()
 			range.selectNodeContents(this.$refs.contenteditable)
 			range.collapse(false)


### PR DESCRIPTION
### ☑️ Resolves

- Since #4924 either something was changed in browsers, or wasn't tested in different OS properly
- ATM on Linux, unfocusing page with focused NcRichContenteditable and the focus the page back trigger `@focus="moveCursorToEnd"` event, effectively setting cursor to the end
- Now, we check if element was previously focused/has a selection range, and keep it as-is
- on Windows, can be tested with `$0.blur(); $0.focus()`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
