### PR TITLE
docs: Move more icons to outline

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -36,19 +36,19 @@ Using `v-show` directly will result in usability issues due to internal focus tr
 			@figure-click="figureClick">
 			<NcAppSidebarTab name="Search" id="search-tab">
 				<template #icon>
-					<Magnify :size="20" />
+					<IconMagnify :size="20" />
 				</template>
 				Search tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Settings" id="settings-tab">
 				<template #icon>
-					<Cog :size="20" />
+					<IconCogOutline :size="20" />
 				</template>
 				Settings tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Sharing" id="share-tab">
 				<template #icon>
-					<ShareVariant :size="20" />
+					<IconShareVariantOutline :size="20" />
 				</template>
 				Sharing tab content
 			</NcAppSidebarTab>
@@ -57,15 +57,15 @@ Using `v-show` directly will result in usability issues due to internal focus tr
 </template>
 
 <script>
-	import Magnify from 'vue-material-design-icons/Magnify.vue'
-	import Cog from 'vue-material-design-icons/Cog.vue'
-	import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
+	import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
+	import IconShareVariantOutline from 'vue-material-design-icons/ShareVariantOutline.vue'
 
 	export default {
 		components: {
-			Magnify,
-			Cog,
-			ShareVariant,
+			IconMagnify,
+			IconCogOutline,
+			IconShareVariantOutline,
 		},
 		provide() {
 			return {
@@ -133,19 +133,19 @@ Single tab is rendered without navigation, but it is possible to force it.
 			subname="last edited 3 weeks ago">
 			<NcAppSidebarTab v-if="showTabs[0]" name="Search" id="search-tab">
 				<template #icon>
-					<Magnify :size="20" />
+					<IconMagnify :size="20" />
 				</template>
 				Search tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab v-if="showTabs[1]" name="Settings" id="settings-tab">
 				<template #icon>
-					<Cog :size="20" />
+					<IconCogOutline :size="20" />
 				</template>
 				Settings
 			</NcAppSidebarTab>
 			<NcAppSidebarTab v-if="showTabs[2]" name="Sharing" id="share-tab">
 				<template #icon>
-					<ShareVariant :size="20" />
+					<IconShareVariantOutline :size="20" />
 				</template>
 				Sharing tab content
 			</NcAppSidebarTab>
@@ -154,15 +154,15 @@ Single tab is rendered without navigation, but it is possible to force it.
 </template>
 
 <script>
-	import Magnify from 'vue-material-design-icons/Magnify.vue'
-	import Cog from 'vue-material-design-icons/Cog.vue'
-	import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
+	import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
+	import IconShareVariantOutline from 'vue-material-design-icons/ShareVariantOutline.vue'
 
 	export default {
 		components: {
-			Magnify,
-			Cog,
-			ShareVariant,
+			IconMagnify,
+			IconCogOutline,
+			IconShareVariantOutline,
 		},
 		provide() {
 			return {
@@ -223,19 +223,19 @@ To customize the order of tabs, ``order`` prop can be used on child components.
 			v-model:active="active">
 			<NcAppSidebarTab name="Search" id="search-tab" :order="3">
 				<template #icon>
-					<Magnify :size="20" />
+					<IconMagnify :size="20" />
 				</template>
 				Search tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Settings" id="settings-tab" :order="2">
 				<template #icon>
-					<Cog :size="20" />
+					<IconCogOutline :size="20" />
 				</template>
 				Settings
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Sharing" id="share-tab" :order="1">
 				<template #icon>
-					<ShareVariant :size="20" />
+					<IconShareVariantOutline :size="20" />
 				</template>
 				Sharing tab content
 			</NcAppSidebarTab>
@@ -244,15 +244,15 @@ To customize the order of tabs, ``order`` prop can be used on child components.
 </template>
 
 <script>
-	import Magnify from 'vue-material-design-icons/Magnify.vue'
-	import Cog from 'vue-material-design-icons/Cog.vue'
-	import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
+	import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
+	import IconShareVariantOutline from 'vue-material-design-icons/ShareVariantOutline.vue'
 
 	export default {
 		components: {
-			Magnify,
-			Cog,
-			ShareVariant,
+			IconMagnify,
+			IconCogOutline,
+			IconShareVariantOutline,
 		},
 		provide() {
 			return {

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -23,16 +23,16 @@
 <template>
 	<NcAvatar>
 		<template #icon>
-			<AccountMultiple :size="20" />
+			<IconAccountMultipleOutline :size="20" />
 		</template>
 	</NcAvatar>
 </template>
 <script>
-import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+import IconAccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
 
 export default {
 	components: {
-		AccountMultiple,
+		IconAccountMultipleOutline,
 	},
 }
 </script>

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -40,7 +40,7 @@ It can be used with one or multiple actions.
 			:text
 			variant="tertiary-no-background">
 			<template v-if="style.indexOf('icon') !== -1" #icon>
-				<Video
+				<IconVideoOutline
 					:size="20" />
 			</template>
 		</NcButton>
@@ -51,7 +51,7 @@ It can be used with one or multiple actions.
 			:text
 			variant="tertiary">
 			<template v-if="style.indexOf('icon') !== -1" #icon>
-				<Video
+				<IconVideoOutline
 					:size="20" />
 			</template>
 		</NcButton>
@@ -61,7 +61,7 @@ It can be used with one or multiple actions.
 			:size
 			:text>
 			<template v-if="style.indexOf('icon') !== -1" #icon>
-				<Video
+				<IconVideoOutline
 					:size="20" />
 			</template>
 		</NcButton>
@@ -72,7 +72,7 @@ It can be used with one or multiple actions.
 			:text
 			variant="primary">
 			<template v-if="style.indexOf('icon') !== -1" #icon>
-				<Video
+				<IconVideo
 					:size="20" />
 			</template>
 		</NcButton>
@@ -87,7 +87,7 @@ It can be used with one or multiple actions.
 		:wide="true"
 		text="Example text">
 		<template #icon>
-			<Video
+			<IconVideoOutline
 				:size="20" />
 		</template>
 	</NcButton>
@@ -105,7 +105,7 @@ It can be used with one or multiple actions.
 			text="Example text"
 			variant="success">
 			<template #icon>
-				<Video
+				<IconVideoOutline
 					:size="20" />
 			</template>
 		</NcButton>
@@ -115,7 +115,7 @@ It can be used with one or multiple actions.
 			text="Example text"
 			variant="warning">
 			<template #icon>
-				<Video
+				<IconVideoOutline
 					:size="20" />
 			</template>
 		</NcButton>
@@ -125,7 +125,7 @@ It can be used with one or multiple actions.
 			text="Example text"
 			variant="error">
 			<template #icon>
-				<Video
+				<IconVideoOutline
 					:size="20" />
 			</template>
 		</NcButton>
@@ -135,11 +135,13 @@ It can be used with one or multiple actions.
 
 </template>
 <script>
-import Video from 'vue-material-design-icons/Video.vue'
+import IconVideo from 'vue-material-design-icons/Video.vue'
+import IconVideoOutline from 'vue-material-design-icons/VideoOutline.vue'
 
 export default {
 	components: {
-		Video,
+		IconVideo,
+		IconVideoOutline,
 	},
 	data() {
 		return {

--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -9,26 +9,26 @@
 <template>
 	<div style="display: flex; gap: 8px; flex-wrap: wrap;">
 		<NcChip text="Notes.txt" />
-		<NcChip text="Files" :icon-path="mdiFile" />
-		<NcChip text="Color" :icon-path="mdiPalette" variant="tertiary" />
+		<NcChip text="Files" :icon-path="mdiFileOutline" />
+		<NcChip text="Color" :icon-path="mdiPaletteOutline" variant="tertiary" />
 		<NcChip text="Current time" :icon-path="mdiClock" no-close variant="primary" />
 		<NcChip text="Canceled" :icon-path="mdiCancel" variant="error" no-close />
-		<NcChip text="Open" :icon-path="mdiCircle" variant="success" no-close />
+		<NcChip text="Open" :icon-path="mdiCircleOutline" variant="success" no-close />
 		<NcChip text="Due tomorrow" :icon-path="mdiAlertCircleOutline" variant="warning" no-close />
 	</div>
 </template>
 <script>
-import { mdiClock, mdiFile, mdiPalette, mdiCancel, mdiCircle, mdiAlertCircleOutline } from '@mdi/js'
+import { mdiClock, mdiFileOutline, mdiPaletteOutline, mdiCancel, mdiCircleOutline, mdiAlertCircleOutline } from '@mdi/js'
 
 export default {
 	setup() {
 		return {
 			mdiAlertCircleOutline,
 			mdiCancel,
-			mdiCircle,
+			mdiCircleOutline,
 			mdiClock,
-			mdiFile,
-			mdiPalette,
+			mdiFileOutline,
+			mdiPaletteOutline,
 		}
 	}
 }

--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -94,8 +94,8 @@ export default {
 const myItems = [
 	{
 		id: '1',
-		targetUrl: 'https://target.org',
-		avatarUrl: 'https://avatar.url/img.png',
+		targetUrl: 'https://example.tld',
+		avatarUrl: 'https://example.tld/img.png',
 		avatarUsername: 'Robert',
 		avatarIsNoUser: true,
 		overlayIconUrl: '/svg/core/actions/sound?color=000',
@@ -104,8 +104,8 @@ const myItems = [
 	},
 	{
 		id: '2',
-		targetUrl: 'https://other-target.org',
-		avatarUrl: 'https://other-avatar.url/img.png',
+		targetUrl: 'https://example.tld',
+		avatarUrl: 'https://example.tld/img.jpg',
 		overlayIconUrl: '/svg/core/actions/add?color=000',
 		mainText: 'Second item text',
 		subText: 'Second item subtext',

--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -30,12 +30,12 @@ Render raw SVG string icons.
 		</NcButton>
 		<NcButton aria-label="Send">
 			<template #icon>
-				<NcIconSvgWrapper :path="mdiSend" name="Send" />
+				<NcIconSvgWrapper :path="mdiSendOutline" name="Send" />
 			</template>
 		</NcButton>
 		<NcButton aria-label="Star">
 			<template #icon>
-				<NcIconSvgWrapper :path="mdiStar" name="Star" />
+				<NcIconSvgWrapper :path="mdiStarOutline" name="Star" />
 			</template>
 		</NcButton>
 	</div>
@@ -43,20 +43,20 @@ Render raw SVG string icons.
 
 <script>
 import closeSvg from '@mdi/svg/svg/close.svg?raw'
-import cogSvg from '@mdi/svg/svg/cog.svg?raw'
+import cogSvg from '@mdi/svg/svg/cog-outline.svg?raw'
 import plusSvg from '@mdi/svg/svg/plus.svg?raw'
-import { mdiSend } from '@mdi/js'
-import { mdiStar } from '@mdi/js'
+import { mdiSendOutline } from '@mdi/js'
+import { mdiStarOutline } from '@mdi/js'
 
 export default {
 	setup() {
-		// This icons are static data, so you do not need to put them into `data` which will make them reactive
+		// These icons are static data, so you do not need to put them into `data` which will make them reactive
 		return {
 			closeSvg,
 			cogSvg,
 			plusSvg,
-			mdiSend,
-			mdiStar,
+			mdiSendOutline,
+			mdiStarOutline,
 		}
 	},
 }
@@ -76,16 +76,16 @@ export default {
 ```vue
 <template>
 	<p>
-		This is my <NcIconSvgWrapper inline :path="mdiStar" /> Favorite
+		This is my <NcIconSvgWrapper inline :path="mdiStarOutline" /> Favorite
 	</p>
 </template>
 <script>
-import { mdiStar } from '@mdi/js'
+import { mdiStarOutline } from '@mdi/js'
 
 export default {
 	setup() {
 		return {
-			mdiStar,
+			mdiStarOutline,
 		}
 	},
 }

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -24,7 +24,7 @@
 			</template>
 			<template #indicator>
 				<!-- Color dot -->
-				<CheckboxBlankCircle :size="16" fill-color="#fff" />
+				<CheckboxBlankCircleOutline :size="16" fill-color="#fff" />
 			</template>
 			<template #actions>
 				<NcActionButton>
@@ -314,17 +314,17 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 			<template #extra-actions>
 				<NcButton variant="tertiary">
 					<template #icon>
-						<IconPencil :size="20" />
+						<IconPencilOutline :size="20" />
 					</template>
 				</NcButton>
 				<NcButton variant="tertiary">
 					<template #icon>
-						<IconCog :size="20" />
+						<IconCogOutline :size="20" />
 					</template>
 				</NcButton>
 			</template>
 			<template #actions-icon>
-				<IconNoteText :size="20" />
+				<IconNoteTextOutline :size="20" />
 			</template>
 			<template #actions>
 				<NcActionButton>
@@ -342,14 +342,20 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 </template>
 <script>
 	import IconCog from 'vue-material-design-icons/Cog.vue'
+	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
 	import IconNoteText from 'vue-material-design-icons/NoteText.vue'
+	import IconNoteTextOutline from 'vue-material-design-icons/NoteTextOutline.vue'
 	import IconPencil from 'vue-material-design-icons/Pencil.vue'
+	import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 
 	export default {
 		components: {
 			IconCog,
+			IconCogOutline,
 			IconNoteText,
+			IconNoteTextOutline,
 			IconPencil,
+			IconPencilOutline,
 		},
 	}
 </script>
@@ -368,14 +374,14 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 		<NcListItem compact
 			name="Name of the element">
 			<template #icon>
-				<IconNoteText :size="20" />
+				<IconNoteTextOutline :size="20" />
 			</template>
 		</NcListItem>
 		<NcListItem compact
 			name="Name of the element"
 			:counter-number="1">
 			<template #icon>
-				<IconNoteText :size="20" />
+				<IconNoteTextOutline :size="20" />
 			</template>
 			<template #subname>
 				This one is with subname
@@ -393,7 +399,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 			name="Name of the element"
 			:counter-number="3">
 			<template #icon>
-				<IconNoteText :size="20" />
+				<IconNoteTextOutline :size="20" />
 			</template>
 			<template #subname>
 				This one is with subname
@@ -412,7 +418,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 			:counter-number="4"
 			href="https://nextcloud.com">
 			<template #icon>
-				<IconNoteText :size="20" />
+				<IconNoteTextOutline :size="20" />
 			</template>
 			<template #subname>
 				This one is with an external link
@@ -422,10 +428,12 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 </template>
 <script>
 	import IconNoteText from 'vue-material-design-icons/NoteText.vue'
+	import IconNoteTextOutline from 'vue-material-design-icons/NoteTextOutline.vue'
 
 	export default {
 		components: {
 			IconNoteText,
+			IconNoteTextOutline,
 		},
 	}
 </script>

--- a/src/components/NcListItemIcon/NcListItemIcon.vue
+++ b/src/components/NcListItemIcon/NcListItemIcon.vue
@@ -16,15 +16,15 @@ It might be used for list rendering or within the multiselect for example
 ```vue
 	<template>
 		<NcListItemIcon name="User 1" :avatar-size="44">
-			<Account :size="20" />
+			<IconAccountOutline :size="20" />
 		</NcListItemIcon>
 	</template>
 	<script>
-	import Account from 'vue-material-design-icons/Account.vue'
+	import IconAccountOutline from 'vue-material-design-icons/AccountOutline.vue'
 
 	export default {
 		components: {
-			Account,
+			IconAccountOutline,
 		},
 	}
 	</script>
@@ -34,15 +34,15 @@ It might be used for list rendering or within the multiselect for example
 ```vue
 	<template>
 		<NcListItemIcon name="Group 1" subname="13 members" :is-no-user="true">
-			<AccountMultiple :size="20" />
+			<IconAccountMultipleOutline :size="20" />
 		</NcListItemIcon>
 	</template>
 	<script>
-	import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+	import IconAccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
 
 	export default {
 		components: {
-			AccountMultiple,
+			IconAccountMultipleOutline,
 		},
 	}
 	</script>
@@ -54,15 +54,15 @@ It might be used for list rendering or within the multiselect for example
 		<NcListItemIcon name="Test user 1" subname="callmetest@domain.com" search="test" />
 		<NcListItemIcon name="Testing admin" subname="testme@example.com" search="test" />
 		<NcListItemIcon name="Test group 2" subname="loremipsum@domain.com" :is-no-user="true" search="test">
-			<AccountMultiple :size="20" />
+			<IconAccountMultipleOutline :size="20" />
 		</NcListItemIcon>
 	</template>
 	<script>
-	import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+	import IconAccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
 
 	export default {
 		components: {
-			AccountMultiple,
+			IconAccountMultipleOutline,
 		},
 	}
 	</script>
@@ -75,13 +75,13 @@ It might be used for list rendering or within the multiselect for example
 			<NcActions>
 				<NcActionButton @click="alert('Edit')">
 					<template #icon>
-						<Pencil :size="20" />
+						<IconPencilOutline :size="20" />
 					</template>
 					Edit
 				</NcActionButton>
 				<NcActionButton @click="alert('Delete')">
 					<template #icon>
-						<Delete :size="20" />
+						<IconDeleteOutline :size="20" />
 					</template>
 					Delete
 				</NcActionButton>
@@ -89,13 +89,13 @@ It might be used for list rendering or within the multiselect for example
 		</NcListItemIcon>
 	</template>
 	<script>
-	import Delete from 'vue-material-design-icons/Delete.vue'
-	import Pencil from 'vue-material-design-icons/Pencil.vue'
+	import IconDeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
+	import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
 
 	export default {
 		components: {
-			Delete,
-			Pencil,
+			IconDeleteOutline,
+			IconPencilOutline,
 		},
 	}
 	</script>

--- a/src/components/NcNoteCard/NcNoteCard.vue
+++ b/src/components/NcNoteCard/NcNoteCard.vue
@@ -34,7 +34,7 @@ available in four versions:
 		<h4>Custom icon</h4>
 		<NcNoteCard type="warning" text="Custom icon usage">
 			<template #icon>
-				<Cog :size="20"/>
+				<IconCogOutline :size="20"/>
 			</template>
 		</NcNoteCard>
 
@@ -46,11 +46,11 @@ available in four versions:
 </template>
 
 <script>
-	import Cog from 'vue-material-design-icons/Cog.vue'
+	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
 
 	export default {
 		components: {
-			Cog,
+			IconCogOutline,
 		},
 	}
 </script>

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -37,7 +37,7 @@ General purpose password field component.
 			placeholder="Min. 12 characters"
 			helper-text="Password is secure">
 			<template #icon>
-				<Lock :size="20" />
+				<IconLockOutline :size="20" />
 			</template>
 		</NcPasswordField>
 
@@ -51,7 +51,7 @@ General purpose password field component.
 	</div>
 </template>
 <script>
-import Lock from 'vue-material-design-icons/Lock'
+import IconLockOutline from 'vue-material-design-icons/LockOutline'
 
 export default {
 	data() {
@@ -66,7 +66,7 @@ export default {
 	},
 
 	components: {
-		Lock,
+		IconLockOutline,
 	},
 }
 </script>

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -34,7 +34,7 @@ and `minlength`.
 			:show-trailing-button="text4 !== ''"
 			@trailing-button-click="clearText">
 			<template #icon>
-				<Lock :size="20" />
+				<IconLockOutline :size="20" />
 			</template>
 		</NcTextField>
 		<NcTextField v-model="text2"
@@ -73,7 +73,7 @@ and `minlength`.
 </template>
 <script>
 import Magnify from 'vue-material-design-icons/Magnify'
-import Lock from 'vue-material-design-icons/Lock'
+import IconLockOutline from 'vue-material-design-icons/LockOutline'
 import Close from 'vue-material-design-icons/Close'
 
 export default {
@@ -89,7 +89,7 @@ export default {
 
 	components: {
 		Magnify,
-		Lock,
+		IconLockOutline,
 		Close,
 	},
 


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="365" height="195" alt="Bildschirmfoto vom 2025-11-14 14-23-54" src="https://github.com/user-attachments/assets/a68bb8d3-635d-4b4c-a8a3-7083de1ce6f7" /> | <img width="365" height="195" alt="Bildschirmfoto vom 2025-11-14 14-23-45" src="https://github.com/user-attachments/assets/e1861614-547a-4654-9353-dd265ffe6354" />
<img width="525" height="288" alt="Bildschirmfoto vom 2025-11-14 14-25-04" src="https://github.com/user-attachments/assets/7b58234c-1986-41f4-856a-277608b20be1" /> | <img width="525" height="288" alt="Bildschirmfoto vom 2025-11-14 14-25-48" src="https://github.com/user-attachments/assets/5179ed83-d21d-47f4-bb3c-6bde7a689d50" />
<img width="1081" height="233" alt="Bildschirmfoto vom 2025-11-14 14-29-36" src="https://github.com/user-attachments/assets/f3b7a4cd-1ab4-4a32-b714-c99917c4d01f" /> | <img width="1081" height="233" alt="Bildschirmfoto vom 2025-11-14 14-29-26" src="https://github.com/user-attachments/assets/77344b94-95cc-467b-8dec-0244bc42dbf9" />
<img width="1090" height="621" alt="Bildschirmfoto vom 2025-11-14 14-31-00" src="https://github.com/user-attachments/assets/873a4fc8-98e2-4dc0-8252-795646ae3385" /> | <img width="1090" height="621" alt="Bildschirmfoto vom 2025-11-14 14-31-49" src="https://github.com/user-attachments/assets/7c8adb51-7e1f-41e2-954e-632e8cece8dc" />
<img width="583" height="235" alt="Bildschirmfoto vom 2025-11-14 14-32-22" src="https://github.com/user-attachments/assets/5be87eb3-c887-4d6e-9ff4-bce935fd6d65" /> | <img width="583" height="235" alt="Bildschirmfoto vom 2025-11-14 14-32-54" src="https://github.com/user-attachments/assets/7e0c974b-50b0-4036-980f-e0fbb2c6690e" />
<img width="1197" height="976" alt="Bildschirmfoto vom 2025-11-14 14-34-38" src="https://github.com/user-attachments/assets/17b13b93-41e1-4c18-a7db-f8e7faa70beb" /> | <img width="1197" height="976" alt="Bildschirmfoto vom 2025-11-14 14-37-02" src="https://github.com/user-attachments/assets/2e49d5d5-7f4b-492e-98da-a13cba0cf5dc" />
<img width="1191" height="1143" alt="Bildschirmfoto vom 2025-11-14 14-38-25" src="https://github.com/user-attachments/assets/0085e857-883a-4509-a52a-536eb338a930" /> | <img width="1191" height="1143" alt="Bildschirmfoto vom 2025-11-14 14-38-33" src="https://github.com/user-attachments/assets/2d2a463b-563e-4d62-b7bc-5fb3b3896759" />
<img width="328" height="152" alt="Bildschirmfoto vom 2025-11-14 14-40-13" src="https://github.com/user-attachments/assets/e299ac0f-bdd7-4025-9cfc-7df9e75f62aa" /> | <img width="327" height="187" alt="Bildschirmfoto vom 2025-11-14 14-40-25" src="https://github.com/user-attachments/assets/67e9d86b-9dc5-4119-a6f3-bdc46d87f056" />
<img width="1083" height="427" alt="Bildschirmfoto vom 2025-11-14 14-45-15" src="https://github.com/user-attachments/assets/2652de65-7420-44ae-a03f-47359a975ec0" /> | <img width="1083" height="427" alt="Bildschirmfoto vom 2025-11-14 14-47-45" src="https://github.com/user-attachments/assets/1204b273-4cdf-4cc1-a35b-db1ef3d8e85a" />
<img width="696" height="575" alt="Bildschirmfoto vom 2025-11-14 14-48-30" src="https://github.com/user-attachments/assets/b4c0d799-7cf7-46ac-b486-42e64ec3173c" /> | <img width="696" height="575" alt="Bildschirmfoto vom 2025-11-14 14-49-57" src="https://github.com/user-attachments/assets/65cae2dd-5d1f-4fb5-897f-b819db83e2a5" />
