### PR TITLE
build: fix translations in vue modules

### DIFF
--- a/build/l10n-plugin.mts
+++ b/build/l10n-plugin.mts
@@ -104,7 +104,9 @@ export default (dir: string) => {
 				return `import {t,n,register,${imports.join(',')}} from '\0l10n';register(${imports.join(',')});export {t,n};`
 			} else if (id === '\0l10n') {
 				// exports are all chunked translations
-				const exports = Object.entries(nameMap).map(([usage, id]) => `export const ${id} = ${JSON.stringify(translations[usage])}`).join(';\n')
+				const exports = Object.entries(nameMap)
+					.map(([usage, id]) => `export const ${id} = ${JSON.stringify(translations[usage])}`)
+					.join(';\n')
 				return `${l10nRegistrationCode}\n${exports}`
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

When a vue file is handled by vite it will have some query string like `source.vue?lang=ts&...` so to properly add the correct translations for that file we need to remove the query string.

This resolves an issue where some files (e.g. `NcAppSettingsShortcutsSection`) were missing their translations in the bundle.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
