### PR TITLE
fix(NcFormBox*): user-select: none on Safari as well

### DIFF
--- a/src/components/NcFormBox/NcFormBoxItem.vue
+++ b/src/components/NcFormBox/NcFormBoxItem.vue
@@ -120,6 +120,7 @@ const hasDescription = () => !!description || !!slots.description
 	transition-property: color, border-color, background-color;
 	transition-duration: var(--animation-quick);
 	transition-timing-function: linear;
+	-webkit-user-select: none;
 	user-select: none;
 	cursor: pointer;
 


### PR DESCRIPTION
### ☑️ Resolves

- I missed that `use-select` is still not supported on Safari without a prefix

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
