### PR TITLE
fix(NcRichText): do not render nested links in markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "ts-md5": "^2.0.1",
         "unified": "^11.0.5",
         "unist-builder": "^4.0.0",
-        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
         "vue": "^3.5.18",
         "vue-router": "^5.0.4",
         "vue-select": "^4.0.0-beta.6"
@@ -25032,9 +25032,9 @@
       }
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "ts-md5": "^2.0.1",
     "unified": "^11.0.5",
     "unist-builder": "^4.0.0",
-    "unist-util-visit": "^5.1.0",
+    "unist-util-visit-parents": "^6.0.2",
     "vue": "^3.5.18",
     "vue-router": "^5.0.4",
     "vue-select": "^4.0.0-beta.6"

--- a/src/components/NcRichText/autolink.ts
+++ b/src/components/NcRichText/autolink.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { Node, Parent } from 'unist'
 import type { Router } from 'vue-router'
 
 import { getBaseUrl, getRootUrl } from '@nextcloud/router'
 import { u } from 'unist-builder'
-import { SKIP, visit } from 'unist-util-visit'
+import { SKIP, visitParents } from 'unist-util-visit-parents'
 import { defineComponent, h } from 'vue'
 import { logger } from '../../utils/logger.ts'
 import { URL_PATTERN_AUTOLINK } from './helpers.js'
@@ -45,18 +46,19 @@ export function remarkAutolink({ autolink, useMarkdown, useExtendedMarkdown }) {
 			return
 		}
 
-		visit(tree, (node) => node.type === 'text', (node, index, parent) => {
+		visitParents(tree, (node) => node.type === 'text', (node, ancestors: Parent[]) => {
 			// Do not autolink text already inside a link node
-			if (parent?.type === 'link' || parent?.type === 'linkReference') {
+			if (ancestors.some((ancestor) => ancestor.type === 'link' || ancestor.type === 'linkReference')) {
 				return
 			}
 
-			let parsed = parseUrl(node.value)
-			if (typeof parsed === 'string') {
-				parsed = [u('text', parsed)]
-			} else {
-				parsed = parsed
-					.map((n) => {
+			const parent = ancestors.at(-1)
+			const index = parent!.children.indexOf(node) ?? 0
+
+			const parsed = parseUrl(node.value)
+			const parsedNodes: Node[] = (typeof parsed === 'string')
+				? [u('text', parsed)]
+				: parsed.map((n) => {
 						if (typeof n === 'string') {
 							return u('text', n)
 						}
@@ -65,12 +67,11 @@ export function remarkAutolink({ autolink, useMarkdown, useExtendedMarkdown }) {
 							url: n.props.href,
 						}, [u('text', n.props.href)])
 					})
-					.filter((x) => x)
-					.flat()
-			}
+						.filter((x) => x)
+						.flat()
 
-			parent.children.splice(index, 1, ...parsed)
-			return [SKIP, (index ?? 0) + parsed.length]
+			parent!.children.splice(index, 1, ...parsedNodes)
+			return [SKIP, index + parsedNodes.length]
 		})
 	}
 }

--- a/src/components/NcRichText/autolink.ts
+++ b/src/components/NcRichText/autolink.ts
@@ -46,6 +46,11 @@ export function remarkAutolink({ autolink, useMarkdown, useExtendedMarkdown }) {
 		}
 
 		visit(tree, (node) => node.type === 'text', (node, index, parent) => {
+			// Do not autolink text already inside a link node
+			if (parent?.type === 'link' || parent?.type === 'linkReference') {
+				return
+			}
+
 			let parsed = parseUrl(node.value)
 			if (typeof parsed === 'string') {
 				parsed = [u('text', parsed)]

--- a/src/components/NcRichText/remarkPlaceholder.ts
+++ b/src/components/NcRichText/remarkPlaceholder.ts
@@ -8,7 +8,7 @@ import type { Node, Parent } from 'unist'
 import type { TextNode } from './helpers.ts'
 
 import { u } from 'unist-builder'
-import { visit } from 'unist-util-visit'
+import { visitParents } from 'unist-util-visit-parents'
 
 /**
  * Check if the given node is a literal and specifically a text node
@@ -21,14 +21,10 @@ function isTextNode(node: Node): node is TextNode {
 
 const transformPlaceholders: Transformer = function(ast: Node) {
 	// Apply the visitor to all text nodes of the AST
-	visit(ast, isTextNode, visitor)
+	visitParents(ast, isTextNode, (node: TextNode, ancestors: Parent[]) => {
+		const parent = ancestors.at(-1)
+		const index = parent!.children.indexOf(node)
 
-	/**
-	 * @param node - The text node
-	 * @param index - The index of the node
-	 * @param parent - The parent node
-	 */
-	function visitor(node: TextNode, index?: number, parent?: Parent) {
 		const placeholders = node.value.split(/(\{[a-z\-_.0-9]+\})/ig)
 			.map((entry: string) => {
 				const matches = entry.match(/^\{([a-z\-_.0-9]+)\}$/i)
@@ -43,7 +39,7 @@ const transformPlaceholders: Transformer = function(ast: Node) {
 			})
 
 		parent!.children.splice(index!, 1, ...placeholders)
-	}
+	})
 }
 
 export const remarkPlaceholder: Plugin = () => transformPlaceholders

--- a/src/components/NcRichText/remarkStripCode.ts
+++ b/src/components/NcRichText/remarkStripCode.ts
@@ -7,7 +7,7 @@ import type { Plugin } from 'unified'
 import type { Node, Parent } from 'unist'
 import type { TextNode } from './helpers.ts'
 
-import { SKIP, visit } from 'unist-util-visit'
+import { SKIP, visitParents } from 'unist-util-visit-parents'
 
 /**
  * Check if the given node is a literal and specifically a fenced node (inline code or code block)
@@ -20,7 +20,10 @@ function isCodeNode(node: Node): node is TextNode {
 
 export const remarkStripCode: Plugin = function() {
 	return function(tree: Node) {
-		visit(tree, isCodeNode, (node: TextNode, index?: number, parent?: Parent) => {
+		visitParents(tree, isCodeNode, (node: TextNode, ancestors: Parent[]) => {
+			const parent = ancestors.at(-1)
+			const index = parent!.children.indexOf(node)
+
 			parent!.children.splice(index!, 1, {
 				...node,
 				value: '',

--- a/src/components/NcRichText/remarkUnescape.ts
+++ b/src/components/NcRichText/remarkUnescape.ts
@@ -7,7 +7,7 @@ import type { Plugin } from 'unified'
 import type { Node, Parent } from 'unist'
 import type { TextNode } from './helpers.ts'
 
-import { SKIP, visit } from 'unist-util-visit'
+import { SKIP, visitParents } from 'unist-util-visit-parents'
 
 /**
  * Check if the given node is a literal and specifically a text node
@@ -20,7 +20,10 @@ function isTextNode(node: Node): node is TextNode {
 
 export const remarkUnescape: Plugin = function() {
 	return function(tree: Node) {
-		visit(tree, isTextNode, (node: TextNode, index?: number, parent?: Parent) => {
+		visitParents(tree, isTextNode, (node: TextNode, ancestors: Parent[]) => {
+			const parent = ancestors.at(-1)
+			const index = parent!.children.indexOf(node)
+
 			parent!.children.splice(index!, 1, {
 				...node,
 				value: node.value.replace(/&lt;/gmi, '<').replace(/&gt;/gmi, '>'),

--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -192,6 +192,37 @@ describe('Foo', () => {
 		expect(wrapper.find('em').text()).toEqual('to')
 	})
 
+	it('does not autolink markdown link text that is already inside a link', async () => {
+		const wrapper = mount(NcRichText, {
+			props: {
+				text: '[https://example-nested.org](https://example.com)',
+				autolink: true,
+				useMarkdown: true,
+			},
+		})
+
+		const links = wrapper.findAll('a')
+		expect(links).toHaveLength(1)
+		expect(links[0].attributes('href')).toEqual('https://example.com')
+		expect(links[0].text()).toEqual('https://example-nested.org')
+	})
+
+	it('does not autolink deeply nested markdown link text that is already inside a link', async () => {
+		const wrapper = mount(NcRichText, {
+			props: {
+				text: '[**https://example-nested.org**](https://example.com)',
+				autolink: true,
+				useMarkdown: true,
+			},
+		})
+
+		const links = wrapper.findAll('a')
+		expect(links).toHaveLength(1)
+		expect(links[0].attributes('href')).toEqual('https://example.com')
+		expect(links[0].text()).toEqual('https://example-nested.org')
+		expect(wrapper.find('strong').text()).toEqual('https://example-nested.org')
+	})
+
 	it('formats markdown is disabled', async () => {
 		const wrapper = mount(NcRichText, {
 			props: {


### PR DESCRIPTION
### ☑️ Resolves

- Extracted from #8397
- with autolink + useMarkdown props `[href2](href1)` syntax is rendered as `<a href1><a href2>href2</a></a>` instead of href2 being a plain text
- deep nested links also respected

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="359" height="118" alt="image" src="https://github.com/user-attachments/assets/f9308786-cca0-40b1-abdd-dabf7d5f15aa" /> | <img width="367" height="63" alt="image" src="https://github.com/user-attachments/assets/d6d3cc9b-2f1b-4e0e-9f62-4080b4baa554" /><img width="382" height="100" alt="image" src="https://github.com/user-attachments/assets/ebe54b57-84dc-4cd8-9135-2df37f1c3da4" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
