### PR TITLE
fix(build): include full package version for CSS hash prefix

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import { join, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import vueDocsPlugin from './build/docs-plugin.ts'
 import l10nPlugin from './build/l10n-plugin.mjs'
+import packageJson from './package.json' with { type: 'json' }
 
 // Entry points which we build using vite
 const entryPoints = {
@@ -43,8 +44,14 @@ const overrides = defineConfig({
 			},
 		},
 		modules: {
-			// Make sure @nextcloud/vue v9 and @nextcloud/vue v8 have different scopes even for the same component code
-			hashPrefix: '@nextcloud/vue@9',
+			/*
+			 * Make sure different versions of @nextcloud/vue
+			 * have different CSS Modules scopes even for the same component code:
+			 * - Vue 2 and Vue 3 components behave differently even with exactly the same source
+			 * - v-bind() in CSS does not guarantee stable CSS variable name and may change
+			 *   on patch update even when the component source did not change
+			 */
+			hashPrefix: `@nextcloud/vue@${packageJson.version}`,
 			// hashPrefix only works when custom generateScopedName is set
 			// Ref: https://github.com/madyankin/postcss-modules/blob/v6.0.1/src/scoping.js#L39
 			generateScopedName: '_[local]_[hash:base64:5]',


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/18182
- Styles were leaking from vue-lib@9.x.x to another vue-lib@9.x.x
  - Now hash is scoped to the full version (minor+patch)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="412" height="160" alt="image" src="https://github.com/user-attachments/assets/683aa86c-b09b-4d74-b2fa-0975e65a9e3e" /> | <img width="424" height="146" alt="image" src="https://github.com/user-attachments/assets/36ffca81-e7f1-40df-9d24-6d7abc68ce8d" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
