### PR TITLE
fix(NcFormBox): use default text color in items

### DIFF
--- a/src/components/NcFormBox/NcFormBoxItem.vue
+++ b/src/components/NcFormBox/NcFormBoxItem.vue
@@ -116,7 +116,7 @@ const hasDescription = () => !!description || !!slots.description
 	border-bottom-width: 2px;
 	border-radius: var(--border-radius-element);
 	background-color: var(--color-primary-element-extra-light);
-	color: var(--color-primary-element-light-text);
+	color: var(--color-main-text);
 	transition-property: color, border-color, background-color;
 	transition-duration: var(--animation-quick);
 	transition-timing-function: linear;


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/7853

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="814" height="262" alt="image" src="https://github.com/user-attachments/assets/720838fe-753e-4a1d-82be-aa4573f7bb9f" /> | <img width="816" height="267" alt="image" src="https://github.com/user-attachments/assets/440674e5-49d6-4ca1-b4c9-b4f02f89785e" />
<img width="794" height="287" alt="image" src="https://github.com/user-attachments/assets/6adb824a-9ea6-4ae2-80f9-84d3eceea068" /> | <img width="798" height="284" alt="image" src="https://github.com/user-attachments/assets/299c83cd-39f6-4edc-abc3-2744b5578750" />
<img width="815" height="513" alt="image" src="https://github.com/user-attachments/assets/61c48986-6034-4e21-b11a-588b35b236eb" /> | <img width="814" height="509" alt="image" src="https://github.com/user-attachments/assets/dbd3072a-f929-4c79-a98b-7eab2265be3a" />
<img width="796" height="536" alt="image" src="https://github.com/user-attachments/assets/f6e30f1e-9682-428d-8c46-efdd13462de6" /> | <img width="792" height="535" alt="image" src="https://github.com/user-attachments/assets/05f69f3e-94e0-443a-b7f3-94375643f246" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
