### PR TITLE
fix(NcSelect): announce selected option to screen readers

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-msgid ", selected"
+msgid "{option} (selected)"
 msgstr ""
 
 msgid "{tag} (invisible)"

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,9 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
+msgid ", selected"
+msgstr ""
+
 msgid "{tag} (invisible)"
 msgstr ""
 

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,9 +2,6 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-msgid "{option} (selected)"
-msgstr ""
-
 msgid "{tag} (invisible)"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nextcloud/logger": "^3.0.3",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.4.0",
+        "@nextcloud/vue-select": "^4.0.0-beta.1",
         "@vuepic/vue-datepicker": "^11.0.3",
         "@vueuse/components": "^14.2.1",
         "@vueuse/core": "^14.2.1",
@@ -3714,6 +3715,18 @@
         "browserslist": ">=4.0",
         "sass": ">=1.60",
         "vite": "^7.1.10"
+      }
+    },
+    "node_modules/@nextcloud/vue-select": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-4.0.0-beta.1.tgz",
+      "integrity": "sha512-sEnVFiSkOukzqkf3CbDHyXltLVeyhV4mfeEbSvOU6Bx/NSa6vtAhT8mH8M/B+yV0gNT1ym9iEjPHpZW4qn6nrA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22 || ^24"
+      },
+      "peerDependencies": {
+        "vue": "^3"
       }
     },
     "node_modules/@nextcloud/webpack-vue-config": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@nextcloud/logger": "^3.0.3",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/sharing": "^0.4.0",
+    "@nextcloud/vue-select": "^4.0.0-beta.1",
     "@vuepic/vue-datepicker": "^11.0.3",
     "@vueuse/components": "^14.2.1",
     "@vueuse/core": "^14.2.1",
@@ -117,8 +118,7 @@
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.1.0",
     "vue": "^3.5.18",
-    "vue-router": "^5.0.4",
-    "vue-select": "^4.0.0-beta.6"
+    "vue-router": "^5.0.4"
   },
   "devDependencies": {
     "@babel/plugin-syntax-import-assertions": "^7.28.6",

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -331,18 +331,21 @@ export default {
 		v-bind="propsToForward"
 		@search="search = $event"
 		@update:modelValue="$emit('update:modelValue', $event)">
-		<template v-if="!labelOutside && inputLabel" #header>
+		<template #header>
 			<label
+				v-if="!labelOutside && inputLabel"
 				:for="inputId"
 				class="select__label">
 				{{ inputLabel }}
 			</label>
+			<span :id="selectedDescriptionId" class="hidden-visually">{{ selectedDescription }}</span>
 		</template>
 		<template #search="{ attributes, events }">
 			<input
 				class="vs__search"
 				:class="[inputClass]"
 				v-bind="attributes"
+				:aria-describedby="selectedDescriptionId"
 				:required="inputRequired"
 				dir="auto"
 				v-on="events">
@@ -364,6 +367,8 @@ export default {
 					:name="String(option[localLabel])"
 					:search="search" />
 			</slot>
+			<!-- Visually hidden marker so screen readers can identify the selected option -->
+			<span v-if="isOptionCurrentlySelected(option)" class="hidden-visually">{{ t(', selected') }}</span>
 		</template>
 		<template #selected-option="selectedOption">
 			<!-- @slot Customize how a selected option is rendered -->
@@ -778,10 +783,12 @@ export default {
 		const clickableArea = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area'))
 		const gridBaseLine = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-grid-baseline'))
 		const avatarSize = clickableArea - 2 * gridBaseLine
+		const selectedDescriptionId = createElementId()
 
 		return {
 			avatarSize,
 			isLegacy,
+			selectedDescriptionId,
 		}
 	},
 
@@ -792,6 +799,22 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Set of label strings for the currently selected value(s).
+		 * Used for O(1) lookup in isOptionCurrentlySelected and joined for aria-describedby.
+		 */
+		selectedLabels() {
+			if (this.modelValue === null) {
+				return new Set()
+			}
+			const values = Array.isArray(this.modelValue) ? this.modelValue : [this.modelValue]
+			return new Set(values.map((v) => typeof v === 'object' ? String(v[this.localLabel]) : String(v)))
+		},
+
+		selectedDescription() {
+			return [...this.selectedLabels].join(', ')
+		},
+
 		inputRequired() {
 			if (!this.required) {
 				return null
@@ -900,6 +923,16 @@ export default {
 
 	methods: {
 		t,
+
+		/**
+		 * Returns true if the given option (as received from vue-select's #option slot)
+		 * is currently selected. Uses the selectedLabels computed Set for O(1) lookup.
+		 *
+		 * @param {object} option - normalized option from the #option slot
+		 */
+		isOptionCurrentlySelected(option) {
+			return this.selectedLabels.has(String(option[this.localLabel]))
+		},
 	},
 }
 </script>

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -365,10 +365,13 @@ export default {
 			<slot name="option" v-bind="option">
 				<NcEllipsisedOption
 					:name="String(option[localLabel])"
-					:search="search" />
+					:search="search"
+					:aria-hidden="isOptionCurrentlySelected(option) || undefined" />
 			</slot>
 			<!-- Visually hidden marker so screen readers can identify the selected option -->
-			<span v-if="isOptionCurrentlySelected(option)" class="hidden-visually">{{ t(', selected') }}</span>
+			<span v-if="isOptionCurrentlySelected(option)" class="hidden-visually">
+				{{ t('{option} (selected)', { option: String(option[localLabel]) }) }}
+			</span>
 		</template>
 		<template #selected-option="selectedOption">
 			<!-- @slot Customize how a selected option is rendered -->

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -338,14 +338,12 @@ export default {
 				class="select__label">
 				{{ inputLabel }}
 			</label>
-			<span :id="selectedDescriptionId" class="hidden-visually">{{ selectedDescription }}</span>
 		</template>
 		<template #search="{ attributes, events }">
 			<input
 				class="vs__search"
 				:class="[inputClass]"
 				v-bind="attributes"
-				:aria-describedby="selectedDescriptionId"
 				:required="inputRequired"
 				dir="auto"
 				v-on="events">
@@ -365,13 +363,8 @@ export default {
 			<slot name="option" v-bind="option">
 				<NcEllipsisedOption
 					:name="String(option[localLabel])"
-					:search="search"
-					:aria-hidden="isOptionCurrentlySelected(option) || undefined" />
+					:search="search" />
 			</slot>
-			<!-- Visually hidden marker so screen readers can identify the selected option -->
-			<span v-if="isOptionCurrentlySelected(option)" class="hidden-visually">
-				{{ t('{option} (selected)', { option: String(option[localLabel]) }) }}
-			</span>
 		</template>
 		<template #selected-option="selectedOption">
 			<!-- @slot Customize how a selected option is rendered -->
@@ -403,8 +396,8 @@ import {
 	offset,
 	shift,
 } from '@floating-ui/dom'
+import { VueSelect } from '@nextcloud/vue-select'
 import { h, warn } from 'vue'
-import VueSelect from 'vue-select'
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import Close from 'vue-material-design-icons/Close.vue'
 import NcEllipsisedOption from '../NcEllipsisedOption/NcEllipsisedOption.vue'
@@ -413,10 +406,7 @@ import { t } from '../../l10n.ts'
 import { createElementId } from '../../utils/createElementId.ts'
 import { isLegacy } from '../../utils/legacy.ts'
 
-// TODO: Use @nextcloud/vue-select once a vue 3 version is available.
-// Until then, all @nextcloud/vue-select specific improvements won't be available.
-// E.g. the `limit` prop has no effect, currently.
-import 'vue-select/dist/vue-select.css'
+import '@nextcloud/vue-select/styles.css'
 
 export default {
 	name: 'NcSelect',
@@ -786,12 +776,10 @@ export default {
 		const clickableArea = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area'))
 		const gridBaseLine = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-grid-baseline'))
 		const avatarSize = clickableArea - 2 * gridBaseLine
-		const selectedDescriptionId = createElementId()
 
 		return {
 			avatarSize,
 			isLegacy,
-			selectedDescriptionId,
 		}
 	},
 
@@ -802,22 +790,6 @@ export default {
 	},
 
 	computed: {
-		/**
-		 * Set of label strings for the currently selected value(s).
-		 * Used for O(1) lookup in isOptionCurrentlySelected and joined for aria-describedby.
-		 */
-		selectedLabels() {
-			if (this.modelValue === null) {
-				return new Set()
-			}
-			const values = Array.isArray(this.modelValue) ? this.modelValue : [this.modelValue]
-			return new Set(values.map((v) => typeof v === 'object' ? String(v[this.localLabel]) : String(v)))
-		},
-
-		selectedDescription() {
-			return [...this.selectedLabels].join(', ')
-		},
-
 		inputRequired() {
 			if (!this.required) {
 				return null
@@ -927,15 +899,6 @@ export default {
 	methods: {
 		t,
 
-		/**
-		 * Returns true if the given option (as received from vue-select's #option slot)
-		 * is currently selected. Uses the selectedLabels computed Set for O(1) lookup.
-		 *
-		 * @param {object} option - normalized option from the #option slot
-		 */
-		isOptionCurrentlySelected(option) {
-			return this.selectedLabels.has(String(option[this.localLabel]))
-		},
 	},
 }
 </script>

--- a/tests/component/components/NcSelect/NcSelect.spec.ts
+++ b/tests/component/components/NcSelect/NcSelect.spec.ts
@@ -14,9 +14,9 @@ test('selected option has visually-hidden selected marker in dropdown', async ({
 	await component.getByRole('searchbox').click()
 
 	// The selected option should contain ", selected" text (visually hidden)
-	await expect(page.getByRole('option', { name: 'Banana' })).toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Banana' })).toContainText('(selected)')
 	// Non-selected options should not
-	await expect(page.getByRole('option', { name: 'Cherry' })).not.toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Cherry' })).not.toContainText('(selected)')
 })
 
 test('selected marker stays on correct option during keyboard navigation', async ({ mount, page }) => {
@@ -29,9 +29,9 @@ test('selected marker stays on correct option during keyboard navigation', async
 	await page.keyboard.press('ArrowDown')
 
 	// Banana is still the selected value — marker stays
-	await expect(page.getByRole('option', { name: 'Banana' })).toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Banana' })).toContainText('(selected)')
 	// Cherry is only keyboard-focused, not selected — no marker
-	await expect(page.getByRole('option', { name: 'Cherry' })).not.toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Cherry' })).not.toContainText('(selected)')
 })
 
 test('selected marker updates after selecting a different option', async ({ mount, page }) => {
@@ -45,8 +45,8 @@ test('selected marker updates after selecting a different option', async ({ moun
 	// Re-open dropdown
 	await component.getByRole('searchbox').click()
 
-	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText(', selected')
-	await expect(page.getByRole('option', { name: 'Banana' })).not.toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText('(selected)')
+	await expect(page.getByRole('option', { name: 'Banana' })).not.toContainText('(selected)')
 })
 
 test('multiple selected options have selected marker in dropdown', async ({ mount, page }) => {
@@ -56,9 +56,9 @@ test('multiple selected options have selected marker in dropdown', async ({ moun
 
 	await component.getByRole('searchbox').click()
 
-	await expect(page.getByRole('option', { name: 'Apple' })).toContainText(', selected')
-	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText(', selected')
-	await expect(page.getByRole('option', { name: 'Banana' })).not.toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Apple' })).toContainText('(selected)')
+	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText('(selected)')
+	await expect(page.getByRole('option', { name: 'Banana' })).not.toContainText('(selected)')
 })
 
 test('selected marker updates in keepOpen mode without closing dropdown', async ({ mount, page }) => {
@@ -69,8 +69,8 @@ test('selected marker updates in keepOpen mode without closing dropdown', async 
 	await component.getByRole('searchbox').click()
 	await page.getByRole('option', { name: 'Cherry' }).click()
 
-	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText(', selected')
-	await expect(page.getByRole('option', { name: 'Apple' })).not.toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText('(selected)')
+	await expect(page.getByRole('option', { name: 'Apple' })).not.toContainText('(selected)')
 })
 
 test('search input describes the selected value', async ({ mount }) => {

--- a/tests/component/components/NcSelect/NcSelect.spec.ts
+++ b/tests/component/components/NcSelect/NcSelect.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/experimental-ct-vue'
+import NcSelectStory from './NcSelect.story.vue'
+
+test('selected option has visually-hidden selected marker in dropdown', async ({ mount, page }) => {
+	const component = await mount(NcSelectStory, {
+		props: { initialValue: 'Banana' },
+	})
+
+	await component.getByRole('searchbox').click()
+
+	// The selected option should contain ", selected" text (visually hidden)
+	await expect(page.getByRole('option', { name: 'Banana' })).toContainText(', selected')
+	// Non-selected options should not
+	await expect(page.getByRole('option', { name: 'Cherry' })).not.toContainText(', selected')
+})
+
+test('selected marker stays on correct option during keyboard navigation', async ({ mount, page }) => {
+	const component = await mount(NcSelectStory, {
+		props: { initialValue: 'Banana' },
+	})
+
+	await component.getByRole('searchbox').click()
+	// Navigate away from the selected option
+	await page.keyboard.press('ArrowDown')
+
+	// Banana is still the selected value — marker stays
+	await expect(page.getByRole('option', { name: 'Banana' })).toContainText(', selected')
+	// Cherry is only keyboard-focused, not selected — no marker
+	await expect(page.getByRole('option', { name: 'Cherry' })).not.toContainText(', selected')
+})
+
+test('selected marker updates after selecting a different option', async ({ mount, page }) => {
+	const component = await mount(NcSelectStory, {
+		props: { initialValue: 'Banana' },
+	})
+
+	await component.getByRole('searchbox').click()
+	await page.getByRole('option', { name: 'Cherry' }).click()
+
+	// Re-open dropdown
+	await component.getByRole('searchbox').click()
+
+	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Banana' })).not.toContainText(', selected')
+})
+
+test('multiple selected options have selected marker in dropdown', async ({ mount, page }) => {
+	const component = await mount(NcSelectStory, {
+		props: { multiple: true, keepOpen: true, initialValue: ['Apple', 'Cherry'] },
+	})
+
+	await component.getByRole('searchbox').click()
+
+	await expect(page.getByRole('option', { name: 'Apple' })).toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Banana' })).not.toContainText(', selected')
+})
+
+test('selected marker updates in keepOpen mode without closing dropdown', async ({ mount, page }) => {
+	const component = await mount(NcSelectStory, {
+		props: { initialValue: 'Apple', keepOpen: true },
+	})
+
+	await component.getByRole('searchbox').click()
+	await page.getByRole('option', { name: 'Cherry' }).click()
+
+	await expect(page.getByRole('option', { name: 'Cherry' })).toContainText(', selected')
+	await expect(page.getByRole('option', { name: 'Apple' })).not.toContainText(', selected')
+})
+
+test('search input describes the selected value', async ({ mount }) => {
+	const component = await mount(NcSelectStory, {
+		props: { initialValue: 'Banana' },
+	})
+
+	const searchbox = component.getByRole('searchbox')
+	const describedBy = await searchbox.getAttribute('aria-describedby')
+	expect(describedBy).toBeTruthy()
+
+	const descriptionEl = component.locator(`#${describedBy}`)
+	await expect(descriptionEl).toContainText('Banana')
+})
+
+test('selected value description is empty when nothing selected', async ({ mount }) => {
+	const component = await mount(NcSelectStory)
+
+	const searchbox = component.getByRole('searchbox')
+	const describedBy = await searchbox.getAttribute('aria-describedby')
+	expect(describedBy).toBeTruthy()
+
+	const descriptionEl = component.locator(`#${describedBy}`)
+	await expect(descriptionEl).toHaveText('')
+})
+
+test('search input describes multiple selected values', async ({ mount }) => {
+	const component = await mount(NcSelectStory, {
+		props: { multiple: true, initialValue: ['Apple', 'Cherry'] },
+	})
+
+	const searchbox = component.getByRole('searchbox')
+	const describedBy = await searchbox.getAttribute('aria-describedby')
+	expect(describedBy).toBeTruthy()
+
+	const descriptionEl = component.locator(`#${describedBy}`)
+	await expect(descriptionEl).toContainText('Apple')
+	await expect(descriptionEl).toContainText('Cherry')
+})

--- a/tests/component/components/NcSelect/NcSelect.story.vue
+++ b/tests/component/components/NcSelect/NcSelect.story.vue
@@ -1,0 +1,34 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcSelect
+		v-model="selection"
+		:inputLabel="inputLabel"
+		:options="options"
+		:multiple="multiple"
+		:keepOpen="keepOpen" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import NcSelect from '../../../../src/components/NcSelect/NcSelect.vue'
+
+const props = withDefaults(defineProps<{
+	inputLabel?: string
+	options?: string[]
+	multiple?: boolean
+	keepOpen?: boolean
+	initialValue?: string | string[] | null
+}>(), {
+	inputLabel: 'Choose a fruit',
+	options: () => ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+	multiple: false,
+	keepOpen: false,
+	initialValue: null,
+})
+
+const selection = ref(props.initialValue)
+</script>


### PR DESCRIPTION
### ☑️ Resolves

- Fix #8322

### 🖼️ Screenshots

N/A - behavioural fix, no visual change

### 🚧 Tasks

- [x] Add `aria-describedby` on the search input pointing to a hidden span with the selected value. Screen readers announce it on focus.
- [x] Inject a visually-hidden `<item>, selected` marker into the `#option` slot for the currently selected option. Screen readers pick this up via `aria-activedescendant` while navigating the list.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable

> **Note on `aria-selected`**:
>
> vue-select sets `aria-selected` on the `<li>` elements in its own render function - NcSelect can't control these attributes from the wrapper level without fragile DOM manipulation that gets overwritten on re-renders. The visually-hidden text approach works within Vue's reactivity and doesn't fight the upstream library.
