### PR TITLE
fix(NcFormBox): add nested NcFormBox row support

### DIFF
--- a/src/components/NcFormBox/useNcFormBox.ts
+++ b/src/components/NcFormBox/useNcFormBox.ts
@@ -9,9 +9,11 @@ import { inject } from 'vue'
 
 export const NC_FORM_BOX_CONTEXT_KEY: InjectionKey<{
 	isInFormBox: false
+	isInFormBoxRow: false
 	formBoxItemClass: undefined
 } | {
 	isInFormBox: true
+	isInFormBoxRow: boolean
 	formBoxItemClass: string
 }> = Symbol.for('NcFormBox:context')
 
@@ -22,6 +24,7 @@ export const NC_FORM_BOX_CONTEXT_KEY: InjectionKey<{
 export function useNcFormBox() {
 	return inject(NC_FORM_BOX_CONTEXT_KEY, {
 		isInFormBox: false,
+		isInFormBoxRow: false,
 		formBoxItemClass: undefined,
 	})
 }


### PR DESCRIPTION
### ☑️ Resolves

- Based on https://github.com/nextcloud-libraries/nextcloud-vue/pull/7886
- Use case - split buttons
  - We do not have components requiring this feature at the moment
  - But there were some individual cases

### 🖼️ Screenshots

<img width="816" height="124" alt="image" src="https://github.com/user-attachments/assets/020bee0c-ef49-498a-96cf-a66700737a27" />

<img width="613" height="122" alt="image" src="https://github.com/user-attachments/assets/777efdd4-79d8-4584-a27d-a5b7c1430b4f" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
