### PR TITLE
feat(NcPopover): expose distance and skidding props

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -183,7 +183,8 @@ See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
 		:boundary="boundary || undefined"
 		:container
 		:delay
-		:distance="10"
+		:distance
+		:skidding
 		handleResize
 		:noAutoFocus="true /* Handled by the focus trap */"
 		:placement="internalPlacement"
@@ -281,6 +282,28 @@ export default {
 		 */
 		delay: {
 			type: [Number, Object],
+			default: 0,
+		},
+
+		/**
+		 * Distance in pixels between the popover and the trigger element.
+		 *
+		 * @type {number}
+		 */
+		distance: {
+			type: Number,
+			default: 10,
+		},
+
+		/**
+		 * Skidding (offset along the trigger axis) in pixels. For a `bottom-start`
+		 * placement, positive values shift the popover toward the end of the trigger,
+		 * negative values toward the start.
+		 *
+		 * @type {number}
+		 */
+		skidding: {
+			type: Number,
 			default: 0,
 		},
 


### PR DESCRIPTION
floating-vue's `<Dropdown>` accepts `distance` and `skidding` for nudging the popper relative to the trigger. NcPopover hardcodes `distance` to `10` and never passes `skidding` through, so consumers can't shift a popover without CSS hacks that confuse the positioning math. Defaults are preserved, so this is non-breaking.

### Resolves

Needed for the redesigned app launcher in nextcloud/server#59888.

### Screenshots

No visual change with defaults.

### Tasks

- [x] Add `distance` and `skidding` props
- [x] Forward both to `<Dropdown>`

### Checklist

- [ ] Tests included or not applicable: not applicable. Defaults match the previous hardcoded values, so existing tests still cover the default path.
- [x] Component documentation extended/updated or not applicable: prop JSDoc added, styleguidist picks it up automatically.
- [ ] Backport to `stable8` for Vue 2 or not applicable: additive and non-breaking. Happy to backport if needed.
