### PR TITLE
fix(NcRichText): handle new lines when parsing reference links

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -559,7 +559,9 @@ export default {
 			return processor
 				.use(remarkParse)
 				.use(remarkStripCode)
-				.processSync(text)
+				// replace any whitespace character with literal whitespace for correct parsing
+				// 'mdast-util-to-string' library omits them and followed text is joined to the link
+				.processSync(text.replace(/\s/g, ' '))
 				.value
 		},
 

--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -273,7 +273,7 @@ describe('Foo', () => {
 			},
 		})
 
-		expect(wrapper.findComponent(NcReferenceList).props('text').trim()).toBe('Inline Plain https://example.com/a_b')
+		expect(wrapper.findComponent(NcReferenceList).props('text').trim()).toMatch(/Inline\s.*Plain https:\/\/example.com\/a_b/)
 		expect(axios.get).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent(testUrl)))
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

- Fix parsing the text into reference links
  - Replace whitespace-like characters (new line, caret return, tab) with a whitespace

Test example:
```
https://nextcloud.com/blog/event/nextcloud-talk-vs-microsoft-teams-a-better-alternative/

June 3rd
```

Is fed into `prepareReferenceSource()` as:
```
https://nextcloud.com/blog/event/nextcloud-talk-vs-microsoft-teams-a-better-alternative/\n\nJune 3rd
```

And then `mdast-util-to-string` returns it as:
```
https://nextcloud.com/blog/event/nextcloud-talk-vs-microsoft-teams-a-better-alternative/June 3rd
```

Which NcReferenceList receives as a reference link (valid by URL_PATTERN)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="460" height="127" alt="image" src="https://github.com/user-attachments/assets/c744b3d8-90a2-4479-b17b-98ef7d94bf2b" /> | <img width="464" height="123" alt="image" src="https://github.com/user-attachments/assets/157e6b6b-10e3-4325-8c15-5fba1b0a274f" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
