### PR TITLE
fix(NcHotkeyList): align with the section

### DIFF
--- a/src/components/NcHotkeyList/NcHotkeyList.vue
+++ b/src/components/NcHotkeyList/NcHotkeyList.vue
@@ -42,8 +42,6 @@ const labelId = `NcHotkeyList_${createElementId()}`
 <style module>
 .hotkeyList {
 	--form-element-label-offset: calc(var(--border-radius-element) + var(--default-grid-baseline));
-	/* Too wide list is less readable - 400px seems a good width */
-	max-width: 400px;
 }
 
 .hotkeyList__heading {


### PR DESCRIPTION
### ☑️ Resolves

- A part of https://github.com/nextcloud-libraries/nextcloud-vue/pull/7807

Before | After
-- | --
<img width="917" height="1138" alt="image" src="https://github.com/user-attachments/assets/4a7ee1b0-5743-447c-a692-ffe41c7e6cbb" /> | <img width="925" height="1136" alt="image" src="https://github.com/user-attachments/assets/9eb636fd-182e-4ed3-a4d6-4233b417d23a" />