### PR TITLE
fix(NcInputField): Helper message `word-break` on Chrome

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -494,6 +494,7 @@ function handleInput(event: Event) {
 		display: flex;
 		align-items: center;
 		color: var(--color-text-maxcontrast);
+		word-break: break-all;
 
 		&__icon {
 			margin-inline-end: 8px;


### PR DESCRIPTION
Without it, the message does not break and increase the size of its container.
Couldn't test locally because linking `@nc/vue` fails, but tested manually by changing the CSS in the browser.

| Browser | Before | After |
|--------|--------|--------|
| Firefox | <img width="423" height="564" alt="image" src="https://github.com/user-attachments/assets/e166bd3f-c7e9-4c09-a56b-e5a809b9a7e3" /> | <img width="423" height="564" alt="image" src="https://github.com/user-attachments/assets/0f1576dc-0c38-4d0f-8ab4-0703f4e58a28" /> |
| Chrome | <img width="423" height="564" alt="Screenshot From 2026-01-28 12-11-21" src="https://github.com/user-attachments/assets/7d30e3e6-6159-46f9-be49-996199a16abc" /> | <img width="423" height="564" alt="image" src="https://github.com/user-attachments/assets/79d0ac50-ccc0-490d-bcec-4b4f81828654" /> |
