### PR TITLE
[stable8] fix(NcAppSettingsDialog): Polish dialog navigation and close button

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -47,6 +47,10 @@
 			}
 		}
 
+		:deep(.icon-collapse) {
+			color: var(--color-main-text) !important;
+		}
+
 		&:not(.app-navigation-entry--editing)::before {
 			content: '';
 			position: absolute;

--- a/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
@@ -87,10 +87,10 @@ export default {
 	inset-inline-end: 0;
 
 	// the whole navigation item is hovered thus will have the hover color - to distinguish we need to set a different color here.
-	&:hover {
+	&.button-vue--legacy34:hover {
 		background-color: var(--color-background-dark) !important;
 	}
-	&--active:hover {
+	&--active.button-vue--legacy34:hover {
 		background-color: var(--color-primary-element) !important;
 	}
 }

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -278,6 +278,15 @@ $content-inset: calc(3 * var(--default-grid-baseline));
 		max-width: 900px;
 	}
 
+	:deep(.modal-container__close) {
+		background-color: var(--color-primary-element-light) !important;
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-primary-element-light-hover) !important;
+		}
+	}
+
 	:deep(.dialog__name) {
 		position: absolute;
 		width: 1px;

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -342,6 +342,7 @@ $content-inset: calc(3 * var(--default-grid-baseline));
 			background-color: transparent;
 			border: none;
 			color: var(--color-main-text);
+			transition: background-color var(--animation-quick, 200ms) ease-in-out;
 
 			&:hover,
 			&:focus-visible {
@@ -364,11 +365,12 @@ $content-inset: calc(3 * var(--default-grid-baseline));
 				&::before {
 					content: '';
 					position: absolute;
-					inset-block: var(--default-grid-baseline);
+					inset-block: calc(var(--default-grid-baseline, 4px) * 2);
 					inset-inline-start: 0;
 					width: 3px;
 					background-color: var(--color-primary-element);
 					border-radius: 999px;
+					animation: nc-settings-pill-in var(--animation-quick, 200ms) ease-out;
 				}
 			}
 
@@ -473,6 +475,17 @@ $content-inset: calc(3 * var(--default-grid-baseline));
 				max-width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
 			}
 		}
+	}
+}
+
+@keyframes nc-settings-pill-in {
+	from {
+		transform: scaleY(0);
+		opacity: 0;
+	}
+	to {
+		transform: scaleY(1);
+		opacity: 1;
 	}
 }
 </style>


### PR DESCRIPTION
  Addresses the remaining Settings Dialog follow-ups from #8526:

  - Hovering an item and switching the selected item now animate smoothly instead of snapping.
  - The selection pill matches the regular navigation height, so it no longer clips into the rounded corners of the item.
  - The close button sits on a tinted background, so content scrolling underneath no longer bleeds through behind it.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="321" height="56" alt="close-b4" src="https://github.com/user-attachments/assets/115a4c00-6798-40c3-b241-0c71435f3d88" /> | <img width="321" height="56" alt="close-After" src="https://github.com/user-attachments/assets/12d331c0-9be9-4cc9-85ef-0f9fa33dde29" />
| <img width="321" height="56" alt="before-chevron" src="https://github.com/user-attachments/assets/7b965022-e1ee-433d-a0aa-91b069c41315" /> | <img width="321" height="56" alt="after-chevron" src="https://github.com/user-attachments/assets/9e26bcb5-3117-4f04-ada5-54744aaae4ff" />




