### PR TITLE
fix(build): prevent styles leak to v8

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,13 @@ const overrides = defineConfig({
 				],
 			},
 		},
+		modules: {
+			// Make sure @nextcloud/vue v9 and @nextcloud/vue v8 have different scopes even for the same component code
+			hashPrefix: '@nextcloud/vue@9',
+			// hashPrefix only works when custom generateScopedName is set
+			// Ref: https://github.com/madyankin/postcss-modules/blob/v6.0.1/src/scoping.js#L39
+			generateScopedName: '_[local]_[hash:base64:5]',
+		},
 	},
 })
 


### PR DESCRIPTION
### ☑️ Resolves

- We have styles encapsulation
- It uses content hash for encapsulation, so the same component code results in the same styles scope
- However, Vue 2 and Vue 3 components may have exactly the same code, which results in the same styles scope
- While runtime is different, for example, with `v-bind in css` feature
- It may result in Vue 2 component breaking the same Vue 3 component styles 

<img width="2278" height="1069" alt="image" src="https://github.com/user-attachments/assets/6d07b1b0-3b65-4a1d-95f7-030f8ab6c22a" />

- Example: `NcIconToggleSwitch` component. Tables app (Vue 2) breaks styles for Talk (Vue 3)

<img width="922" height="311" alt="Screenshot 2026-01-16 141158" src="https://github.com/user-attachments/assets/398d874c-62d5-4a95-93e2-07da4d291ef5" />

- Fix: add hash prefix to make it different from v8

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
