### PR TITLE
[stable8] fix(NcAppNavigation): Restore opaque background on mobile

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -467,6 +467,9 @@ export default {
 	.app-navigation {
 		position: absolute;
 		border-inline-end: 1px solid var(--color-border);
+		background-color: var(--color-main-background-blur, var(--color-main-background));
+		-webkit-backdrop-filter: var(--filter-background-blur, none);
+		backdrop-filter: var(--filter-background-blur, none);
 	}
 }
 


### PR DESCRIPTION
The mobile navigation slides in over the content area, where the content wrapper's frosted chrome no longer backs it. The drawer was appearing transparent and the page underneath bled through. The overlay now has its own opaque blurred background again.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="747" height="954" alt="Screenshot From 2026-05-07 19-41-39" src="https://github.com/user-attachments/assets/1c2ae8d2-ace4-48dd-94de-e794436ab4c6" /> | <img width="747" height="954" alt="Screenshot From 2026-05-07 19-37-41" src="https://github.com/user-attachments/assets/508cb9d3-01e0-43a1-acac-e7158796a7d2" />

