### PR TITLE
[stable8] fix(NcFormBoxSwitch): use passive model to sync checkbox and icon

### DIFF
--- a/src/components/NcFormBoxSwitch/NcFormBoxSwitch.vue
+++ b/src/components/NcFormBoxSwitch/NcFormBoxSwitch.vue
@@ -43,7 +43,7 @@ const emit = defineEmits<{
 	(event: 'update:modelValue', value: boolean): void
 }>()
 
-const model = useVModel(props, 'modelValue', emit)
+const model = useVModel(props, 'modelValue', emit, { passive: true })
 
 const inputId = createElementId()
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/7848
- `defineModel` has internal model value state. `useVModel` does it in `passive` mode. This is the only `useVModel` usage with missed `passive`.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
