### PR TITLE
feat(NcSelectUsers): export `NcSelectUsersModel` type

### DIFF
--- a/src/components/NcSelectUsers/NcSelectUsers.vue
+++ b/src/components/NcSelectUsers/NcSelectUsers.vue
@@ -169,7 +169,7 @@ import { ref, watch } from 'vue'
 import NcListItemIcon from '../NcListItemIcon/index.js'
 import NcSelect from '../NcSelect/index.js'
 
-export interface IUserData {
+export interface NcSelectUsersModel {
 	id: string
 
 	/**
@@ -219,7 +219,7 @@ export interface IUserData {
  * If the `multiple` property is set then an array of users is emitted,
  * otherwise a single user data object will be emitted.
  */
-const modelValue = defineModel<IUserData | IUserData[]>('modelValue')
+const modelValue = defineModel<NcSelectUsersModel | NcSelectUsersModel[]>('modelValue')
 
 defineProps<{
 	/**
@@ -291,7 +291,7 @@ defineProps<{
 	/**
 	 * Array of users or similar object (e.g. groups or guest users).
 	 */
-	options: IUserData[]
+	options: NcSelectUsersModel[]
 
 	/**
 	 * Placeholder text.

--- a/src/components/NcSelectUsers/index.ts
+++ b/src/components/NcSelectUsers/index.ts
@@ -3,4 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+export type { NcSelectUsersModel } from './NcSelectUsers.vue'
+
 export { default } from './NcSelectUsers.vue'


### PR DESCRIPTION
### ☑️ Resolves

So that you can make use of the type inside apps, otherwise its pretty cumbersome to get it.
`type IUserData = InstanceType<typeof NcSelectUsers>['$props']['options'][number]`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
