### PR TITLE
[stable8] fix(NcPasswordField): respect `checkPasswordStrength` for input validation

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -206,7 +206,7 @@ export default {
 		 */
 		minlength: {
 			type: Number,
-			default: 0,
+			default: undefined,
 		},
 
 		/**
@@ -304,7 +304,7 @@ export default {
 		rules() {
 			const { minlength } = this
 			return {
-				minlength: minlength ?? passwordPolicy?.minLength,
+				minlength: minlength ?? (this.checkPasswordStrength ? passwordPolicy?.minLength : undefined),
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

Backport of #7845
default value is changed, but it's neglectible as it just removes the input attribute