### PR TITLE
fix(NcTextField): helper text icon is too large

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -20,7 +20,7 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 import type { Slot } from 'vue'
 import type { VueClassType } from '../../utils/VueTypes.ts'
 
-import { mdiAlertCircle, mdiCheck } from '@mdi/js'
+import { mdiAlertCircleOutline, mdiCheck } from '@mdi/js'
 import { computed, useAttrs, useTemplateRef, warn } from 'vue'
 import { createElementId } from '../../utils/createElementId.ts'
 import { isLegacy } from '../../utils/legacy.ts'
@@ -285,7 +285,7 @@ function handleInput(event: Event) {
 				v-else-if="success || error"
 				class="input-field__icon input-field__icon--trailing">
 				<NcIconSvgWrapper v-if="success" :path="mdiCheck" />
-				<NcIconSvgWrapper v-else :path="mdiAlertCircle" />
+				<NcIconSvgWrapper v-else :path="mdiAlertCircleOutline" />
 			</div>
 		</div>
 		<p
@@ -300,7 +300,7 @@ function handleInput(event: Event) {
 			<NcIconSvgWrapper
 				v-else-if="error"
 				class="input-field__helper-text-message__icon"
-				:path="mdiAlertCircle"
+				:path="mdiAlertCircleOutline"
 				inline />
 			{{ helperText }}
 		</p>

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -74,7 +74,7 @@ export default {
 <script setup lang="ts">
 import type { VueClassType } from '../../utils/VueTypes.ts'
 
-import { mdiAlertCircle, mdiCheck } from '@mdi/js'
+import { mdiAlertCircleOutline, mdiCheck } from '@mdi/js'
 import { computed, useAttrs, useTemplateRef, watch } from 'vue'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import { createElementId } from '../../utils/createElementId.ts'
@@ -277,7 +277,7 @@ function select() {
 			<NcIconSvgWrapper
 				v-else-if="error"
 				class="textarea__helper-text-message__icon"
-				:path="mdiAlertCircle"
+				:path="mdiAlertCircleOutline"
 				inline />
 			{{ helperText }}
 		</p>


### PR DESCRIPTION
### ☑️ Resolves

- Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6951
- Missing `inline`
- Not outline icons where used (the import on stable8 was confusing)
- We miss it quite often 🙈

### 🖼️ Screenshots

Stable8 | Before | After
-- | -- | --
<img width="310" height="87" alt="image" src="https://github.com/user-attachments/assets/9fd967a0-cd96-4f5e-a588-001ce1223611" /> | <img width="309" height="88" alt="image" src="https://github.com/user-attachments/assets/65ac0d6b-6066-4aa6-bb05-583d99b2205a" /> | <img width="308" height="89" alt="image" src="https://github.com/user-attachments/assets/1f3a5caa-fffc-4832-921c-62540ff2fdd7" />
<img width="312" height="71" alt="image" src="https://github.com/user-attachments/assets/281cacf4-64c2-4020-b02f-f3eeb41843c6" /> | <img width="319" height="100" alt="image" src="https://github.com/user-attachments/assets/a26dbf58-bc88-418a-923b-34148d388044" /> | <img width="316" height="74" alt="image" src="https://github.com/user-attachments/assets/785a6c73-a9c3-40d2-9525-a86880d2e862" />
<img width="311" height="102" alt="image" src="https://github.com/user-attachments/assets/baca467e-9a36-41a1-bd16-7e686504f742" /> | <img width="317" height="122" alt="image" src="https://github.com/user-attachments/assets/127151d0-1861-4496-a9ac-d3f25e56fa8b" /> | <img width="314" height="107" alt="image" src="https://github.com/user-attachments/assets/5be2e0af-a279-43e4-a652-653643a3fd1b" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
