### PR TITLE
chore: release v8.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 # Changelog
 
+## [v8.35.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.35.1) (2026-01-08)
+### 🐛 Fixed bugs
+* [stable8] fix(NcActionInput): use internal label of NcDateTimePickerNative [\#7979](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7979) \([backportbot[bot]](https://github.com/backportbot[bot])\)
+* [stable8] fix(NcPopover): Don't warn on hidden button elements [\#7975](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7975) \([mejo-](https://github.com/mejo-)\)
+* [stable8] build: fix translations in Vue modules [\#8038](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8038) \([backportbot[bot]](https://github.com/backportbot[bot])\)
+* [stable8] fix(NcModal): Adjust max height of the modal [\#8046](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8046) \([backportbot[bot]](https://github.com/backportbot[bot])\)
+* [stable8] fix: animate toggle switch icon [\#8047](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8047) \([backportbot[bot]](https://github.com/backportbot[bot])\)
+
 ## [v8.35.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.35.0) (2025-12-10)
 ### 🚀 Enhancements
 * [stable8] feat(NcAppSettingsDialog): add version on the bottom and `noVersion` prop to disable it  [\#7850](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7850) \([ShGKme](https://github.com/ShGKme)\)
@@ -111,10 +119,10 @@ it is no longer used by Nextcloud or Nextcloud apps and not recommended to be us
 * fix(NcReferenceWidget): harden checks for reference = null [\#7493](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7493)
 * fix(NcRadioGroup): fieldsets always need a label for accessibility [\#7495](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7495)
 * fix(NcAvatar): make min status size visually accessible [\#7480](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7480)
-* fix(NcAppNavigationItem): ensure to pass boolean where needed [\#7491](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7491) 
+* fix(NcAppNavigationItem): ensure to pass boolean where needed [\#7491](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7491)
 
 ### Other Changes
-* chore(NcCheckboxRadioSwitch): deprecate button variant in favor of `NcRadioGroup` [\#7492](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7492) 
+* chore(NcCheckboxRadioSwitch): deprecate button variant in favor of `NcRadioGroup` [\#7492](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7492)
 * chore: deprecate `NcSettingsInputText` component [\#7488](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7488)
 * chore: migrate to ESLint 9 and @nextcloud/eslint-config 9 [\#7418](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7418) \([ShGKme](https://github.com/ShGKme)\)
 * chore(lint): fix [\#7425](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7425) \([ShGKme](https://github.com/ShGKme)\)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.35.0",
+  "version": "8.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.35.0",
+      "version": "8.35.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.35.0",
+  "version": "8.35.1",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.35.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.35.1) (2026-01-08)
### 🐛 Fixed bugs
* [stable8] fix(NcActionInput): use internal label of NcDateTimePickerNative [\#7979](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7979) \([backportbot[bot]](https://github.com/backportbot[bot])\)
* [stable8] fix(NcPopover): Don't warn on hidden button elements [\#7975](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7975) \([mejo-](https://github.com/mejo-)\)
* [stable8] build: fix translations in Vue modules [\#8038](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8038) \([backportbot[bot]](https://github.com/backportbot[bot])\)
* [stable8] fix(NcModal): Adjust max height of the modal [\#8046](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8046) \([backportbot[bot]](https://github.com/backportbot[bot])\)
* [stable8] fix: animate toggle switch icon [\#8047](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8047) \([backportbot[bot]](https://github.com/backportbot[bot])\)
