### PR TITLE
fix(NcButton): do not reduce border radius for small buttons

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -756,7 +756,6 @@ function onClick(event: MouseEvent) {
 	// Setup different button sizes
 	&--size-small {
 		--button-size: var(--clickable-area-small);
-		--button-radius: var(--border-radius-small); // make the border radius even smaller for small buttons
 	}
 
 	&--size-large {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/8117

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="836" height="600" alt="Screenshot 2026-01-28 at 18-28-41 Nextcloud Vue Style Guide" src="https://github.com/user-attachments/assets/a18109b6-6832-42ad-8915-c1b8f6de7d67" />|<img width="836" height="600" alt="Screenshot 2026-01-28 at 18-28-27 Nextcloud Vue Style Guide" src="https://github.com/user-attachments/assets/1092f9c4-a402-4f36-b1d5-7b9cc48cbfce" />


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
