### PR TITLE
fix(NcModal): scoped styles with teleport

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -16,6 +16,7 @@ import NcActions from '../NcActions/NcActions.vue'
 import NcButton from '../NcButton/NcButton.vue'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import { useHotKey } from '../../composables/index.ts'
+import { useScopeIdAttrs } from '../../composables/useScopeIdAttrs.ts'
 import { t } from '../../l10n.ts'
 import { createElementId } from '../../utils/createElementId.ts'
 import { getTrapStack } from '../../utils/focusTrap.ts'
@@ -187,6 +188,8 @@ defineSlots<{
 	 */
 	default?: Slot
 }>()
+
+const scopeIdAttrs = useScopeIdAttrs()
 
 const modalId = createElementId()
 const maskElement = useTemplateRef('mask')
@@ -401,7 +404,7 @@ function clearFocusTrap() {
 			@before-leave="clearFocusTrap">
 			<div
 				v-show="showModal"
-				v-bind="$attrs"
+				v-bind="{ ...$attrs, ...scopeIdAttrs }"
 				ref="mask"
 				class="modal-mask"
 				:class="{

--- a/src/composables/useScopeIdAttrs.ts
+++ b/src/composables/useScopeIdAttrs.ts
@@ -1,0 +1,82 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ComponentInternalInstance } from 'vue'
+
+import { getCurrentInstance, warn } from 'vue'
+
+/**
+ * Get the parent instance of the instance only if the instance is the root node of the parent
+ * - Parent > Child - same root node
+ * - Parent > div > Child - different root node
+ * - Parent > WrapperWithSlot > Child - different root node
+ *
+ * @param instance - Current instance (internal)
+ */
+function getSameNodeParent(instance: ComponentInternalInstance): ComponentInternalInstance | null {
+	if (!instance.parent) {
+		return null
+	}
+
+	if ('vapor' in instance || 'vapor' in instance.parent) {
+		warn('Vapor instances are not supported in useScopeIdAttrs :(')
+		return null
+	}
+
+	if (instance.parent.subTree !== instance.vnode) {
+		return null
+	}
+
+	return instance.parent
+}
+
+/**
+ * Get all ancestor instances of the instance that are on the same root node
+ *
+ * @param instance - Current instance (internal)
+ */
+function getSameNodeAncestors(instance: ComponentInternalInstance): ComponentInternalInstance[] {
+	const ancestors: ComponentInternalInstance[] = [instance]
+	let parent = getSameNodeParent(instance)
+	while (parent) {
+		ancestors.push(parent)
+		parent = getSameNodeParent(parent)
+	}
+	return ancestors
+}
+
+/**
+ * Get a binding object for all data-v-scopeid attributes that are supposed to be on the root node.
+ * It allows to have scoped styles from parents in edge cases not covered by Vue:
+ * - Teleport on the root
+ * - Fragments
+ *
+ * @todo Do we need to support slotScopeIds for `:slotted()`?
+ *
+ * @example
+ * ```ts
+ * <script setup>
+ * import { useScopeIdAttrs } from './useScopeIdAttrs.ts'
+ * const scopeIdAttrs = useScopeIdAttrs()
+ * </script>
+ * <template>
+ *   <teleport to="body">
+ *     <div v-bind="scopeIdAttrs" />
+ *   </teleport>
+ * </template>
+ * ```
+ */
+export function useScopeIdAttrs() {
+	const instance = getCurrentInstance()
+
+	if (!instance) {
+		throw new Error('useScopeId must be called within a setup context')
+	}
+
+	const sameNodeAncestors = getSameNodeAncestors(instance)
+	const scopeIds = sameNodeAncestors.map((instance) => instance.vnode.scopeId).filter(Boolean)
+	const scopeIdAttrs = Object.fromEntries(scopeIds.map((scopeId) => [scopeId, '']))
+	return scopeIdAttrs
+}


### PR DESCRIPTION
### ☑️ Resolves

- Regression from: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7514
- Ref: https://github.com/vuejs/core/issues/2047
- Ref: https://github.com/vuejs/core/issues/2669
- Custom styles with scoped styles on `NcModal` are broken when relying on the root class
- `NcDialog` lost some styles

I don't know how to properly solve this problem. This is the solution I came up with, but it seems to work.

- Alternatives:
  - Revert migration to `<teleport>`
  - Introduce a hidden breaking change (only breaks custom styles)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="495" height="312" alt="image" src="https://github.com/user-attachments/assets/41660cc4-2ada-461d-94b8-545011265fce" /> | <img width="496" height="313" alt="image" src="https://github.com/user-attachments/assets/9ea79173-7a0f-4100-9364-8dd5d7d39309" />
<img width="923" height="460" alt="image" src="https://github.com/user-attachments/assets/6b7d72c7-e6fd-4975-b820-9d1861fe88c2" /> | <img width="915" height="458" alt="image" src="https://github.com/user-attachments/assets/ed811b72-e868-4eda-aa47-cd89ef6bdad8" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
