### PR TITLE
fix(NcAppContent): background blur may be missing after minification

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -363,7 +363,6 @@ function handleEsc(): void {
 
 	&--legacy {
 		background-color: var(--color-main-background-blur, var(--color-main-background));
-		-webkit-backdrop-filter: var(--filter-background-blur, none);
 		backdrop-filter: var(--filter-background-blur, none);
 	}
 
@@ -424,7 +423,6 @@ function handleEsc(): void {
 		position: absolute;
 		border-inline-end: 1px solid var(--color-border);
 		background-color: var(--color-main-background-blur, var(--color-main-background));
-		-webkit-backdrop-filter: var(--filter-background-blur, none);
 		backdrop-filter: var(--filter-background-blur, none);
 	}
 }

--- a/src/components/NcContent/NcContent.vue
+++ b/src/components/NcContent/NcContent.vue
@@ -254,7 +254,6 @@ function setAppNavigation(value: boolean): void {
 	&:not(&--legacy) {
 		background-color: var(--color-main-background-blur, var(--color-main-background));
 		backdrop-filter: var(--filter-background-blur, none);
-		-webkit-backdrop-filter: var(--filter-background-blur, none);
 	}
 
 	&:not(.with-sidebar--full) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud/spreed/issues/17991
- `-webkit-backdrop-filter` doesn't work in Chromium
- `-webkit-backdrop-filter` should be added by build tools only if needed (according to the browserslist config), we don't need it in the source
- When both prefixed and unprefixed values are present, and prefixed is the second, CSS optimization with LightningCSS (used in Vite and RSPack) keeps the prefixed value only
  - Bug: https://github.com/parcel-bundler/lightningcss/issues/1229

### Screenshots

Before | After
-- | --
<img width="343" height="336" alt="image" src="https://github.com/user-attachments/assets/ce02cc13-e23b-4689-9cba-eea08fdcb76c" /> | <img width="347" height="338" alt="image" src="https://github.com/user-attachments/assets/88b0ec95-ee99-416d-b0cb-30a6a19bbb6c" />


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
