### PR TITLE
fix(NcActions): introduce 'size' prop

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1081,7 +1081,6 @@ export default {
 		/**
 		 * Specifies the button variant used for trigger and single actions buttons.
 		 *
-		 * Accepted values: primary, secondary, tertiary, tertiary-no-background, tertiary-on-primary, error, warning, success.
 		 * If left empty, the default button style will be applied.
 		 *
 		 * @since 8.23.0
@@ -1093,6 +1092,19 @@ export default {
 			},
 
 			default: null,
+		},
+
+		/**
+		 * Specify the size used for trigger and single actions buttons.
+		 *
+		 * If left empty, the default button size will be applied.
+		 */
+		size: {
+			type: String,
+			default: 'normal',
+			validator(value) {
+				return ['small', 'normal', 'large'].includes(value)
+			},
 		},
 	},
 
@@ -1741,6 +1753,7 @@ export default {
 						title,
 						disabled: this.disabled || action?.props?.disabled,
 						pressed: action?.props?.modelValue,
+						size: this.size,
 						type,
 						// If it has a menuName, we use a secondary button
 						variant: this.variant || (buttonText ? 'secondary' : 'tertiary'),
@@ -1797,6 +1810,7 @@ export default {
 						id: triggerRandomId,
 						class: 'action-item__menutoggle',
 						disabled: this.disabled,
+						size: this.size,
 						variant: this.triggerButtonVariant,
 						ref: 'triggerButton',
 						'aria-label': this.menuName ? null : this.ariaLabel,


### PR DESCRIPTION
### ☑️ Resolves

- Allows to pass 'size' prop to underlying NcButton components
- Introducing beforehand, if that would be ever required by apps

### 🖼️ Screenshots

<img width="183" height="101" alt="image" src="https://github.com/user-attachments/assets/fab63aee-a8d9-4ecd-95b7-25b42cda97a1" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
