### PR TITLE
fix(NcActionInput): use internal label of NcDateTimePickerNative

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -167,6 +167,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:type="datePickerType"
 							:input-class="['mx-input', { focusable: isFocusable }]"
 							class="action-input__datetimepicker"
+							append-to-body
 							v-bind="$attrs"
 							@update:model-value="onUpdateModelValue" />
 

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -660,7 +660,7 @@ function cancelSelection() {
 			</template>
 		</VueDatePicker>
 		<Teleport to="body" :disabled="!appendToBody">
-			<div ref="target" class="vue-date-time-picker__wrapper" />
+			<div ref="target" class="vue-date-time-picker__wrapper vue-date-time-picker__wrapper--teleport" />
 		</Teleport>
 	</div>
 </template>
@@ -709,6 +709,11 @@ function cancelSelection() {
 	// plain @import does not work as this will scope all styles imported.
 	:deep() {
 		@include meta.load-css('@vuepic/vue-datepicker/dist/main.css');
+	}
+
+	// When rendered as part of NcActionInput, should be lifted above the NcPopover (99999 < 100000)
+	&.vue-date-time-picker__wrapper--teleport :deep(.dp--menu-wrapper) {
+		z-index: 100001;
 	}
 
 	.vue-date-time-picker--clearable :deep(.dp__input) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix usage of NcActionInput with date/time types

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="423" height="139" alt="image" src="https://github.com/user-attachments/assets/d75024fa-3642-4e4a-8b86-ac627df71483" /> | <img width="430" height="147" alt="image" src="https://github.com/user-attachments/assets/0f8590ea-f018-4f1d-b928-5e7d41732f54" />
<img width="444" height="547" alt="image" src="https://github.com/user-attachments/assets/15ca9310-a836-4546-b1ec-f96c2e8270cb" /> | <img width="438" height="565" alt="image" src="https://github.com/user-attachments/assets/7748749b-cf5b-4c6f-9675-04c1550da166" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
