### PR TITLE
chore: prepare v9.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v9.2.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.1.0) (2025-11-07)
+## [v9.3.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.3.0) (2025-11-20)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.2.0...v9.3.0)
+
+### 🚀 Enhancements
+* feat(NcAppSettingsDialog): add version on the bottom and `noVersion` prop to disable it [\#7837](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7837) \([ShGKme](https://github.com/ShGKme)\)
+* fix(NcActions): introduce 'size' prop [\#7847](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7847) \([Antreesy](https://github.com/Antreesy)\)
+* feat(NcRichText): add 'Copy to clipboard' button for code blocks [\#7841](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7841) \([Antreesy](https://github.com/Antreesy)\)
+
+### 🐛 Fixed bugs
+* fix(NcPasswordField): respect `checkPasswordStrength` for input validation [\#7845](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7845) \([Antreesy](https://github.com/Antreesy)\)
+* fix(NcTextField): adjust helper text icon [\#7856](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7856) \([ShGKme](https://github.com/ShGKme)\)
+* fix(NcFormBox): use default text color in items [\#7854](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7854) \([ShGKme](https://github.com/ShGKme)\)
+* fix(NcAvatar): do no request avatar image if icon slot provided [\#7891](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7891) \([Antreesy](https://github.com/Antreesy)\)
+
+### Other Changes
+* ci(dependabot): Use auto merge instead of deprecated option [\#7835](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7835) \([nickvergessen](https://github.com/nickvergessen)\)
+* docs: Update icons to outline style [\#7860](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7860) \([nickvergessen](https://github.com/nickvergessen)\) [\#7862](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7862) \([nickvergessen](https://github.com/nickvergessen)\)
+* fix(NcActions): handle expensive height computation by popover library [\#7778](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7778) \([Antreesy](https://github.com/Antreesy)\)
+* chore: refactor deprecated :deep selector [\#7875](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7875) \([ShGKme](https://github.com/ShGKme)\)
+
+## [v9.2.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.2.0) (2025-11-07)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.1.0...v9.2.0)
 
 ### 📝 Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v9.3.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.3.0) (2025-11-20)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.2.0...v9.3.0)

## What's Changed
### 🚀 Enhancements
* feat(NcAppSettingsDialog): add version on the bottom and `noVersion` prop to disable it by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7837
* fix(NcActions): introduce 'size' prop by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7847
* feat(NcRichText): add 'Copy to clipboard' button for code blocks by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7841
### 🐛 Fixed bugs
* fix(NcPasswordField): respect `checkPasswordStrength` for input validation by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7845
* fix(NcTextField): helper text icon is too large by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7856
* fix(NcFormBox): use default text color in items by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7854
* fix(NcAvatar): do no request avatar image if icon slot provided by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7891
### Other Changes
* ci(dependabot): Use auto merge instead of deprecated option by @nickvergessen in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7835
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7840
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7858
* docs: Move to more outline icons by @nickvergessen in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7860
* docs: Move more icons to outline by @nickvergessen in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7862
* fix(NcActions): handle expensive height computation by popover library by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7778
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7867
* chore: refactor deprecated :deep selector by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7875
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7876
* chore(package): npm >=11.3.0 <=11.6.2 by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/7895


**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.2.0...v9.3.0