### PR TITLE
fix(NcSettingsSection): clear NcAppNavigation toggle overhang

### DIFF
--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -108,12 +108,18 @@ const ariaLabel = t('External documentation')
 <style lang="scss" scoped>
 $maxWidth: 900px;
 $sectionMargin: calc(var(--default-grid-baseline) * 7);
+// Clear the NcAppNavigation toggle overhang on the inline-start edge.
+$sectionMarginStart: max(
+	#{$sectionMargin},
+	calc(var(--app-navigation-padding) + var(--default-clickable-area) + var(--default-grid-baseline) * 2)
+);
 
 .settings-section {
 	display: block;
 	padding: 0 0 calc(var(--default-grid-baseline) * 5) 0;
 	margin: $sectionMargin;
-	width: min($maxWidth, 100% - calc($sectionMargin * 2));
+	margin-inline-start: $sectionMarginStart;
+	width: min($maxWidth, 100% - #{$sectionMarginStart} - $sectionMargin);
 
 	&:not(:last-child) {
 		border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
### Resolves

The `NcAppNavigationToggle` button overlaps the first `NcSettingsSection` heading on Nextcloud settings pages. This PR widen the section's inline-start margin so the heading clears the toggle. Falls back to the existing margin when used without an app navigation.

A companion server [PR](https://github.com/nextcloud/server/pull/60596) covers the legacy markup and Vue 2 line.

### Fix

Widen the inline-start margin using `max()`. With an `NcAppNavigation` present, the formula evaluates to ~60 px and clears the toggle. Embedded without a nav, the `max()` falls back to the existing 28 px and the layout is unchanged.


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="580" height="349" alt="image" src="https://github.com/user-attachments/assets/3b57c34f-8795-43f4-91c8-c28ac9673ced" /> | <img width="580" height="349" alt="image" src="https://github.com/user-attachments/assets/3bf7d762-7a69-4995-94c5-4d4176d27047" />

### 🚧 Tasks

- [ ] Check with design if growing left gutter is OK

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
