### PR TITLE
[stable8] feat(NcAppSettingsDialog): new navigation design

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -14,6 +14,7 @@ import NcVNodes from '../NcVNodes/NcVNodes.vue'
 import NcAppSettingsDialogVersion from './NcAppSettingsDialogVersion.vue'
 import { useIsMobile } from '../../composables/useIsMobile/index.ts'
 import { t } from '../../l10n.js'
+import { isLegacy34 } from '../../utils/legacy.ts'
 import { APP_SETTINGS_LEGACY_DESIGN_KEY, APP_SETTINGS_REGISTRATION_KEY } from './useAppSettingsDialog.ts'
 
 export interface IAppSettingsSection {
@@ -215,6 +216,7 @@ function unregisterSection(id: string) {
 	<NcDialog
 		v-if="open"
 		class="app-settings"
+		:class="{ 'app-settings--legacy': isLegacy34 }"
 		:content-classes="['app-settings__content', { 'app-settings__non-legacy': !legacy }]"
 		navigation-classes="app-settings__navigation"
 		:additional-trap-elements="additionalTrapElements"
@@ -225,6 +227,9 @@ function unregisterSection(id: string) {
 		:name="name"
 		@update:open="handleCloseModal">
 		<template v-if="hasNavigation" #navigation="{ isCollapsed }">
+			<div v-if="!isLegacy34" class="app-settings__title">
+				{{ name }}
+			</div>
 			<ul
 				v-if="!isCollapsed"
 				class="navigation-list">
@@ -258,76 +263,215 @@ function unregisterSection(id: string) {
 </template>
 
 <style lang="scss" scoped>
-.app-settings {
+$navigation-width: 200px;
+$content-inset: calc(3 * var(--default-grid-baseline));
+
+.app-settings:not(.app-settings--legacy) {
+	--nav-tint: hsl(from var(--color-primary-element-light) h s calc(l * 1.045));
+	--nav-tint-strong: var(--color-primary-element-light);
+
+	:deep(.modal-wrapper .modal-container) {
+		padding-inline-start: 0 !important;
+		padding-block-start: 0 !important;
+		background-color: var(--nav-tint);
+		overflow: hidden;
+		max-width: 900px;
+	}
+
+	:deep(.dialog__name) {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		padding: 0;
+		overflow: hidden;
+		clip-path: inset(100%);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.app-settings__title {
+		box-sizing: border-box;
+		padding: $content-inset;
+		margin: 0;
+		font-size: 20px;
+		font-weight: 700;
+	}
+
+	:deep(.app-settings__navigation) {
+		min-width: $navigation-width;
+		max-width: $navigation-width;
+		flex: 0 0 $navigation-width;
+		margin-right: 0 !important;
+		overflow-x: hidden;
+		overflow-y: auto;
+		position: relative;
+		background-color: var(--nav-tint);
+	}
+
+	:deep(.app-settings__content) {
+		box-sizing: border-box;
+		padding: $content-inset;
+		background-color: var(--color-main-background);
+		border-inline-start: 1px solid var(--color-border-dark);
+		border-start-start-radius: var(--border-radius-element);
+		border-end-start-radius: var(--border-radius-element);
+	}
+
+	.navigation-list {
+		height: 100%;
+		box-sizing: border-box;
+		overflow-y: auto;
+		padding: var(--default-grid-baseline);
+
+		&__link {
+			position: relative;
+			display: flex;
+			align-items: center;
+			font-size: var(--default-font-size);
+			font-weight: 500;
+			height: var(--default-clickable-area);
+			margin: 2px 0;
+			line-height: var(--default-clickable-area);
+			border-radius: var(--border-radius-element, var(--border-radius-pill));
+			padding-inline: calc(2 * var(--default-grid-baseline));
+			cursor: pointer;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			background-color: transparent;
+			border: none;
+			color: var(--color-main-text);
+
+			&:hover,
+			&:focus-visible {
+				background-color: color-mix(in srgb, var(--color-primary-element) 8%, transparent);
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--color-main-text);
+				outline-offset: -2px;
+			}
+
+			&--active {
+				background-color: var(--nav-tint-strong);
+
+				&:hover,
+				&:focus-visible {
+					background-color: var(--color-primary-element-light-hover);
+				}
+
+				&::before {
+					content: '';
+					position: absolute;
+					inset-block: var(--default-grid-baseline);
+					inset-inline-start: 0;
+					width: 3px;
+					background-color: var(--color-primary-element);
+					border-radius: 999px;
+				}
+			}
+
+			&--icon {
+				gap: var(--default-grid-baseline);
+			}
+
+			&-icon {
+				display: flex;
+				justify-content: center;
+				align-content: center;
+				width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+				max-width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+			}
+		}
+	}
+}
+
+:deep(.app-settings__content.app-settings__non-legacy) * {
+	box-sizing: border-box;
+}
+
+@media only screen and (max-width: $breakpoint-mobile) {
+	.app-settings:not(.app-settings--legacy) {
+		:deep(.modal-wrapper .modal-container) {
+			padding-inline-start: 12px !important;
+			padding-block-start: 4px !important;
+			background-color: var(--color-main-background);
+		}
+		:deep(.dialog__name) {
+			position: static;
+			width: auto;
+			height: auto;
+			margin: 0 0 12px 0;
+			padding-inline-end: var(--default-clickable-area);
+			overflow: visible;
+			clip-path: none;
+			white-space: normal;
+			border: 0;
+		}
+		:deep(.app-settings__content) {
+			border: none;
+			border-radius: 0;
+		}
+	}
+}
+
+.app-settings.app-settings--legacy {
 	:deep(.app-settings__navigation) {
 		min-width: 200px;
-		margin-right: calc(4 * var(--default-grid-baseline));
+		margin-inline-end: calc(4 * var(--default-grid-baseline));
 		overflow-x: hidden;
 		overflow-y: auto;
 		position: relative;
 	}
 
 	:deep(.app-settings__content) {
-		box-sizing: border-box;
 		padding-inline: calc(4 * var(--default-grid-baseline));
-
-		&.app-settings__non-legacy * {
-			box-sizing: border-box;
-		}
 	}
-}
 
-.navigation-list {
-	height: 100%;
-	box-sizing: border-box;
-	overflow-y: auto;
-	padding: calc(3 * var(--default-grid-baseline));
+	.navigation-list {
+		height: 100%;
+		overflow-y: auto;
+		padding: calc(3 * var(--default-grid-baseline));
 
-	&__link {
-		display: flex;
-		align-content: center;
-		font-size: 16px;
-		height: var(--default-clickable-area);
-		margin: 4px 0;
-		line-height: var(--default-clickable-area);
-		border-radius: var(--border-radius-element, var(--border-radius-pill));
-		font-weight: bold;
-		padding: 0 calc(4 * var(--default-grid-baseline));
-		cursor: pointer;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		overflow: hidden;
-		background-color: transparent;
-		border: none;
-
-		&:hover,
-		&:focus {
-			background-color: var(--color-background-hover);
-		}
-
-		&--active {
-			background-color: var(--color-primary-element-light) !important;
-		}
-
-		&--icon {
-			padding-inline-start: calc(2 * var(--default-grid-baseline));
-			gap: var(--default-grid-baseline);
-		}
-
-		&-icon {
+		&__link {
 			display: flex;
-			justify-content: center;
 			align-content: center;
-			width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
-			max-width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
-		}
-	}
-}
+			font-size: 16px;
+			height: var(--default-clickable-area);
+			margin: 4px 0;
+			line-height: var(--default-clickable-area);
+			border-radius: var(--border-radius-element, var(--border-radius-pill));
+			font-weight: var(--font-weight-element, bold);
+			padding: 0 calc(4 * var(--default-grid-baseline));
+			cursor: pointer;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			background-color: transparent;
+			border: none;
 
-@media only screen and (max-width: $breakpoint-small-mobile) {
-	.app-settings {
-		:deep .dialog__name {
-			padding-inline-start: 16px;
+			&:hover,
+			&:focus {
+				background-color: var(--color-background-hover);
+			}
+
+			&--active {
+				background-color: var(--color-primary-element-light) !important;
+			}
+
+			&--icon {
+				padding-inline-start: calc(2 * var(--default-grid-baseline));
+				gap: var(--default-grid-baseline);
+			}
+
+			&-icon {
+				display: flex;
+				justify-content: center;
+				align-content: center;
+				width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+				max-width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+			}
 		}
 	}
 }

--- a/src/utils/legacy.ts
+++ b/src/utils/legacy.ts
@@ -3,5 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-const version = window.OC?.config?.version?.split('.')[0] || '32'
-export const isLegacy32 = Number.parseInt(version) < 32
+const version = window.OC?.config?.version?.split('.')[0] || '34'
+const major = Number.parseInt(version)
+export const isLegacy32 = major < 32
+export const isLegacy34 = major < 34


### PR DESCRIPTION
The settings dialog title now sits over a tinted navigation column on the inline-start edge of the dialog, replacing the centered header. Navigation links use the default button weight with a rounded inline-start stripe on the active item.

Backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/8477

