### PR TITLE
docs(NcDateTimePickerNative): clarify local timezone conversion behavior

### DIFF
--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -97,9 +97,12 @@ import { createElementId } from '../../utils/createElementId.ts'
 defineOptions({ inheritAttrs: false })
 
 /**
- * The date is – like the `Date` object in JavaScript – tied to UTC.
- * The selected time zone does not have an influence of the selected time and date value.
- * You have to translate the time yourself when you want to factor in time zones.
+ * The selected value is interpreted in the browser's local timezone.
+ * The component converts between the native input value and a JavaScript
+ * `Date` using that local timezone context.
+ * If your app needs to work in a specific timezone other than the
+ * browser's local one (for example UTC or an IANA timezone), you
+ * must convert the value yourself.
  * Pass null to clear the input field.
  */
 const modelValue = defineModel<Date | null>({ default: null })

--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -103,6 +103,10 @@ defineOptions({ inheritAttrs: false })
  * If your app needs to work in a specific timezone other than the
  * browser's local one (for example UTC or an IANA timezone), you
  * must convert the value yourself.
+ *
+ * For example, serializing the resulting `Date` with `toISOString()`
+ * will produce the corresponding UTC timestamp.
+ *
  * Pass null to clear the input field.
  */
 const modelValue = defineModel<Date | null>({ default: null })


### PR DESCRIPTION
### ☑️ Resolves

Clarify the `NcDateTimePickerNative` documentation comment to reflect actual behavior more accurately.

The component interprets values in the browser's local timezone and converts between the native input value and a JavaScript `Date` using that local timezone context. The updated comment also makes it clearer that consumers must handle conversion themselves if they need a timezone other than the browser's local one.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [x] ...

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
