### PR TITLE
chore: prepare release v9.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v9.8.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.8.2) (2026-06-02)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.8.1...v9.8.2)
+
+## What's Changed
+### 🐛 Fixed bugs
+* fix(build): include full package version for CSS hash prefix [\#8580](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8580) \([Antreesy](https://github.com/Antreesy)\)
+### Other Changes
+* Updated dependencies
+
 ## [v9.8.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.8.1) (2026-05-28)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.8.0...v9.8.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.8.1",
+  "version": "9.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "9.8.1",
+      "version": "9.8.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.8.1",
+  "version": "9.8.2",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v9.8.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.8.2) (2026-06-02)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.8.1...v9.8.2)

## What's Changed
### 🐛 Fixed bugs
* fix(build): include full package version for CSS hash prefix [\#8580](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8580) \([Antreesy](https://github.com/Antreesy)\)
### Other Changes
* Updated dependencies