### PR TITLE
fix(useHotKey): do not prevent hotkeys on hidden modal/dialog

### DIFF
--- a/src/composables/useHotKey/index.ts
+++ b/src/composables/useHotKey/index.ts
@@ -72,8 +72,11 @@ function shouldIgnoreEvent(event: KeyboardEvent, options: UseHotKeyOptions): boo
 		return false
 	}
 
-	/** Abort if any modal/dialog opened */
-	return document.getElementsByClassName('modal-mask').length !== 0
+	/** Abort if any modal/dialog is opened AND visible */
+	return Array.prototype.filter.call(
+		document.getElementsByClassName('modal-mask'),
+		(el) => el.checkVisibility(),
+	).length > 0
 }
 
 type KeyboardEventHandler = (event: KeyboardEvent) => void

--- a/tests/unit/composables/useHotKey.spec.js
+++ b/tests/unit/composables/useHotKey.spec.js
@@ -40,16 +40,31 @@ describe('useHotKey', () => {
 		expect(mockCallback).not.toHaveBeenCalled()
 	})
 
-	it('should not invoke callback by default, when a modal is shown', () => {
+	it('should not invoke callback by default, when a modal is shown', async () => {
 		const modal = document.createElement('div')
 		modal.className = 'modal-mask'
 		document.body.appendChild(modal)
+		modal.checkVisibility = () => true
 
 		const stop = useHotKey(true, mockCallback)
 		triggerKeyDown({ key: 'a', code: 'KeyA' })
 		stop()
 
 		expect(mockCallback).not.toHaveBeenCalled()
+	})
+
+	it('should invoke callback by default, when a modal present but hidden', async () => {
+		const modal = document.createElement('div')
+		modal.className = 'modal-mask'
+		modal.style.display = 'none'
+		document.body.appendChild(modal)
+		modal.checkVisibility = () => false
+
+		const stop = useHotKey(true, mockCallback)
+		triggerKeyDown({ key: 'a', code: 'KeyA' })
+		stop()
+
+		expect(mockCallback).toHaveBeenCalled()
 	})
 
 	it('should invoke callback if modals are allowed, when a modal is shown', () => {


### PR DESCRIPTION
Found working on Server upgrade. If the viewer is idling waiting to be shown, the element is still present in the dom.
We need to ensure it's also really shown.


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
