### PR TITLE
chore(package): npm >=11.3.0 <=11.6.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
 
 [build.environment]
 	NODE_VERSION = "24"
-	NPM_VERSION = "11"
+	NPM_VERSION = "11.6.2"

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "packageManager": [
       {
         "name": "npm",
-        "version": "^11.3.0",
+        "version": ">=11.3.0 <=11.6.2",
         "onFail": "error"
       }
     ],


### PR DESCRIPTION
### ☑️ Resolves

- Ref: https://github.com/npm/cli/issues/8757
- CI is failing with

```
0 verbose cli /home/shgk/.volta/tools/image/node/24.11.1/bin/node /home/shgk/.volta/tools/image/npm/11.6.3/bin/npm-cli.js
1 info using npm@11.6.3
2 info using node@v24.11.1
3 silly config load:file:/home/shgk/.volta/tools/image/npm/11.6.3/npmrc
4 silly config load:file:/home/shgk/nextcloud/nextcloud-vue/.npmrc
5 silly config load:file:/home/shgk/.npmrc
6 silly config load:file:/home/shgk/.volta/tools/image/node/24.11.1/etc/npmrc
7 verbose title npm ci
8 verbose argv "ci"
9 verbose logfile logs-max:10 dir:/home/shgk/.npm/_logs/2025-11-20T10_57_24_409Z-
10 verbose logfile /home/shgk/.npm/_logs/2025-11-20T10_57_24_409Z-debug-0.log
11 silly logfile start cleaning logs, removing 1 files
12 silly logfile done cleaning log files
13 silly packumentCache heap:4496293888 maxSize:1124073472 maxEntrySize:562036736
14 silly Conflicting override sets <ref *1> OverrideSet {
14 silly Conflicting override sets   parent: undefined,
14 silly Conflicting override sets   children: Map(2) {
14 silly Conflicting override sets     '@playwright/experimental-ct-core' => OverrideSet {
14 silly Conflicting override sets       parent: [Circular *1],
14 silly Conflicting override sets       children: [Map],
14 silly Conflicting override sets       name: '@playwright/experimental-ct-core',
14 silly Conflicting override sets       key: '@playwright/experimental-ct-core',
14 silly Conflicting override sets       keySpec: '*',
14 silly Conflicting override sets       value: '*'
14 silly Conflicting override sets     },
14 silly Conflicting override sets     'mdast-util-gfm' => OverrideSet {
14 silly Conflicting override sets       parent: [Circular *1],
14 silly Conflicting override sets       children: [Map],
14 silly Conflicting override sets       name: 'mdast-util-gfm',
14 silly Conflicting override sets       key: 'mdast-util-gfm',
14 silly Conflicting override sets       keySpec: '*',
14 silly Conflicting override sets       value: '*'
14 silly Conflicting override sets     }
14 silly Conflicting override sets   }
14 silly Conflicting override sets } undefined
15 verbose stack TypeError: Cannot read properties of undefined (reading 'ruleset')
15 verbose stack     at OverrideSet.haveConflictingRules (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/@npmcli/arborist/lib/override-set.js:220:32)
15 verbose stack     at OverrideSet.doOverrideSetsConflict (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/@npmcli/arborist/lib/override-set.js:214:17)
15 verbose stack     at get error (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/@npmcli/arborist/lib/edge.js:278:74)
15 verbose stack     at get valid (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/@npmcli/arborist/lib/edge.js:251:18)
15 verbose stack     at visit (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:342:71)
15 verbose stack     at visitNode (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/treeverse/lib/depth-descent.js:58:25)
15 verbose stack     at next (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/treeverse/lib/depth-descent.js:44:19)
15 verbose stack     at depth (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/treeverse/lib/depth-descent.js:83:10)
15 verbose stack     at depth (/home/shgk/.volta/tools/image/npm/11.6.3/node_modules/treeverse/lib/depth.js:27:12)
15 verbose stack     at /home/shgk/.volta/tools/image/npm/11.6.3/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:330:9
16 error Cannot read properties of undefined (reading 'ruleset')
17 silly unfinished npm timer idealTree:init 1763636245159
18 verbose cwd /home/shgk/nextcloud/nextcloud-vue
19 verbose os Linux 6.12.11-200.fc41.x86_64
20 verbose node v24.11.1
21 verbose npm  v11.6.3
22 verbose exit 1
23 verbose code 1
24 error A complete log of this run can be found in: /home/shgk/.npm/_logs/2025-11-20T10_57_24_409Z-debug-0.log
```
