### PR TITLE
[stable8] fix(NcPopover): Don't warn on hidden button elements

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -287,15 +287,14 @@ export default {
 	watch: {
 		shown(value) {
 			this.internalShown = value
+			if (this.internalShown) {
+				this.checkTriggerA11y()
+			}
 		},
 
 		internalShown(value) {
 			this.$emit('update:shown', value)
 		},
-	},
-
-	mounted() {
-		this.checkTriggerA11y()
 	},
 
 	beforeDestroy() {


### PR DESCRIPTION
`tabbable(<element>)` doesn't return elements that are hidden. This makes the a11y test warn if the trigger element is hidden.

In Nextcloud Text the menubar gets initialized with `visibility: hidden`.

No need to forward-patch this to `main` as `tabbable` is not used in NcPopover there.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
