### PR TITLE
feat: NcAppSettingsSectionShortcuts -> NcAppSettingsShortcutsSection

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -689,7 +689,7 @@ export default {
 				<NcFormGroup label="Acknowledgements" description="This application includes CKEditor, an open-source editor. Copyright (C) CKEditor contributors. Licensed under GPLv2." />
 			</NcAppSettingsSection>
 
-			<NcAppSettingsSectionShortcuts>
+			<NcAppSettingsShortcutsSection>
 				<NcHotkeyList>
 					<NcHotkey label="Compose new message" hotkey="C" />
 					<NcHotkey label="Newer message" hotkey="ArrowLeft" />
@@ -702,7 +702,7 @@ export default {
 					<NcHotkey label="Send" hotkey="Control Enter" />
 					<NcHotkey label="Refresh" hotkey="R" />
 				</NcHotkeyList>
-			</NcAppSettingsSectionShortcuts>
+			</NcAppSettingsShortcutsSection>
 		</NcAppSettingsDialog>
 	</div>
 </template>

--- a/src/components/NcAppSettingsSectionShortcuts/index.ts
+++ b/src/components/NcAppSettingsSectionShortcuts/index.ts
@@ -1,6 +1,9 @@
-/*
+/*!
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export { default } from './NcAppSettingsSectionShortcuts.vue'
+/**
+ * @deprecated Component has been renamed to NcAppSettingsShortcutsSection
+ */
+export { default } from '../NcAppSettingsShortcutsSection/NcAppSettingsShortcutsSection.vue'

--- a/src/components/NcAppSettingsShortcutsSection/NcAppSettingsShortcutsSection.vue
+++ b/src/components/NcAppSettingsShortcutsSection/NcAppSettingsShortcutsSection.vue
@@ -51,7 +51,7 @@ export default {
 	<div>
 		<NcButton @click="open = true">App Settings</NcButton>
 		<NcAppSettingsDialog v-model:open="open" name="Application settings" show-navigation>
-			<NcAppSettingsSectionShortcuts>
+			<NcAppSettingsShortcutsSection>
 				<NcHotkeyList label="Actions">
 					<NcHotkey label="File actions" hotkey="A" />
 					<NcHotkey label="Rename" hotkey="F2" />
@@ -80,7 +80,7 @@ export default {
 					<NcHotkey label="Open file sidebar" hotkey="D" />
 					<NcHotkey label="Show those shortcuts" hotkey="?" />
 				</NcHotkeyList>
-			</NcAppSettingsSectionShortcuts>
+			</NcAppSettingsShortcutsSection>
 		</NcAppSettingsDialog>
 	</div>
 </template>

--- a/src/components/NcAppSettingsShortcutsSection/index.ts
+++ b/src/components/NcAppSettingsShortcutsSection/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export { default } from './NcAppSettingsShortcutsSection.vue'

--- a/src/components/NcHotkeyList/NcHotkeyList.vue
+++ b/src/components/NcHotkeyList/NcHotkeyList.vue
@@ -53,7 +53,7 @@ const labelId = `NcHotkeyList_${createElementId()}`
 <docs>
 ## General
 
-List of keyboard shortcuts for the `<NcAppSettingsSectionShortcuts>`.
+List of keyboard shortcuts for the `<NcAppSettingsShortcutsSection>`.
 
 ```vue
 <template>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export { default as NcAppNavigationSpacer } from './NcAppNavigationSpacer/index.
 export { default as NcAppSettingsDialog } from './NcAppSettingsDialog/index.ts'
 export { default as NcAppSettingsSection } from './NcAppSettingsSection/index.ts'
 export { default as NcAppSettingsSectionShortcuts } from './NcAppSettingsSectionShortcuts/index.ts'
+export { default as NcAppSettingsShortcutsSection } from './NcAppSettingsShortcutsSection/index.ts'
 export { default as NcAppSidebar } from './NcAppSidebar/index.js'
 export { default as NcAppSidebarHeader } from './NcAppSidebarHeader/index.ts'
 export { default as NcAppSidebarTab } from './NcAppSidebarTab/index.js'


### PR DESCRIPTION
### ☑️ Resolves

- Because the new component is a specific version of the common component, but not the part/child of it, it should be named `Section + ShortcutsSection`, not `Section + SectionShortcuts`
- The component is also re-exported by the old name with deprecation to prevent breaking changes

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
