### PR TITLE
fix(NcActions): migrate to custom icons in Checkbox and Radio actions

### DIFF
--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -8,43 +8,48 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 
 ```vue
 	<NcActions>
-		<NcActionCheckbox @change="alert('(un)checked !')">First choice</NcActionCheckbox>
-		<NcActionCheckbox value="second" @change="alert('(un)checked !')">Second choice</NcActionCheckbox>
-		<NcActionCheckbox :model-value="true" @change="alert('(un)checked !')">Third choice (checked)</NcActionCheckbox>
-		<NcActionCheckbox :disabled="true" @change="alert('(un)checked !')">Second choice (disabled)</NcActionCheckbox>
+		<NcActionCheckbox @change="console.log('(un)checked !')">First choice</NcActionCheckbox>
+		<NcActionCheckbox value="second" @change="console.log('(un)checked !')">Second choice</NcActionCheckbox>
+		<NcActionCheckbox :model-value="true" @change="console.log('(un)checked !')">Third choice (checked)</NcActionCheckbox>
+		<NcActionCheckbox :disabled="true" @change="console.log('(un)checked !')">Second choice (disabled)</NcActionCheckbox>
 	</NcActions>
 ```
 </docs>
 
 <template>
 	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
-		<span class="action-checkbox" :role="isInSemanticMenu && 'menuitemcheckbox'" :aria-checked="ariaChecked">
-			<input
-				:id="id"
-				ref="checkbox"
-				:disabled="disabled"
-				:checked="modelValue"
-				:value="value"
-				:class="{ focusable: isFocusable }"
-				type="checkbox"
-				class="checkbox action-checkbox__checkbox"
-				@keydown.enter.exact.prevent="checkInput"
-				@change="onChange">
-			<label ref="label" :for="id" class="action-checkbox__label">{{ text }}</label>
-
-			<!-- fake slot to gather inner text -->
-			<slot v-if="false" />
-		</span>
+		<label class="action-checkbox" :role="isInSemanticMenu && 'menuitemcheckbox'" :aria-checked="isInSemanticMenu && model.toString()">
+			<span class="action-checkbox__icon">
+				<input
+					:id
+					v-model="model"
+					type="checkbox"
+					class="action-checkbox__input"
+					:class="{ focusable: !disabled }"
+					:value
+					:disabled
+					@change="onChange">
+				<NcIconSvgWrapper :path="model ? mdiCheckboxMarked : mdiCheckboxBlankOutline" :size="20" />
+			</span>
+			<span class="action-checkbox__text">{{ text }}</span>
+		</label>
 	</li>
 </template>
 
 <script>
+import { mdiCheckboxBlankOutline, mdiCheckboxMarked } from '@mdi/js'
+import { useModel } from 'vue'
+import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import { createElementId } from '../../utils/createElementId.ts'
 import { NC_ACTIONS_IS_SEMANTIC_MENU } from '../NcActions/useNcActions.ts'
 
 export default {
 	name: 'NcActionCheckbox',
+
+	components: {
+		NcIconSvgWrapper,
+	},
 
 	mixins: [ActionGlobalMixin],
 
@@ -91,69 +96,31 @@ export default {
 	},
 
 	emits: [
+		/** Native change event */
 		'change',
+		/** Checkbox is checked */
 		'check',
+		/** Checkbox is unchecked */
 		'uncheck',
+		/** Model value changed */
 		'update:modelValue',
 	],
 
-	computed: {
-		/**
-		 * determines if the action is focusable
-		 *
-		 * @return {boolean} is the action focusable ?
-		 */
-		isFocusable() {
-			return !this.disabled
-		},
-
-		/**
-		 * aria-checked attribute for role="menuitemcheckbox"
-		 *
-		 * @return {'true'|'false'|undefined} aria-checked value if needed
-		 */
-		ariaChecked() {
-			if (this.isInSemanticMenu) {
-				return this.modelValue ? 'true' : 'false'
-			}
-			return undefined
-		},
+	setup(props) {
+		const model = useModel(props, 'modelValue')
+		return {
+			model,
+			mdiCheckboxBlankOutline,
+			mdiCheckboxMarked,
+		}
 	},
 
 	methods: {
-		checkInput(/* event */) {
-			// by clicking we also trigger the change event
-			this.$refs.label.click()
-		},
-
 		onChange(event) {
-			/**
-			 * Emitted when the checkbox state is changed
-			 *
-			 * @type {boolean}
-			 */
-			this.$emit('update:modelValue', this.$refs.checkbox.checked)
-
-			/**
-			 * Emitted when the checkbox state is changed
-			 *
-			 * @type {Event}
-			 */
 			this.$emit('change', event)
-
-			if (this.$refs.checkbox.checked) {
-				/**
-				 * Emitted when the checkbox is checked
-				 *
-				 * @type {Event}
-				 */
+			if (event.target.checked) {
 				this.$emit('check')
 			} else {
-				/**
-				 * Emitted when the checkbox is unchecked
-				 *
-				 * @type {Event}
-				 */
 				this.$emit('uncheck')
 			}
 		},
@@ -165,56 +132,24 @@ export default {
 @use '../../assets/action.scss' as *;
 @include action-active;
 @include action--disabled;
+@include action-item('checkbox');
 
-.action-checkbox {
-	display: flex;
-	align-items: flex-start;
-
-	width: 100%;
-	height: auto;
-	margin: 0;
-	padding: 0;
-
-	cursor: pointer;
-	white-space: nowrap;
-
-	color: var(--color-main-text);
-	border: 0;
-	border-radius: 0; // otherwise Safari will cut the border-radius area
-	background-color: transparent;
-	box-shadow: none;
-
-	font-weight: normal;
-	line-height: var(--default-clickable-area);
-
-	/* checkbox/radio fixes */
-	&__checkbox {
-		position: absolute;
-		inset-inline-start: 0 !important;
-		z-index: -1;
-		opacity: 0;
-	}
-
-	&__label {
-		display: flex;
-		align-items: center; // align checkbox to text
-
-		width: 100%;
-		padding: 0 !important;
-		padding-inline-end: $icon-margin !important;
-
-		&::before {
-			margin-block: 0 !important;
-			margin-inline: calc((var(--default-clickable-area) - 14px) / 2) !important;
-		}
-	}
-
-	&--disabled {
-		&,
-		.action-checkbox__label {
-			cursor: pointer;
-		}
-	}
+.action:has(:focus-visible) {
+	outline: 2px solid currentColor;
 }
 
+.action-checkbox {
+	&__icon {
+		color: var(--color-primary-element);
+	}
+
+	&__input {
+		width: 20px;
+		height: 20px;
+		margin: auto;
+		position: absolute;
+		z-index: -1;
+		opacity: 0 !important;
+	}
+}
 </style>

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -45,35 +45,39 @@ So that only one of each name set can be selected at the same time.
 
 <template>
 	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
-		<span class="action-radio" role="menuitemradio" :aria-checked="ariaChecked">
-			<input
-				:id="id"
-				ref="radio"
-				v-model="model"
-				class="radio action-radio__radio"
-				:class="{ focusable: isFocusable }"
-				:disabled="disabled"
-				:name="name"
-				:value="value"
-				type="radio"
-				@keydown.enter.exact.prevent="toggleInput"
-				@change="onChange">
-			<label ref="label" :for="id" class="action-radio__label">{{ text }}</label>
-
-			<!-- fake slot to gather inner text -->
-			<slot v-if="false" />
-		</span>
+		<label class="action-radio" :role="isInSemanticMenu && 'menuitemradio'" :aria-checked="isInSemanticMenu && checked.toString()">
+			<span class="action-radio__icon">
+				<input
+					:id
+					v-model="model"
+					type="radio"
+					class="action-radio__input"
+					:class="{ focusable: !disabled }"
+					:value
+					:name
+					:disabled
+					@change="$emit('change', $event)">
+				<NcIconSvgWrapper :path="checked ? mdiRadioboxMarked : mdiRadioboxBlank" :size="20" />
+			</span>
+			<span class="action-radio__text">{{ text }}</span>
+		</label>
 	</li>
 </template>
 
 <script>
+import { mdiRadioboxBlank, mdiRadioboxMarked } from '@mdi/js'
 import { useModel } from 'vue'
+import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import { createElementId } from '../../utils/createElementId.ts'
 import { NC_ACTIONS_IS_SEMANTIC_MENU } from '../NcActions/useNcActions.ts'
 
 export default {
 	name: 'NcActionRadio',
+
+	components: {
+		NcIconSvgWrapper,
+	},
 
 	mixins: [ActionGlobalMixin],
 
@@ -137,45 +141,14 @@ export default {
 	setup(props) {
 		return {
 			model: useModel(props, 'modelValue'),
+			mdiRadioboxBlank,
+			mdiRadioboxMarked,
 		}
 	},
 
 	computed: {
-		/**
-		 * determines if the action is focusable
-		 *
-		 * @return {boolean} is the action focusable ?
-		 */
-		isFocusable() {
-			return !this.disabled
-		},
-
-		/**
-		 * aria-checked attribute for role="menuitemcheckbox"
-		 *
-		 * @return {'true'|'false'|undefined} aria-checked value if needed
-		 */
-		ariaChecked() {
-			if (this.isInSemanticMenu) {
-				return this.modelValue === this.value ? 'true' : 'false'
-			}
-			return undefined
-		},
-	},
-
-	methods: {
-		toggleInput(/* event */) {
-			// by clicking we also trigger the change event
-			this.$refs.label.click()
-		},
-
-		onChange(event) {
-			/**
-			 * Emitted when the radio state is changed
-			 *
-			 * @type {Event}
-			 */
-			this.$emit('change', event)
+		checked() {
+			return this.model === this.value
 		},
 	},
 }
@@ -185,56 +158,24 @@ export default {
 @use '../../assets/action.scss' as *;
 @include action-active;
 @include action--disabled;
+@include action-item('radio');
 
-.action-radio {
-	display: flex;
-	align-items: flex-start;
-
-	width: 100%;
-	height: auto;
-	margin: 0;
-	padding: 0;
-
-	cursor: pointer;
-	white-space: nowrap;
-
-	color: var(--color-main-text);
-	border: 0;
-	border-radius: 0; // otherwise Safari will cut the border-radius area
-	background-color: transparent;
-	box-shadow: none;
-
-	font-weight: normal;
-	line-height: var(--default-clickable-area);
-
-	/* checkbox/radio fixes */
-	&__radio {
-		position: absolute;
-		inset-inline-start: 0 !important;
-		z-index: -1;
-		opacity: 0;
-	}
-
-	&__label {
-		display: flex;
-		align-items: center; // align radio to text
-
-		width: 100%;
-		padding: 0 !important;
-		padding-inline-end: $icon-margin !important;
-
-		// (34 -14) / 2 = 10 same as ncactioncheckbox
-		&::before {
-			margin: calc((var(--default-clickable-area) - 14px) / 2) !important;
-		}
-	}
-
-	&--disabled {
-		&,
-		.action-radio__label {
-			cursor: pointer;
-		}
-	}
+.action:has(:focus-visible) {
+	outline: 2px solid currentColor;
 }
 
+.action-radio {
+	&__icon {
+		color: var(--color-primary-element);
+	}
+
+	&__input {
+		width: 20px;
+		height: 20px;
+		margin: auto;
+		position: absolute;
+		z-index: -1;
+		opacity: 0 !important;
+	}
+}
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Alternative to https://github.com/nextcloud-libraries/nextcloud-vue/pull/7890
- Use the same icons as in `NcCheckboxRadioSwitch` instead of legacy server styles
- Specify the focus visible outline.
- Also simplify components a bit
- Both components are very similar, but I don't want to reuse the code to not complicate existing `NcActions` set. Duplicated code is quite small and simple

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="389" height="486" alt="image" src="https://github.com/user-attachments/assets/ff9d6e89-5000-4437-a5c2-5ac287897d44" /> | <img width="383" height="487" alt="image" src="https://github.com/user-attachments/assets/453fa840-45ba-4ec6-8f2b-a848961b03e3" />
<img width="320" height="519" alt="image" src="https://github.com/user-attachments/assets/83a8802e-8def-435b-9bd7-a2dd26b4eeb4" /> | <img width="324" height="511" alt="image" src="https://github.com/user-attachments/assets/7a6733e2-30cc-44b5-8d87-bc7b7257ef79" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
