### PR TITLE
feat(NcRichContenteditable): allow to pass `menuContainer` as string

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -566,11 +566,6 @@ export default {
 
 		// Update default value
 		this.updateContent(this.modelValue)
-
-		// Tribute.js library ensures that `el.contentEditable = true` when attaching to element.
-		// This overwrites the template binding.
-		// Set the contenteditable attribute to actual value afterward
-		this.$refs.contenteditable.contentEditable = this.contenteditableAttributeValue
 	},
 
 	beforeUnmount() {
@@ -701,6 +696,12 @@ export default {
 				menuContainer,
 			})
 			this.tribute.attach(this.$refs.contenteditable)
+
+			// Tribute.js library v5.1.3 ensures that `el.contentEditable = true` when attaching to element.
+			// This overwrites the template binding.
+			// Set the contenteditable attribute to actual value afterward
+			// TODO remove when Tribute.js library v5.1.4 is published on npm (or fork it)
+			this.$refs.contenteditable.contentEditable = this.contenteditableAttributeValue
 		},
 
 		getLink(item) {

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -363,11 +363,12 @@ export default {
 		},
 
 		/**
-		 * The containing element for the menu popover
+		 * The containing element or selector for the tribute (menu popover)
+		 * Defaults to `body` element
 		 */
 		menuContainer: {
-			type: Element,
-			default: () => document.body,
+			type: [String, Element, null],
+			default: null,
 		},
 
 		/**
@@ -686,13 +687,18 @@ export default {
 				})
 			}
 
+			// Resolve container for Tribute.js to be mounted to (default - `null`)
+			const menuContainer = (typeof this.menuContainer === 'string')
+				? document.querySelector(this.menuContainer)
+				: this.menuContainer
+
 			this.tribute = new Tribute({
 				collection: tributesCollection,
 				// FIXME: tributejs doesn't support allowSpaces as a collection option, only as a global one
 				// Requires to fork a library to allow spaces only in the middle of mentions ('@' trigger)
 				allowSpaces: false,
 				// Where to inject the menu popup
-				menuContainer: this.menuContainer,
+				menuContainer,
 			})
 			this.tribute.attach(this.$refs.contenteditable)
 		},


### PR DESCRIPTION
### ☑️ Resolves

- 🚀 allow to pass string selector as a prop
  - 🧹 change default value to null (as per upstream)
  - 🧹 resolve selector at `mounted()` -> `initializeTribute()`
- 🧹 move DOM patch inside of `initializeTribute()`
  - Not needed as per 5.1.4 release, but it's not published on NPM


### 🚧 Tasks

- [ ] ~~Can we fork [tributejs](https://github.com/zurb/tribute) and release under `@nextcloud-libraries` ?~~

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
