### PR TITLE
fix(NcActionCheckbox): margin around the checkbox

### DIFF
--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -206,6 +206,7 @@ export default {
 		&::before {
 			margin-block: 0 !important;
 			margin-inline: calc((var(--default-clickable-area) - 14px) / 2) !important;
+			margin: 9px !important;
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

- Ref https://github.com/nextcloud/mail/issues/11328

### 🖼️ Screenshots

<img width="281" height="181" alt="Screenshot from 2025-11-19 16-59-49" src="https://github.com/user-attachments/assets/ff19f1b9-918d-48fe-bb4b-92ad2736e6be" />
<img width="281" height="181" alt="Screenshot from 2025-11-19 16-59-43" src="https://github.com/user-attachments/assets/dc08a284-f16e-473c-948e-f6dd54def48a" />


### 🚧 Tasks

- [ ] Some margin from inputs.scss is applied that creates that small space between the label and the checkbox. This fixes it. I cannot think of any better solution

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
