### PR TITLE
chore(docs): optionally set docs server port via VUE_STYLEGUIDIST_PORT

### DIFF
--- a/styleguide.config.cjs
+++ b/styleguide.config.cjs
@@ -67,6 +67,8 @@ module.exports = async () => {
 			},
 		}),
 
+		serverPort: +(process.env.VUE_STYLEGUIDIST_PORT || 6060),
+
 		exampleMode: 'collapse',
 		usageMode: 'collapse',
 


### PR DESCRIPTION
### ☑️ Resolves

- A bit personal request
- Allows running `vue-styleguidist` in `main` and `stable8` in parallel locally

```sh
# main
npm run styleguide

# stable8
VUE_STYLEGUIDIST_PORT=6061 npm run styleguide
```