### PR TITLE
[stable8] fix(build): prevent styles leak to v9

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -93,6 +93,13 @@ const overrides = defineConfig({
 				],
 			},
 		},
+		modules: {
+			// Make sure @nextcloud/vue v9 and @nextcloud/vue v8 have different scopes even for the same component code
+			hashPrefix: '@nextcloud/vue@8',
+			// hashPrefix only works when custom generateScopedName is set
+			// Ref: https://github.com/madyankin/postcss-modules/blob/v6.0.1/src/scoping.js#L39
+			generateScopedName: '_[local]_[hash:base64:5]',
+		},
 	},
 })
 


### PR DESCRIPTION
- Manual backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/8091