### PR TITLE
ci(dependabot): bring back Nextcloud command approve

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -50,6 +50,13 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Nextcloud bot approve
+      - name: Nextcloud Bot approve
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
+        with:
+          github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
+
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # v2.0.0


### PR DESCRIPTION
### ☑️ Resolves

- Ref: https://github.com/nextcloud-libraries/nextcloud-vue/pull/8368/
- Example: https://github.com/nextcloud-libraries/nextcloud-vue/pull/8460

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
