### PR TITLE
revert: chore(package): npm=11.6.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
 
 [build.environment]
 	NODE_VERSION = "24"
-	NPM_VERSION = "11.6.2"
+	NPM_VERSION = "11"

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "packageManager": [
       {
         "name": "npm",
-        "version": ">=11.3.0 <=11.6.2",
+        "version": "^11.3.0",
         "onFail": "error"
       }
     ],


### PR DESCRIPTION
### ☑️ Resolves

- Reverts: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7895/
- Not needed after npm 11.6.4 release

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
