### PR TITLE
feat(NcRadioGroupButton): add disabled state styling to NcRadioGroupButton 

### DIFF
--- a/src/components/NcRadioGroup/NcRadioGroup.vue
+++ b/src/components/NcRadioGroup/NcRadioGroup.vue
@@ -159,7 +159,7 @@ The radio group also allows to create a button like styling together with the `N
 		<h4>With icons</h4>
 		<div style="max-width: 250px">
 			<NcRadioGroup v-model="alignment" label="Example alignment with icons" hide-label>
-				<NcRadioGroupButton aria-label="Start" value="start" disabled="true">
+				<NcRadioGroupButton aria-label="Start" value="start" disabled>
 					<template #icon>
 						<NcIconSvgWrapper directional :path="mdiAlignHorizontalLeft" />
 					</template>

--- a/src/components/NcRadioGroupButton/NcRadioGroupButton.vue
+++ b/src/components/NcRadioGroupButton/NcRadioGroupButton.vue
@@ -55,6 +55,7 @@ function onUpdate() {
 	if (props.disabled) {
 		return
 	}
+
 	radioGroup!.value.onUpdate(props.value)
 }
 </script>
@@ -80,7 +81,7 @@ function onUpdate() {
 			class="hidden-visually"
 			:checked="isChecked"
 			type="radio"
-			:disabled="disabled"
+			:disabled
 			:value
 			@input="onUpdate">
 	</div>
@@ -123,7 +124,7 @@ function onUpdate() {
 		padding-inline-start: var(--radio-group-button--padding);
 	}
 
-	&:hover {
+	&:hover:not(.radioGroupButton_disabled) {
 		background-color: var(--radio-group-button--background-color-hover);
 	}
 
@@ -153,10 +154,6 @@ function onUpdate() {
 	cursor: default;
 	* {
 		cursor: default;
-	}
-
-	&:hover {
-		background-color: var(--radio-group-button--background-color);
 	}
 }
 


### PR DESCRIPTION
- resolves : https://github.com/nextcloud-libraries/nextcloud-vue/issues/7930

### ☑️ Resolves

- Adds proper disabled state styling to NcRadioGroupButton
- Ensures checked+disabled state is visually indicated

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1337" height="594" alt="image" src="https://github.com/user-attachments/assets/39e75c57-3318-4bb0-ad11-a4b0e09a5bb5" /> | <img width="1372" height="612" alt="image" src="https://github.com/user-attachments/assets/9d57e820-46ca-46f1-9c16-6b98a7c530dc" />


### 🚧 Tasks

- [x] Add .radioGroupButton_disabled class and styles

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
