### PR TITLE
docs: Move to more outline icons

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -14,13 +14,13 @@
 					<NcActions>
 						<NcActionButton close-after-click @click="showModal = true">
 							<template #icon>
-								<IconCog />
+								<IconCogOutline />
 							</template>
 							App settings (close after click)
 						</NcActionButton>
 						<NcActionButton @click="showModal = true">
 							<template #icon>
-								<IconCog />
+								<IconCogOutline />
 							</template>
 							App settings (handle only click)
 						</NcActionButton>
@@ -38,7 +38,7 @@
 				<div class="navigation__footer">
 					<NcButton wide @click="showModal = true">
 						<template #icon>
-							<IconCog />
+							<IconCogOutline />
 						</template>
 						App settings
 					</NcButton>
@@ -56,12 +56,12 @@
 
 <script>
 	import IconCheck from 'vue-material-design-icons/Check'
-	import IconCog from 'vue-material-design-icons/Cog'
+	import IconCogOutline from 'vue-material-design-icons/CogOutline'
 
 	export default {
 		components: {
 			IconCheck,
-			IconCog,
+			IconCogOutline,
 		},
 		provide() {
 			return {

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -83,7 +83,7 @@ button will be automatically created.
 
 ```vue
 	<template>
-		<div id="app-navigation-vue"><!-- Just a wrapper necessary in the docs. Not needed when NcAppNavigation is correctly used as parent. -->
+		<div id="app-navigation-vue-action"><!-- Just a wrapper necessary in the docs. Not needed when NcAppNavigation is correctly used as parent. -->
 			<ul>
 				<NcAppNavigationItem name="Item with actions">
 					<template #icon>
@@ -142,7 +142,7 @@ Just nest the counter in a template within `<NcAppNavigationItem>` and add `#cou
 		<ul>
 			<NcAppNavigationItem name="Item with counter">
 				<template #icon>
-					<Folder :size="20" />
+					<IconFolderOutline :size="20" />
 				</template>
 				<template #counter>
 					<NcCounterBubble :count="90" />
@@ -151,11 +151,11 @@ Just nest the counter in a template within `<NcAppNavigationItem>` and add `#cou
 		</ul>
 	</template>
 	<script>
-	import Folder from 'vue-material-design-icons/Folder.vue'
+	import IconFolderOutline from 'vue-material-design-icons/FolderOutline.vue'
 
 	export default {
 		components: {
-			Folder,
+			IconFolderOutline,
 		},
 	}
 	</script>
@@ -163,15 +163,15 @@ Just nest the counter in a template within `<NcAppNavigationItem>` and add `#cou
 
 #### Element with children
 
-Wrap the children in a template with the `slot` property and use the prop `allowCollapse` to choose wether to allow or
+Wrap the children in a template with the `slot` property and use the prop `allowCollapse` to choose whether to allow or
 prevent the user from collapsing the items.
 
 ```vue
 	<template>
 		<ul>
-			<NcAppNavigationItem name="Item with children" :allowCollapse="true" :open="true">
+			<NcAppNavigationItem name="Item with children" :allowCollapse="true">
 				<template #icon>
-					<Folder :size="20" />
+					<IconFolderOutline :size="20" />
 				</template>
 				<template #counter>
 					<NcCounterBubble :count="90" />
@@ -205,14 +205,14 @@ prevent the user from collapsing the items.
 		</ul>
 	</template>
 	<script>
-	import Folder from 'vue-material-design-icons/Folder.vue'
+	import IconFolderOutline from 'vue-material-design-icons/FolderOutline.vue'
 	import Delete from 'vue-material-design-icons/Delete.vue'
 	import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 	import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 	export default {
 		components: {
-			Folder,
+			IconFolderOutline,
 			Delete,
 			OpenInNew,
 			Pencil,
@@ -236,17 +236,17 @@ the placeholder is the previous name of the element.
 			<NcAppNavigationItem name="Editable Item" :editable="true"
 				editPlaceholder="your_placeholder_here" @update:name="function(value){alert(value)}">
 				<template #icon>
-					<Folder :size="20" />
+					<IconFolderOutline :size="20" />
 				</template>
 			</NcAppNavigationItem>
 		</ul>
 	</template>
 	<script>
-	import Folder from 'vue-material-design-icons/Folder.vue'
+	import IconFolderOutline from 'vue-material-design-icons/FolderOutline.vue'
 
 	export default {
 		components: {
-			Folder,
+			IconFolderOutline,
 		},
 		methods: {
 			alert(msg) {

--- a/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
+++ b/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
@@ -16,24 +16,24 @@
 						<template #actions>
 							<NcActions aria-label="Filters">
 								<template #icon>
-									<IconFilter :size="20" />
+									<IconFilterOutline :size="20" />
 								</template>
 								<NcActionButton>
 									<template #icon>
-										<IconAccount :size="20" />
+										<IconAccountOutline :size="20" />
 									</template>
 									Filter by name
 								</NcActionButton>
 								<NcActionButton>
 									<template #icon>
-										<IconCalendarAccount :size="20" />
+										<IconCalendarAccountOutline :size="20" />
 									</template>
 									Filter by year
 								</NcActionButton>
 							</NcActions>
 							<NcButton aria-label="Search globally" variant="tertiary">
 								<template #icon>
-									<IconSearchGlobal :size="20" />
+									<IconSearchGlobalOutline :size="20" />
 								</template>
 							</NcButton>
 						</template>
@@ -42,12 +42,12 @@
 				<template #list>
 					<NcAppNavigationItem name="First navigation entry">
 						<template #icon>
-							<IconStar :size="20" />
+							<IconStarOutline :size="20" />
 						</template>
 					</NcAppNavigationItem>
 					<NcAppNavigationItem name="Second navigation entry">
 						<template #icon>
-							<IconStar :size="20" />
+							<IconStarOutline :size="20" />
 						</template>
 					</NcAppNavigationItem>
 				</template>
@@ -64,21 +64,21 @@
 	</div>
 </template>
 <script>
-import IconAccount from 'vue-material-design-icons/Account.vue'
-import IconCalendarAccount from 'vue-material-design-icons/CalendarAccount.vue'
-import IconFilter from 'vue-material-design-icons/Filter.vue'
-import IconSearchGlobal from 'vue-material-design-icons/CloudSearch.vue'
-import IconStar from 'vue-material-design-icons/Star.vue'
+import IconAccountOutline from 'vue-material-design-icons/AccountOutline.vue'
+import IconCalendarAccountOutline from 'vue-material-design-icons/CalendarAccountOutline.vue'
+import IconFilterOutline from 'vue-material-design-icons/FilterOutline.vue'
+import IconSearchGlobalOutline from 'vue-material-design-icons/CloudSearchOutline.vue'
+import IconStarOutline from 'vue-material-design-icons/StarOutline.vue'
 
 const exampleItem = ['Mary', 'Patricia', 'James', 'Michael']
 
 export default {
 	components: {
-		IconAccount,
-		IconCalendarAccount,
-		IconFilter,
-		IconSearchGlobal,
-		IconStar,
+		IconAccountOutline,
+		IconCalendarAccountOutline,
+		IconFilterOutline,
+		IconSearchGlobalOutline,
+		IconStarOutline,
 	},
 
 	data() {


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="691" height="738" alt="grafik" src="https://github.com/user-attachments/assets/7fec0592-36a1-40fa-89dd-dcaf03448667" /> | <img width="691" height="738" alt="grafik" src="https://github.com/user-attachments/assets/05342514-4ec7-4a33-a0f5-8fc3eb14fae0" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
