### PR TITLE
chore: add Development container

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+{
+	"name": "NextcloudVue",
+	// Do not use mcr.microsoft.com/devcontainers/javascript-node because it only uses Debian.
+	// Playwright snapshots are rendered slightly differently on Debian than on Ubuntu.
+	// Using Ubuntu is consistent with .github/workflows/playwright.yml
+	//
+	// Do not use mcr.microsoft.com/devcontainers/universal because it does not support arm64.
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	"features": {
+		"ghcr.io/devcontainers/features/node:2": {}
+	},
+	// Work around for localhost:9323 (Playwright report) not beeing properly forwared due to issues with IPv6.
+	// https://github.com/microsoft/vscode-remote-release/issues/7029
+	"containerEnv": {
+		"NODE_OPTIONS": "--dns-result-order=ipv4first"
+	}
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-FileCopyrightText: 2021-2026 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: CC0-1.0
 
 version: 2
@@ -24,6 +24,16 @@ updates:
           - "@vitest/*"
 
   - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      timezone: Europe/Paris
+    open-pull-requests-limit: 10
+    labels:
+    - 3. to review
+    - dependencies
+
+  - package-ecosystem: devcontainers
     directory: "/"
     schedule:
       interval: weekly

--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ You can also test if the design still works with a legacy Nextcloud version by s
 NEXTCLOUD_LEGACY=y npm run styleguide
 ```
 
+#### Unit tests
+
+```sh
+npm run test
+```
+
+#### Component tests
+
+
+> [!TIP]
+> We use Playwright for component tests.
+>
+> If you don't meet the [system requirements](https://playwright.dev/docs/intro#system-requirements),
+> try the provided [Development Container](.devcontainer/devcontainer.json).
+>
+> It also matches the CI environment, so snapshots taken with it are less likely to break in CI.
+
+```sh
+npm run test:component # or test:component:gui
+```
+
 #### ☁️ Development with Nextcloud apps
 
 To test or debug `@nextcloud/vue` in Nextcloud app you need to [pack](https://docs.npmjs.com/cli/v11/commands/npm-pack) the library and **install** it in the app.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,7 @@ SPDX-PackageSupplier = "Nextcloud GmbH <https://nextcloud.com/impressum/>"
 SPDX-PackageDownloadLocation = "https://github.com/nextcloud-libraries/nextcloud-vue"
 
 [[annotations]]
-path = ["package.json", "package-lock.json", ".github/pull_request_template.md"]
+path = ["package.json", "package-lock.json", ".github/pull_request_template.md", ".devcontainer/devcontainer-lock.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
+import jsonPlugin from '@eslint/json'
 import { recommendedLibrary } from '@nextcloud/eslint-config'
 import { defineConfig } from 'eslint/config'
 
@@ -29,5 +30,12 @@ export default defineConfig([
 		rules: {
 			'vue/require-prop-comment': 'off',
 		},
+	},
+
+	// lint devcontainer.json as JSONC
+	{
+		files: ['.devcontainer/devcontainer.json'],
+		language: 'json/jsonc',
+		...jsonPlugin.configs.recommended,
 	},
 ])


### PR DESCRIPTION
### ☑️ Resolves

- Resolves #8617

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
  - Do you want to backport this?

### Info

You can try it out for example with:

- https://github.com/features/codespaces
- https://code.visualstudio.com/docs/remote/remote-overview
- https://devpod.sh/
