### PR TITLE
fix(NcModal): Adjust max height to leave some space

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -733,7 +733,7 @@ function clearFocusTrap() {
 
 	// We allow 90% max-height, but we need to ensure the header does not overlap the modal
 	// as the modal is centered, we need the space on top and bottom
-	$max-modal-height: min(90%, calc(100% - 2 * var(--header-height)));
+	$max-modal-height: min(90%, calc(100% - 2 * var(--header-height) - 2 * var(--body-container-margin)));
 
 	// Sizing
 	&--small {


### PR DESCRIPTION
This is so that the modal doesn't exactly touch the edges of the header, which looks a bit weird. Sort of a follow-up to 4d9e81dcd3c1a878472d8bf9d0797a13c38a8a67.

Discussed with @jancborchardt and @nimishavijay 

Not sure about backports?

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2146" height="1432" alt="Before" src="https://github.com/user-attachments/assets/a92dc90f-791a-4654-b4f4-5da55b400d94" /> | <img width="2146" height="1432" alt="After" src="https://github.com/user-attachments/assets/99fc9de5-89c8-488e-a9fc-46e9f24bb4b2" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
