### PR TITLE
fix(NcListItem): do not mount NcAction until necessary

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -513,7 +513,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 
 				<!-- Actions -->
 				<div
-					v-show="forceDisplayActions || displayActionsOnHoverFocus"
+					v-if="forceDisplayActions || displayActionsOnHoverFocus"
 					class="list-item-content__actions"
 					@focusout="handleBlur">
 					<NcActions


### PR DESCRIPTION
### ☑️ Resolves

- Fix performance issues with active/massive `NcListItem`s rendering with (unforced) actions
- Only render `NcActions` when needed instead of hidding visually
- I checked the history and did not found any specific reason to use `v-show`, it looks like that's just how it used to be
- Works with keyboard, focus, mouse over etc. (not worse than in the past)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
