### PR TITLE
fix(NcPasswordField): respect `checkPasswordStrength` for input validation

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -226,6 +226,12 @@ const propsToForward = computed<Partial<NcInputFieldProps>>(() => {
 	return all satisfies Partial<NcInputFieldProps>
 })
 
+const minLengthWithPolicy = computed(() => {
+	return props.minlength
+		?? (props.checkPasswordStrength ? passwordPolicy?.minLength : undefined)
+		?? undefined
+})
+
 /**
  * Validate the entered password.
  * If available this method will use the password-policy app API to validate the password.
@@ -294,7 +300,7 @@ function select() {
 		:error="error || isValid === false"
 		:helper-text="helperText || internalHelpMessage"
 		:input-class="[inputClass, { 'password-field__input--secure-text': !visible && asText }]"
-		:minlength="minlength ?? passwordPolicy?.minLength ?? 0"
+		:minlength="minLengthWithPolicy"
 		:success="success || isValid === true"
 		:trailing-button-label="visible ? t('Hide password') : t('Show password')"
 		:type="visible || asText ? 'text' : 'password'"


### PR DESCRIPTION
### ☑️ Resolves

- Ref https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/1228#issuecomment-3521587719
- Also set minLength to undefined, if not set

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] Test

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
