### PR TITLE
feat(NcProgresBar): add `showValue` prop to show the progress value

### DIFF
--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -24,7 +24,7 @@ This is a simple progress bar component.
 		<NcProgressBar :value="60" size="medium" />
 		<br />
 		Custom size (changes the progress bar height)
-		<NcProgressBar :value="55" :size="8" />
+		<NcProgressBar :value="55" :size="8" showValue />
 	</span>
 </template>
 ```
@@ -80,11 +80,17 @@ const props = withDefaults(defineProps<{
 	 * The color of the progress bar
 	 */
 	color?: string
+
+	/**
+	 * Show value at the end of progress bar (only for linear type)
+	 */
+	showValue?: boolean
 }>(), {
 	value: 0,
 	color: 'var(--color-primary-element)',
 	size: 'small',
 	type: 'linear',
+	showValue: false,
 })
 
 const normalizedProgress = computed(() => Math.max(0, Math.min(100, props.value)) / 100)
@@ -156,12 +162,15 @@ const clickableAreaSmall = Number.parseInt(window.getComputedStyle(document.body
 				:cy="circleCenterPosition" />
 		</svg>
 	</span>
-	<progress
-		v-else
-		class="progress-bar progress-bar--linear vue"
-		:class="{ 'progress-bar--error': error }"
-		:value
-		max="100" />
+	<div v-else class="progress-bar-container">
+		<progress
+			class="progress-bar progress-bar--linear vue"
+			:class="{ 'progress-bar--error': error }"
+			:value
+			max="100" />
+
+		<span v-if="showValue" class="progress-bar__value">{{ value }}%</span>
+	</div>
 </template>
 
 <style lang="scss" scoped>
@@ -208,6 +217,19 @@ const clickableAreaSmall = Number.parseInt(window.getComputedStyle(document.body
 		&::-webkit-progress-value {
 			background: var(--color-text-error, var(--color-error)) !important;
 		}
+	}
+
+	&-container {
+		display: flex;
+		align-items: center;
+		gap: calc(2 * var(--default-grid-baseline));
+	}
+
+	&__value {
+		font-size: var(--font-size-small, 13px);
+		font-variant-numeric: tabular-nums;
+		min-width: 4ch;
+		text-align: end;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- resolves: #8068 

- Fix : Only display the progress value label for linear progress bar

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="894" height="162" alt="image" src="https://github.com/user-attachments/assets/1a8b2ab9-f463-410a-8603-d319d500dfc0" /> | <img width="874" height="168" alt="image" src="https://github.com/user-attachments/assets/b60e7fb2-224f-4b4a-bb56-82919dc9396a" />


### 🚧 Tasks

- [x] Show value label only for linear progress bar
- [x] Update component documentation if needed

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
