### PR TITLE
fix(l10n): Fix spelling of "time zone"

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -427,7 +427,7 @@ msgstr ""
 msgid "Search emoji"
 msgstr ""
 
-msgid "Search for timezone"
+msgid "Search for time zone"
 msgstr ""
 
 msgid "Search results"
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Time picker"
 msgstr ""
 
-msgid "Timezone"
+msgid "Time zone"
 msgstr ""
 
 msgid "Toggle overlay"

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -656,7 +656,7 @@ function cancelSelection() {
 					v-model="timezoneId"
 					class="vue-date-time-picker__timezone"
 					:append-to-body="false"
-					:input-label="t('Timezone')" />
+					:input-label="t('Time zone')" />
 			</template>
 		</VueDatePicker>
 		<Teleport to="body" :disabled="!appendToBody">

--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -100,7 +100,7 @@ function filterBy(option: ITimezone, label: string, search: string): boolean {
 <template>
 	<NcSelect
 		v-model="modelValue"
-		:aria-label-combobox="t('Search for timezone')"
+		:aria-label-combobox="t('Search for time zone')"
 		:clearable="false"
 		:filter-by
 		:multiple="false"


### PR DESCRIPTION
This was spelled inconsistently throughout the repo. I believe this one is the correct spelling.