### PR TITLE
chore: Add .tgz files generated by 'npm pack' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ yarn-error.log*
 
 .marginalia
 
+# npm pack output
+nextcloud-vue-*.tgz
+
 # Unit test / coverage reports
 coverage
 


### PR DESCRIPTION
### ☑️ Resolves

- In the README at https://github.com/nextcloud-libraries/nextcloud-vue#%EF%B8%8F-development-with-nextcloud-apps there is a warning not to commit the .tgz files generated by `npm pack`
- This just adds them to the `.gitignore` to prevent errors.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
