### PR TITLE
fix(NcAppNavigationSearch): Show search clear icon only when field contains something

### DIFF
--- a/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
+++ b/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
@@ -133,7 +133,7 @@ export default {
 			class="app-navigation-search__input"
 			labelOutside
 			:placeholder="placeholder ?? label"
-			showTrailingButton
+			:showTrailingButton="model.length > 0"
 			:trailingButtonLabel="t('Clear search')"
 			type="search"
 			@trailingButtonClick="onCloseSearch">
@@ -229,6 +229,10 @@ function onCloseSearch() {
 	display: flex;
 	gap: var(--app-navigation-padding);
 	padding: var(--app-navigation-padding);
+
+	&__input {
+		--input-padding-end: calc(var(--default-clickable-area) - var(--default-grid-baseline));
+	}
 
 	&--has-actions &__input {
 		flex-grow: 1;

--- a/tests/unit/components/NcAppNavigationSearch/NcAppNavigationSearch.spec.ts
+++ b/tests/unit/components/NcAppNavigationSearch/NcAppNavigationSearch.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+import NcAppNavigationSearch from '../../../../src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue'
+
+function findClearButton(wrapper) {
+	return wrapper.find('button[aria-label="Clear search"]')
+}
+function mountWrapped(value = '') {
+	return mount(defineComponent({
+		components: {
+			NcAppNavigationSearch,
+		},
+		data() {
+			return {
+				value,
+			}
+		},
+		template: '<NcAppNavigationSearch v-model="value" />',
+	}))
+}
+
+describe('NcAppNavigationSearch', () => {
+	it('does not show the clear button for an empty search', () => {
+		const wrapper = mountWrapped()
+
+		expect(findClearButton(wrapper).exists()).toBe(false)
+	})
+
+	it('only shows the clear button once the search has content', async () => {
+		const wrapper = mountWrapped()
+
+		await wrapper.get('input').setValue('a')
+
+		expect(findClearButton(wrapper).exists()).toBe(true)
+	})
+
+	it('hides the clear button again after clearing the search', async () => {
+		const wrapper = mountWrapped('test')
+
+		await findClearButton(wrapper).trigger('click')
+
+		expect(findClearButton(wrapper).exists()).toBe(false)
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

- Fixes the x clear button being there all the time in the search field
- Now adjusted to the behavior of any common platform: x is only present when content is in the field (no matter if field is focused or not)
- The CSS is to prevent the jump in width of the field when the trailing icon is shown or not (see iteration prompt)

### 🖼️ Screenshots

**🏚️ Before**

[search before.webm](https://github.com/user-attachments/assets/61405559-fd01-4a66-8afb-9e32f33367a9)

**🏡 After**

[search after.webm](https://github.com/user-attachments/assets/3bf8b4fa-05ee-4368-8bbc-bf098a9e9a27)


### 🚧 Tasks

- [ ] Has to be checked with the Files app. I didn’t manage to link it up locally with the npm pack strategy apparently due to the `/build/frontend-legacy` folder taking precedence and being unable to resolve that.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable


---

AI-assisted: GitHub Copilot (OpenAI GPT-5.4)

> **Prompt:**
> In the NcAppNavigationSearch component, the close/delete icon in the search field should not be shown by default. It should only appear when there is content in the field, like at least 1 character typed in.
>
> **Iteration:**
> The change works as intended, except that now the width of the search bar jumps. This is because ".input-field--trailing-icon" adds some "--input-padding-end". Please make sure 
that there is no width jumping caused by showing or not showing the clear icon of the search field.