### PR TITLE
fix(NcAvatar): do no request avatar image if icon slot provided

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -713,12 +713,12 @@ export default {
 			if (!this.preloadedUserStatus) {
 				this.fetchUserStatus(this.user)
 			} else {
-				this.userStatus.status = this.preloadedUserStatus.status || ''
-				this.userStatus.message = this.preloadedUserStatus.message || ''
-				this.userStatus.icon = this.preloadedUserStatus.icon || ''
-				this.hasStatus = this.preloadedUserStatus.status !== null
+				this.setUserStatus(this.preloadedUserStatus)
 			}
 			subscribe('user_status:status.updated', this.handleUserStatusUpdated)
+		} else if (!this.hideStatus && this.preloadedUserStatus) {
+			// Always set preloaded status if provided
+			this.setUserStatus(this.preloadedUserStatus)
 		}
 	},
 

--- a/src/mixins/userStatus.js
+++ b/src/mixins/userStatus.js
@@ -44,15 +44,7 @@ export default {
 
 			try {
 				const { data } = await axios.get(generateOcsUrl('apps/user_status/api/v1/statuses/{userId}', { userId }))
-				const {
-					status,
-					message,
-					icon,
-				} = data.ocs.data
-				this.userStatus.status = status
-				this.userStatus.message = message || ''
-				this.userStatus.icon = icon || ''
-				this.hasStatus = true
+				this.setUserStatus(data.ocs.data)
 			} catch (e) {
 				if (e.response.status === 404 && e.response.data.ocs?.data?.length === 0) {
 					// User just has no status set, so don't log it
@@ -60,6 +52,20 @@ export default {
 				}
 				logger.error('Failed to fetch user status', { error: e })
 			}
+		},
+
+		/**
+		 * Sets the user status
+		 *
+		 * @param {string} status user's status
+		 * @param {string} message user's message
+		 * @param {string} icon user's icon
+		 */
+		setUserStatus({ status, message, icon }) {
+			this.userStatus.status = status || ''
+			this.userStatus.message = message || ''
+			this.userStatus.icon = icon || ''
+			this.hasStatus = !!status
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

- Fix component appearance
  - 'fake' preloaded user status can be provided, but it should not be limited to 'users' only, (e.g. there can be federated users and guests having it in the future)
  - avatar should not be requested by url from server, if `<slot #icon>` is provided by app and therefore won't be ever shown

### 🖼️ Screenshots

<img width="99" height="37" alt="image" src="https://github.com/user-attachments/assets/ccef46e2-9d10-4af5-a05e-1bd4d6df0cc4" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
