### PR TITLE
fix(NcAppNavigationItem): Make active state darker than hover

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -34,10 +34,10 @@
 	// !important so :focus-within does not override the active state.
 	// New design (NC34+): glassy tinted bg + inline-start stripe.
 	&:not(.app-navigation-entry--legacy).active {
-		background-color: var(--color-primary-element-light) !important;
+		background-color: color-mix(in srgb, var(--color-primary-element) 16%, transparent) !important;
 
 		&:hover {
-			background-color: var(--color-primary-element-light-hover) !important;
+			background-color: color-mix(in srgb, var(--color-primary-element) 22%, transparent) !important;
 		}
 
 		&:not(.app-navigation-entry--editing) {


### PR DESCRIPTION
The selected nav item appeared lighter than the hovered one in the new NC34+ design. Use a semi-transparent darker overlay so the active state sits visually below hover, matching the mockup intent.

Resolves #8526



### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="344" height="159" alt="Screenshot From 2026-05-13 13-44-12" src="https://github.com/user-attachments/assets/ad14faf5-9c92-4759-8ab7-c168efc7ac98" /> | <img width="344" height="159" alt="Screenshot From 2026-05-13 14-19-03" src="https://github.com/user-attachments/assets/62e25d7f-e291-46e3-8f45-6d04df36fae9" />

