### PR TITLE
fix(NcAppSidebarTab): Reduce pill height

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabsButton.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabsButton.vue
@@ -73,7 +73,7 @@ defineProps<{
 		bottom: 0;
 		left: 50%;
 		width: 0;
-		height: 6px;
+		height: 4px;
 		border-radius: 999px;
 		background-color: var(--color-primary-element);
 		opacity: 0;


### PR DESCRIPTION
Follow-up to #8447

6px may have been a bit too much 😅

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="277" height="67" alt="image" src="https://github.com/user-attachments/assets/621c31a6-82a3-42b5-8db7-b356e89939b6" /> | <img width="277" height="67" alt="image" src="https://github.com/user-attachments/assets/854f9841-c853-4c1c-9b72-cdad6a70104f" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
