### PR TITLE
fix: use correct boundaries of CSS breakpoints

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -419,7 +419,7 @@ function handleEsc(): void {
 }
 
 // When on mobile, we make the navigation slide over the NcAppContent
-@media only screen and (max-width: $breakpoint-mobile) {
+@media only screen and (width < $breakpoint-mobile) {
 	.app-navigation {
 		position: absolute;
 		border-inline-end: 1px solid var(--color-border);

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -388,7 +388,7 @@ $content-inset: calc(3 * var(--default-grid-baseline));
 
 }
 
-@media only screen and (max-width: $breakpoint-mobile) {
+@media only screen and (width < $breakpoint-mobile) {
 	.app-settings:not(.app-settings--legacy) {
 		:deep(.modal-wrapper .modal-container) {
 			padding-inline-start: 12px !important;


### PR DESCRIPTION
### ☑️ Resolves

We mixed up breakpoints in the source code, sometimes mobile is `max-width 1024`, and sometimes `width < 1024`.
Meaning sometimes mobile is `<= 1024` sometimes `< 1024`.

This now is consistent `mobile: width < 1024`.

Follow-up on https://github.com/nextcloud/server/pull/57010

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
