### PR TITLE
feat(NcAppSettingsDialog): adjust design for new form elements, add section descriptions and optional switch to legacy design

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -7,12 +7,12 @@
 import type { Slot, VNode } from 'vue'
 
 import debounce from 'debounce'
-import { computed, onBeforeUnmount, provide, ref, useTemplateRef, warn } from 'vue'
+import { computed, onBeforeUnmount, provide, ref, toRef, useTemplateRef, warn } from 'vue'
 import NcDialog from '../NcDialog/NcDialog.vue'
 import NcVNodes from '../NcVNodes/NcVNodes.vue'
 import { useIsMobile } from '../../composables/useIsMobile/index.ts'
 import { t } from '../../l10n.ts'
-import { APP_SETTINGS_REGISTRATION_KEY } from './useAppSettingsDialog.ts'
+import { APP_SETTINGS_LEGACY_DESIGN_KEY, APP_SETTINGS_REGISTRATION_KEY } from './useAppSettingsDialog.ts'
 
 export interface IAppSettingsSection {
 	id: string
@@ -46,10 +46,18 @@ const props = withDefaults(defineProps<{
 	 * Additional elements to add to the focus trap
 	 */
 	additionalTrapElements?: (string | HTMLElement)[]
+
+	/**
+	 * Use legacy design without any requirements for the section content
+	 *
+	 * @deprecated The legacy design will be removed
+	 */
+	legacy?: boolean
 }>(), {
 	container: 'body',
 	name: '',
 	additionalTrapElements: () => [],
+	legacy: false,
 })
 
 defineSlots<{
@@ -63,6 +71,8 @@ provide(APP_SETTINGS_REGISTRATION_KEY, {
 	registerSection,
 	unregisterSection,
 })
+
+provide(APP_SETTINGS_LEGACY_DESIGN_KEY, toRef(() => props.legacy))
 
 const settingsScrollerElement = useTemplateRef('settingsScroller')
 
@@ -317,7 +327,7 @@ providing the section's name prop. You can put your settings within each
 <template>
 	<div>
 		<NcButton @click="settingsOpen = true">Show Settings</NcButton>
-		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings">
+		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings" legacy>
 			<NcAppSettingsSection id="asci-name-1" name="Example name 1">
 				Some example content
 			</NcAppSettingsSection>
@@ -369,7 +379,7 @@ You can also add icons to the section navigation:
 <template>
 	<div>
 		<NcButton @click="settingsOpen = true">Show Settings</NcButton>
-		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings">
+		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings" legacy>
 			<NcAppSettingsSection id="asci-name-1" name="Instagram">
 				<template #icon>
 					<Instagram :size="20" />
@@ -433,7 +443,7 @@ In case of dynamic/conditional sections rendering explicit `order` prop must be 
 <template>
 	<div>
 		<NcButton @click="settingsOpen = true">Show Settings</NcButton>
-		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings">
+		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings" legacy>
 			<NcAppSettingsSection id="asci-name-1" name="Example name 1" :order="1">
 				Some example content
 				<NcCheckboxRadioSwitch v-model="showExtraSections">Show section 3</NcCheckboxRadioSwitch>
@@ -463,5 +473,223 @@ In case of dynamic/conditional sections rendering explicit `order` prop must be 
 		},
 	}
 </script>
+```
+
+### New design
+
+```vue
+<script>
+import { mdiPlus, mdiDomain, mdiDockLeft, mdiDockBottom, mdiListBoxOutline, mdiPencilOutline, mdiTrashCanOutline, mdiMedalOutline, mdiEmailOutline } from '@mdi/js'
+export default {
+	setup() {
+		return { mdiPlus, mdiDomain, mdiDockLeft, mdiDockBottom, mdiListBoxOutline, mdiPencilOutline, mdiTrashCanOutline, mdiMedalOutline, mdiEmailOutline }
+	},
+	data() {
+		return {
+			settingsOpen: false,
+			switchValue: true,
+			layout: 'vertical',
+			sorting: 'asc',
+			reply: 'top',
+		}
+	},
+}
+</script>
+
+<template>
+	<div>
+		<NcButton @click="settingsOpen = true">Mail Settings</NcButton>
+		<NcAppSettingsDialog v-model:open="settingsOpen" :show-navigation="true" name="Application settings">
+			<NcAppSettingsSection id="general" name="General">
+				<NcButton wide>Set as default mail app</NcButton>
+
+				<NcFormGroup label="Account settings">
+					<NcFormBox v-slot="{ itemClass }">
+						<NcFormBoxButton href="#">user@example.com</NcFormBoxButton>
+						<NcFormBoxButton href="#">sales@example.com</NcFormBoxButton>
+						<NcButton :class="itemClass" wide>
+							<template #icon>
+								<NcIconSvgWrapper :path="mdiPlus" />
+							</template>
+							Add mail account
+						</NcButton>
+					</NcFormBox>
+				</NcFormGroup>
+			</NcAppSettingsSection>
+
+			<NcAppSettingsSection id="appearance" name="Appearance">
+				<NcFormBox>
+					<NcFormBoxSwitch
+						v-model="switchValue"
+						label="Show all messages in thread"
+						description="When off, only the selected messages will be shown" />
+				</NcFormBox>
+				<NcRadioGroup v-model="layout" label="Layout">
+					<NcRadioGroupButton label="Vertical" value="vertical">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiDockLeft" />
+						</template>
+					</NcRadioGroupButton>
+					<NcRadioGroupButton label="Horizontal" value="horizontal">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiDockBottom" />
+						</template>
+					</NcRadioGroupButton>
+					<NcRadioGroupButton label="List" value="list">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiListBoxOutline" />
+						</template>
+					</NcRadioGroupButton>
+				</NcRadioGroup>
+				<NcRadioGroup v-model="sorting" label="Sorting">
+					<NcRadioGroupButton label="Newest first" value="asc" />
+					<NcRadioGroupButton label="Oldest first" value="desc" />
+				</NcRadioGroup>
+			</NcAppSettingsSection>
+
+			<NcAppSettingsSection id="messages" name="Messages">
+				<NcFormBox>
+					<NcFormBoxSwitch v-model="switchValue" label="Avatars from Gravatar and favicons" />
+					<NcFormBoxSwitch v-model="switchValue" label="Determine importance using machine learning" />
+					<NcFormBoxSwitch v-model="switchValue" label="Search the body of messages in Priority inbox" />
+				</NcFormBox>
+				<NcRadioGroup v-model="reply" label="Reply position">
+					<NcRadioGroupButton label="Top" value="top" />
+					<NcRadioGroupButton label="Bottom" value="bottom" />
+				</NcRadioGroup>
+				<NcFormGroup
+					label="Text blocks"
+					description="Reusable pieces of text that can be inserted in messages">
+					<NcListItem name="Title">
+						<template #subname>
+							Content
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiPencilOutline" inline />
+							</NcButton>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+					<NcListItem name="Reply">
+						<template #subname>
+							Thank you for contacting us!
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiPencilOutline" inline />
+							</NcButton>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+				</NcFormGroup>
+			</NcAppSettingsSection>
+
+			<NcAppSettingsSection id="privacy" name="Privacy">
+				<NcFormBox>
+					<NcFormBoxSwitch
+						v-model="switchValue"
+						label="Data collection"
+						description="Allow the app to collect and process data locally to adapt to your preferences" />
+				</NcFormBox>
+				<NcFormGroup label="Always show images from">
+					<NcListItem name="example.com">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiDomain" inline />
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+					<NcListItem name="example.net">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiDomain" inline />
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+					<NcListItem name="mail@example.org">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiEmailOutline" inline />
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+				</NcFormGroup>
+			</NcAppSettingsSection>
+
+			<NcAppSettingsSection id="security" name="Security">
+				<NcFormBox>
+					<NcFormBoxSwitch v-model="switchValue" label="Highlight external addresses" />
+				</NcFormBox>
+				<NcFormGroup label="Internal addresses">
+					<NcListItem name="example.com">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiDomain" inline />
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+					<NcListItem name="example.company@example.net">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiEmailOutline" inline />
+						</template>
+						<template #extra-actions>
+							<NcButton variant="tertiary" #icon>
+								<NcIconSvgWrapper :path="mdiTrashCanOutline" inline />
+							</NcButton>
+						</template>
+					</NcListItem>
+					<NcButton wide>Add internal address</NcButton>
+				</NcFormGroup>
+				<NcFormGroup label="S/MIME">
+					<NcButton wide>
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiMedalOutline" inline />
+						</template>
+						Manage certificates
+					</NcButton>
+				</NcFormGroup>
+				<NcFormGroup label="Mailvelope">
+					<NcFormBox>
+						<NcFormBoxButton
+							label="Step 1"
+							description="Install the browser extension"
+							href="https://www.mailvelope.com/"
+							target="_blank"
+							inverted-accent />
+						<NcFormBoxButton
+							label="Step 2"
+							description="Enable the current domain"
+							inverted-accent>
+							<template #icon>
+								<NcIconSvgWrapper :path="mdiDomain" inline />
+							</template>
+						</NcFormBoxButton>
+					</NcFormBox>
+				</NcFormGroup>
+			</NcAppSettingsSection>
+
+			<NcAppSettingsSection id="about" name="About">
+				<NcFormGroup label="Acknowledgements" description="This application includes CKEditor, an open-source editor. Copyright (C) CKEditor contributors. Licensed under GPLv2." />
+			</NcAppSettingsSection>
+		</NcAppSettingsDialog>
+	</div>
+</template>
 ```
 </docs>

--- a/src/components/NcAppSettingsDialog/useAppSettingsDialog.ts
+++ b/src/components/NcAppSettingsDialog/useAppSettingsDialog.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { InjectionKey, VNode } from 'vue'
+import type { InjectionKey, Ref, VNode } from 'vue'
 
 import { inject } from 'vue'
 
@@ -27,6 +27,7 @@ interface AppSettingsRegistrationContext {
 }
 
 export const APP_SETTINGS_REGISTRATION_KEY: InjectionKey<AppSettingsRegistrationContext> = Symbol.for('NcAppSettingsDialog:registration')
+export const APP_SETTINGS_LEGACY_DESIGN_KEY: InjectionKey<Ref<boolean>> = Symbol.for('NcAppSettingsDialog:legacy')
 
 /**
  * Get the provided methods from the app settings dialog.

--- a/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
+++ b/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
@@ -6,9 +6,9 @@
 <script setup lang="ts">
 import type { Slot } from 'vue'
 
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, watch } from 'vue'
 import { logger } from '../../utils/logger.ts'
-import { useAppSettingsDialog } from '../NcAppSettingsDialog/useAppSettingsDialog.ts'
+import { APP_SETTINGS_LEGACY_DESIGN_KEY, useAppSettingsDialog } from '../NcAppSettingsDialog/useAppSettingsDialog.ts'
 
 const props = defineProps<{
 	/** Name of the section */
@@ -29,6 +29,7 @@ const slots = defineSlots<{
 }>()
 
 const { registerSection, unregisterSection } = useAppSettingsDialog()
+const legacy = inject(APP_SETTINGS_LEGACY_DESIGN_KEY)!
 
 const htmlId = computed(() => 'settings-section_' + props.id)
 
@@ -61,7 +62,8 @@ onBeforeUnmount(() => {
 	<section
 		:id="htmlId"
 		:aria-labelledby="`${htmlId}--label`"
-		class="app-settings-section">
+		class="app-settings-section"
+		:class="{ 'app-settings-section__legacy': legacy }">
 		<h3 :id="`${htmlId}--label`" class="app-settings-section__name">
 			{{ name }}
 		</h3>
@@ -76,21 +78,36 @@ onBeforeUnmount(() => {
 
 <style lang="scss" scoped>
 .app-settings-section {
+	--form-element-label-offset: calc(var(--border-radius-element) + var(--default-grid-baseline));
+	--app-settings-section-text-offset: var(--form-element-label-offset);
+	--app-settings-section-content-gap: calc(6 * var(--default-grid-baseline));
 	margin-block-end: calc(8 * var(--default-grid-baseline));
+
 	&__name {
 		margin: 0;
-		padding-inline: 0;
+		padding-inline: var(--app-settings-section-text-offset);
 		padding-block: 0;
 		font-size: 20px;
 		font-weight: bold;
 	}
 
 	&__description {
+		padding-inline: var(--app-settings-section-text-offset);
 		color: var(--color-text-maxcontrast);
 	}
 
 	&__content {
 		margin-block-start: calc(2 * var(--default-grid-baseline));
+
+		display: flex;
+		flex-direction: column;
+		justify-content: stretch;
+		gap: var(--app-settings-section-content-gap);
 	}
+}
+
+.app-settings-section__legacy {
+	--app-settings-section-text-offset: 0;
+	--app-settings-section-content-gap: 0;
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/7124
- Added `description` for the `NcAppSettingsSection`
- Adjusted to the new design
  - To be used with `NcFormGroup` and `NcFormBox` components
- Added `legacy` prop to revert breaking parts of the new design
- ⚠️ Documentation improvement is in progress
  - Please do not review the documentation update
  - PR will be merged as it is, and the documentation will be adjusted later

### 🖼️ Screenshots

#### With legacy design

🏚️ Before | 🏡 After
---|---
<img width="925" height="1143" alt="image" src="https://github.com/user-attachments/assets/a8eb29dc-5f40-4858-8531-d8d22e07de5c" /> | <img width="936" height="1003" alt="image" src="https://github.com/user-attachments/assets/8fe58305-06f0-4b12-9bd3-add14d615e25" />

#### With the new design

<img width="937" height="1147" alt="image" src="https://github.com/user-attachments/assets/29729848-2e58-4a17-bfed-166061fabb4c" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
