### PR TITLE
feat(referencePicker): introduce getReferenceWithPicker()

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcCustomPickerElement.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcCustomPickerElement.vue
@@ -29,7 +29,7 @@ export default {
 	emits: [
 		'cancel',
 		'submit',
-		'submitReference',
+		'pick',
 	],
 
 	data() {
@@ -63,14 +63,14 @@ export default {
 				this.renderResult = result
 				if (this.renderResult.object?._isVue && this.renderResult.object?.$on) {
 					this.renderResult.object.$on('submit', this.onSubmit)
-					this.renderResult.object.$on('submitReference', this.onSubmitReference)
+					this.renderResult.object.$on('pick', this.onPick)
 					this.renderResult.object.$on('cancel', this.onCancel)
 				}
 				this.renderResult.element.addEventListener('submit', (e) => {
 					this.onSubmit(e.detail)
 				})
-				this.renderResult.element.addEventListener('submitReference', (e) => {
-					this.onSubmitReference(e.detail)
+				this.renderResult.element.addEventListener('pick', (e) => {
+					this.onPick(e.detail)
 				})
 				this.renderResult.element.addEventListener('cancel', this.onCancel)
 			})
@@ -80,8 +80,8 @@ export default {
 			this.$emit('submit', value)
 		},
 
-		onSubmitReference(value) {
-			this.$emit('submitReference', value)
+		onPick(value) {
+			this.$emit('pick', value)
 		},
 
 		onCancel() {

--- a/src/components/NcRichText/NcReferencePicker/NcCustomPickerElement.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcCustomPickerElement.vue
@@ -29,6 +29,7 @@ export default {
 	emits: [
 		'cancel',
 		'submit',
+		'submitReference',
 	],
 
 	data() {
@@ -62,12 +63,14 @@ export default {
 				this.renderResult = result
 				if (this.renderResult.object?._isVue && this.renderResult.object?.$on) {
 					this.renderResult.object.$on('submit', this.onSubmit)
+					this.renderResult.object.$on('submitReference', this.onSubmitReference)
 					this.renderResult.object.$on('cancel', this.onCancel)
 				}
 				this.renderResult.element.addEventListener('submit', (e) => {
-					const detail = e.detail
-					const result = typeof detail === 'string' ? { link: detail } : detail
-					this.onSubmit(result)
+					this.onSubmit(e.detail)
+				})
+				this.renderResult.element.addEventListener('submitReference', (e) => {
+					this.onSubmitReference(e.detail)
 				})
 				this.renderResult.element.addEventListener('cancel', this.onCancel)
 			})
@@ -75,6 +78,10 @@ export default {
 
 		onSubmit(value) {
 			this.$emit('submit', value)
+		},
+
+		onSubmitReference(value) {
+			this.$emit('submitReference', value)
 		},
 
 		onCancel() {

--- a/src/components/NcRichText/NcReferencePicker/NcCustomPickerElement.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcCustomPickerElement.vue
@@ -65,7 +65,9 @@ export default {
 					this.renderResult.object.$on('cancel', this.onCancel)
 				}
 				this.renderResult.element.addEventListener('submit', (e) => {
-					this.onSubmit(e.detail)
+					const detail = e.detail
+					const result = typeof detail === 'string' ? { link: detail } : detail
+					this.onSubmit(result)
 				})
 				this.renderResult.element.addEventListener('cancel', this.onCancel)
 			})

--- a/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
@@ -101,7 +101,7 @@ export default {
 		onProviderSelected(p) {
 			if (p !== null) {
 				if (p.isLink) {
-					this.$emit('submit', p.title)
+					this.$emit('submit', { link: p.title })
 				} else {
 					this.$emit('selectProvider', p)
 				}

--- a/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
@@ -65,6 +65,7 @@ export default {
 	emits: [
 		'selectProvider',
 		'submit',
+		'submitReference',
 	],
 
 	data() {
@@ -101,7 +102,8 @@ export default {
 		onProviderSelected(p) {
 			if (p !== null) {
 				if (p.isLink) {
-					this.$emit('submit', { link: p.title })
+					this.$emit('submit', p.title)
+					this.$emit('submitReference', { link: p.title })
 				} else {
 					this.$emit('selectProvider', p)
 				}

--- a/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
@@ -65,7 +65,7 @@ export default {
 	emits: [
 		'selectProvider',
 		'submit',
-		'submitReference',
+		'pick',
 	],
 
 	data() {
@@ -103,7 +103,7 @@ export default {
 			if (p !== null) {
 				if (p.isLink) {
 					this.$emit('submit', p.title)
-					this.$emit('submitReference', { link: p.title })
+					this.$emit('pick', { link: p.title })
 				} else {
 					this.$emit('selectProvider', p)
 				}

--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -71,6 +71,7 @@ export default {
 
 	emits: [
 		'submit',
+		'submitReference',
 	],
 
 	data() {
@@ -101,7 +102,8 @@ export default {
 		onSubmit(e) {
 			const value = e.target.value
 			if (this.isLinkValid) {
-				this.$emit('submit', { link: value })
+				this.$emit('submit', value)
+				this.$emit('submitReference', { link: value })
 			}
 		},
 

--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -101,7 +101,7 @@ export default {
 		onSubmit(e) {
 			const value = e.target.value
 			if (this.isLinkValid) {
-				this.$emit('submit', value)
+				this.$emit('submit', { link: value })
 			}
 		},
 

--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -71,7 +71,7 @@ export default {
 
 	emits: [
 		'submit',
-		'submitReference',
+		'pick',
 	],
 
 	data() {
@@ -103,7 +103,7 @@ export default {
 			const value = e.target.value
 			if (this.isLinkValid) {
 				this.$emit('submit', value)
-				this.$emit('submitReference', { link: value })
+				this.$emit('pick', { link: value })
 			}
 		},
 

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
@@ -14,19 +14,22 @@
 			ref="provider-list"
 			@selectProvider="onProviderSelected"
 			@submit="submitLink"
+			@submitReference="submitReference"
 			@cancel="cancelProviderSelection" />
 		<NcRawLinkInput
 			v-else-if="mode === MODES.standardLinkInput"
 			ref="url-input"
 			:provider="selectedProvider"
 			@submit="submitLink"
+			@submitReference="submitReference"
 			@cancel="cancelRawLinkInput" />
 		<NcSearch
 			v-else-if="mode === MODES.searchInput"
 			ref="url-input"
 			:provider="selectedProvider"
-			@cancel="cancelSearch"
-			@submit="submitLink" />
+			@submit="submitLink"
+			@submitReference="submitReference"
+			@cancel="cancelSearch" />
 		<div
 			v-else-if="mode === MODES.customElement"
 			class="custom-element-wrapper">
@@ -34,6 +37,7 @@
 				:provider="selectedProvider"
 				class="custom-element"
 				@submit="submitLink"
+				@submitReference="submitReference"
 				@cancel="cancelCustomElement" />
 		</div>
 	</div>
@@ -97,6 +101,7 @@ export default {
 		'cancelSearch',
 		'providerSelected',
 		'submit',
+		'submitReference',
 	],
 
 	data() {
@@ -173,11 +178,19 @@ export default {
 			this.$emit('cancel')
 		},
 
-		submitLink(result) {
+		submitLink(link) {
 			if (this.selectedProvider !== null) {
 				touchProvider(this.selectedProvider.id)
 			}
-			this.$emit('submit', result)
+			this.$emit('submit', link)
+			this.deselectProvider()
+		},
+
+		submitReference(reference) {
+			if (this.selectedProvider !== null) {
+				touchProvider(this.selectedProvider.id)
+			}
+			this.$emit('submitReference', reference)
 			this.deselectProvider()
 		},
 

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
@@ -14,21 +14,21 @@
 			ref="provider-list"
 			@selectProvider="onProviderSelected"
 			@submit="submitLink"
-			@submitReference="submitReference"
+			@pick="pickLink"
 			@cancel="cancelProviderSelection" />
 		<NcRawLinkInput
 			v-else-if="mode === MODES.standardLinkInput"
 			ref="url-input"
 			:provider="selectedProvider"
 			@submit="submitLink"
-			@submitReference="submitReference"
+			@pick="pickLink"
 			@cancel="cancelRawLinkInput" />
 		<NcSearch
 			v-else-if="mode === MODES.searchInput"
 			ref="url-input"
 			:provider="selectedProvider"
 			@submit="submitLink"
-			@submitReference="submitReference"
+			@pick="pickLink"
 			@cancel="cancelSearch" />
 		<div
 			v-else-if="mode === MODES.customElement"
@@ -37,7 +37,7 @@
 				:provider="selectedProvider"
 				class="custom-element"
 				@submit="submitLink"
-				@submitReference="submitReference"
+				@pick="pickLink"
 				@cancel="cancelCustomElement" />
 		</div>
 	</div>
@@ -101,7 +101,7 @@ export default {
 		'cancelSearch',
 		'providerSelected',
 		'submit',
-		'submitReference',
+		'pick',
 	],
 
 	data() {
@@ -186,11 +186,11 @@ export default {
 			this.deselectProvider()
 		},
 
-		submitReference(reference) {
+		pickLink(reference) {
 			if (this.selectedProvider !== null) {
 				touchProvider(this.selectedProvider.id)
 			}
-			this.$emit('submitReference', reference)
+			this.$emit('pick', reference)
 			this.deselectProvider()
 		},
 

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
@@ -173,11 +173,11 @@ export default {
 			this.$emit('cancel')
 		},
 
-		submitLink(link) {
+		submitLink(result) {
 			if (this.selectedProvider !== null) {
 				touchProvider(this.selectedProvider.id)
 			}
-			this.$emit('submit', link)
+			this.$emit('submit', result)
 			this.deselectProvider()
 		},
 

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -41,7 +41,7 @@
 				:focusOnCreate="focusOnCreate"
 				@providerSelected="onProviderSelect"
 				@submit="onSubmit"
-				@submitReference="onSubmitReference"
+				@pick="onPick"
 				@cancel="onCancel" />
 		</div>
 	</NcModal>
@@ -97,7 +97,7 @@ export default {
 	emits: [
 		'cancel',
 		'submit',
-		'submitReference',
+		'pick',
 	],
 
 	data() {
@@ -154,9 +154,9 @@ export default {
 			this.$emit('submit', value)
 		},
 
-		onSubmitReference(value) {
+		onPick(value) {
 			this.show = false
-			this.$emit('submitReference', value)
+			this.$emit('pick', value)
 		},
 
 		onProviderSelect(provider) {

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -41,6 +41,7 @@
 				:focusOnCreate="focusOnCreate"
 				@providerSelected="onProviderSelect"
 				@submit="onSubmit"
+				@submitReference="onSubmitReference"
 				@cancel="onCancel" />
 		</div>
 	</NcModal>
@@ -96,6 +97,7 @@ export default {
 	emits: [
 		'cancel',
 		'submit',
+		'submitReference',
 	],
 
 	data() {
@@ -150,6 +152,11 @@ export default {
 		onSubmit(value) {
 			this.show = false
 			this.$emit('submit', value)
+		},
+
+		onSubmitReference(value) {
+			this.show = false
+			this.$emit('submitReference', value)
 		},
 
 		onProviderSelect(provider) {

--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -122,7 +122,7 @@ export default {
 
 	emits: [
 		'submit',
-		'submitReference',
+		'pick',
 	],
 
 	data() {
@@ -253,7 +253,7 @@ export default {
 					if (item.title) {
 						reference.title = item.title
 					}
-					this.$emit('submitReference', reference)
+					this.$emit('pick', reference)
 				} else if (item.isMore) {
 					this.searchMoreOf(item.providerId).then(() => {
 						// allow clicking twice on the same "more" item

--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -249,7 +249,11 @@ export default {
 				if (item.resourceUrl) {
 					this.cancelSearchRequests()
 					this.$emit('submit', item.resourceUrl)
-					this.$emit('submitReference', { link: item.resourceUrl, title: item.title })
+					const reference = { link: item.resourceUrl }
+					if (item.title) {
+						reference.title = item.title
+					}
+					this.$emit('submitReference', reference)
 				} else if (item.isMore) {
 					this.searchMoreOf(item.providerId).then(() => {
 						// allow clicking twice on the same "more" item

--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -122,6 +122,7 @@ export default {
 
 	emits: [
 		'submit',
+		'submitReference',
 	],
 
 	data() {
@@ -248,6 +249,7 @@ export default {
 				if (item.resourceUrl) {
 					this.cancelSearchRequests()
 					this.$emit('submit', item.resourceUrl)
+					this.$emit('submitReference', { link: item.resourceUrl, title: item.title })
 				} else if (item.isMore) {
 					this.searchMoreOf(item.providerId).then(() => {
 						// allow clicking twice on the same "more" item

--- a/src/components/NcRichText/index.ts
+++ b/src/components/NcRichText/index.ts
@@ -22,7 +22,7 @@ import {
 	searchProvider,
 	sortProviders,
 } from '../../functions/reference/providerHelper.ts'
-import { getLinkWithPicker } from '../../functions/reference/referencePickerModal.ts'
+import { getLinkWithPicker, getReferenceWithPicker } from '../../functions/reference/referencePickerModal.ts'
 import { isWidgetRegistered, registerWidget, renderWidget } from './../../functions/reference/widgets.ts'
 
 export default NcRichText
@@ -32,6 +32,7 @@ export {
 	getLinkWithPicker,
 	getProvider,
 	getProviders,
+	getReferenceWithPicker,
 	isCustomPickerElementRegistered,
 	isWidgetRegistered,
 	NcCustomPickerRenderResult,

--- a/src/functions/reference/index.ts
+++ b/src/functions/reference/index.ts
@@ -13,7 +13,10 @@ export {
 	renderWidget,
 } from './widgets.ts'
 
-export { getLinkWithPicker } from './referencePickerModal.ts'
+export {
+	getLinkWithPicker,
+	getReferenceWithPicker,
+} from './referencePickerModal.ts'
 
 export {
 	type ReferenceProvider,

--- a/src/functions/reference/referencePickerModal.ts
+++ b/src/functions/reference/referencePickerModal.ts
@@ -44,7 +44,9 @@ export async function getLinkWithPicker(providerId?: string, isInsideViewer?: bo
  * The function guarantees a `link: string` on the resolved object. Custom picker elements may
  * include additional fields (e.g. `title`).
  *
- * @template T - Expected shape of the resolved reference, mus extend `PickerReference`
+ * @experimental The shape of the resolved reference and the signature of this function may still change.
+ *
+ * @template T - Expected shape of the resolved reference, must include `link: string`
  * @param providerId - Optional ID of initial selected provider
  * @param isInsideViewer - Should be true if this function is called while the Viewer is displayed
  */
@@ -63,7 +65,7 @@ export async function getReferenceWithPicker<T extends { link: string }>(provide
 			view.unmount()
 			reject(new Error('User cancellation'))
 		},
-		onSubmitReference(reference: T) {
+		onPick(reference: T) {
 			view.unmount()
 			resolve(reference)
 		},

--- a/src/functions/reference/referencePickerModal.ts
+++ b/src/functions/reference/referencePickerModal.ts
@@ -7,7 +7,7 @@ import { createApp } from 'vue'
 import NcReferencePickerModal from './../../components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue'
 import { getProvider } from './providerHelper.js'
 
-type PickerSubmitResult = {
+type PickerReference = {
 	link: string
 	title?: string
 }
@@ -33,9 +33,9 @@ export async function getLinkWithPicker(providerId?: string, isInsideViewer?: bo
 			view.unmount()
 			reject(new Error('User cancellation'))
 		},
-		onSubmit(result: string | PickerSubmitResult) {
+		onSubmit(link: string) {
 			view.unmount()
-			resolve(typeof result === 'string' ? result : result.link)
+			resolve(link)
 		},
 	})
 	view.mount(modalElement)
@@ -49,13 +49,13 @@ export async function getLinkWithPicker(providerId?: string, isInsideViewer?: bo
  * @param providerId - Optional ID of initial selected provider
  * @param isInsideViewer - Should be true if this function is called while the Viewer is displayed
  */
-export async function getReferenceWithPicker(providerId?: string, isInsideViewer?: boolean): Promise<PickerSubmitResult> {
+export async function getReferenceWithPicker(providerId?: string, isInsideViewer?: boolean): Promise<PickerReference> {
 	const modalId = 'referencePickerModal'
 	const modalElement = document.createElement('div')
 	modalElement.id = modalId
 	document.body.append(modalElement)
 
-	const { promise, reject, resolve } = Promise.withResolvers<PickerSubmitResult>()
+	const { promise, reject, resolve } = Promise.withResolvers<PickerReference>()
 	const initialProvider = (providerId && getProvider(providerId)) || null
 	const view = createApp(NcReferencePickerModal, {
 		initialProvider,
@@ -64,9 +64,9 @@ export async function getReferenceWithPicker(providerId?: string, isInsideViewer
 			view.unmount()
 			reject(new Error('User cancellation'))
 		},
-		onSubmit(result: string | PickerSubmitResult) {
+		onSubmitReference(reference: PickerReference) {
 			view.unmount()
-			resolve(typeof result === 'string' ? { link: result } : result)
+			resolve(reference)
 		},
 	})
 	view.mount(modalElement)

--- a/src/functions/reference/referencePickerModal.ts
+++ b/src/functions/reference/referencePickerModal.ts
@@ -7,8 +7,13 @@ import { createApp } from 'vue'
 import NcReferencePickerModal from './../../components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue'
 import { getProvider } from './providerHelper.js'
 
+type PickerSubmitResult = {
+	link: string
+	title?: string
+}
+
 /**
- * Creates a reference picker modal and return a promise which provides the result
+ * Creates a reference picker modal and return a promise which provides the link URL
  *
  * @param providerId - Optional ID of initial selected provider
  * @param isInsideViewer - Should be true if this function is called while the Viewer is displayed
@@ -28,9 +33,40 @@ export async function getLinkWithPicker(providerId?: string, isInsideViewer?: bo
 			view.unmount()
 			reject(new Error('User cancellation'))
 		},
-		onSubmit(link: string) {
+		onSubmit(result: string | PickerSubmitResult) {
 			view.unmount()
-			resolve(link)
+			resolve(typeof result === 'string' ? result : result.link)
+		},
+	})
+	view.mount(modalElement)
+
+	return promise
+}
+
+/**
+ * Creates a reference picker modal and return a promise which provides the reference object
+ *
+ * @param providerId - Optional ID of initial selected provider
+ * @param isInsideViewer - Should be true if this function is called while the Viewer is displayed
+ */
+export async function getReferenceWithPicker(providerId?: string, isInsideViewer?: boolean): Promise<PickerSubmitResult> {
+	const modalId = 'referencePickerModal'
+	const modalElement = document.createElement('div')
+	modalElement.id = modalId
+	document.body.append(modalElement)
+
+	const { promise, reject, resolve } = Promise.withResolvers<PickerSubmitResult>()
+	const initialProvider = (providerId && getProvider(providerId)) || null
+	const view = createApp(NcReferencePickerModal, {
+		initialProvider,
+		isInsideViewer,
+		onCancel() {
+			view.unmount()
+			reject(new Error('User cancellation'))
+		},
+		onSubmit(result: string | PickerSubmitResult) {
+			view.unmount()
+			resolve(typeof result === 'string' ? { link: result } : result)
 		},
 	})
 	view.mount(modalElement)

--- a/src/functions/reference/referencePickerModal.ts
+++ b/src/functions/reference/referencePickerModal.ts
@@ -7,11 +7,6 @@ import { createApp } from 'vue'
 import NcReferencePickerModal from './../../components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue'
 import { getProvider } from './providerHelper.js'
 
-type PickerReference = {
-	link: string
-	title?: string
-}
-
 /**
  * Creates a reference picker modal and return a promise which provides the link URL
  *
@@ -44,18 +39,22 @@ export async function getLinkWithPicker(providerId?: string, isInsideViewer?: bo
 }
 
 /**
- * Creates a reference picker modal and return a promise which provides the reference object
+ * Creates a reference picker modal and return a promise which provides the reference object.
  *
+ * The function guarantees a `link: string` on the resolved object. Custom picker elements may
+ * include additional fields (e.g. `title`).
+ *
+ * @template T - Expected shape of the resolved reference, mus extend `PickerReference`
  * @param providerId - Optional ID of initial selected provider
  * @param isInsideViewer - Should be true if this function is called while the Viewer is displayed
  */
-export async function getReferenceWithPicker(providerId?: string, isInsideViewer?: boolean): Promise<PickerReference> {
+export async function getReferenceWithPicker<T extends { link: string }>(providerId?: string, isInsideViewer?: boolean): Promise<T> {
 	const modalId = 'referencePickerModal'
 	const modalElement = document.createElement('div')
 	modalElement.id = modalId
 	document.body.append(modalElement)
 
-	const { promise, reject, resolve } = Promise.withResolvers<PickerReference>()
+	const { promise, reject, resolve } = Promise.withResolvers<T>()
 	const initialProvider = (providerId && getProvider(providerId)) || null
 	const view = createApp(NcReferencePickerModal, {
 		initialProvider,
@@ -64,7 +63,7 @@ export async function getReferenceWithPicker(providerId?: string, isInsideViewer
 			view.unmount()
 			reject(new Error('User cancellation'))
 		},
-		onSubmitReference(reference: PickerReference) {
+		onSubmitReference(reference: T) {
 			view.unmount()
 			resolve(reference)
 		},


### PR DESCRIPTION
Required for Text and Collectives to pass the link title from the picker (e.g. Collectives PagePicker.vue) to the consumer (menubar in Text).

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
