### PR TITLE
test(NcFilePicker): fix flaky tests

### DIFF
--- a/tests/component/components/NcFilePicker/NcFilePicker.spec.ts
+++ b/tests/component/components/NcFilePicker/NcFilePicker.spec.ts
@@ -110,11 +110,7 @@ test.describe('file picking', () => {
 	test.skip(({ browserName }) => browserName === 'webkit', 'WebKit does not support file pickers in Playwright yet')
 
 	test('picking a single file', async ({ mount, page }) => {
-		page.on('filechooser', async (fileChooser) => {
-			expect(fileChooser.isMultiple()).toBe(false)
-			await fileChooser.setFiles({ name: 'testfile.txt', mimeType: 'text/plain', buffer: Buffer.from('Hello World') })
-		})
-
+		const fileChooserPromise = page.waitForEvent('filechooser')
 		const { promise, resolve } = Promise.withResolvers<string[]>()
 		await mount(NcFilePickerEmitStory, { // we need this story as PlayWright can only proxy simple structures like strings but not complex ones like File objects
 			props: {},
@@ -125,20 +121,15 @@ test.describe('file picking', () => {
 
 		const button = page.getByRole('button', { name: 'Pick file' })
 		await button.click()
+		const fileChooser = await fileChooserPromise
+		expect(fileChooser.isMultiple()).toBe(false)
+		await fileChooser.setFiles({ name: 'testfile.txt', mimeType: 'text/plain', buffer: Buffer.from('Hello World') })
 
 		expect(await promise).toEqual(['testfile.txt'])
 	})
 
 	test('picking multiple files', async ({ mount, page }) => {
-		page.on('filechooser', async (fileChooser) => {
-			expect(fileChooser.isMultiple()).toBe(true)
-			await fileChooser.setFiles([
-				{ name: 'a.txt', mimeType: 'text/plain', buffer: Buffer.from('Hello') },
-				{ name: 'b.txt', mimeType: 'text/plain', buffer: Buffer.from('Hallo') },
-				{ name: 'c.txt', mimeType: 'text/plain', buffer: Buffer.from('Hola') },
-			])
-		})
-
+		const fileChooserPromise = page.waitForEvent('filechooser')
 		const { promise, resolve } = Promise.withResolvers<string[]>()
 		await mount(NcFilePickerEmitStory, {
 			props: {
@@ -151,18 +142,19 @@ test.describe('file picking', () => {
 
 		const button = page.getByRole('button', { name: 'Pick files' })
 		await button.click()
+		const fileChooser = await fileChooserPromise
+		expect(fileChooser.isMultiple()).toBe(true)
+		await fileChooser.setFiles([
+			{ name: 'a.txt', mimeType: 'text/plain', buffer: Buffer.from('Hello') },
+			{ name: 'b.txt', mimeType: 'text/plain', buffer: Buffer.from('Hallo') },
+			{ name: 'c.txt', mimeType: 'text/plain', buffer: Buffer.from('Hola') },
+		])
 
 		expect(await promise).toEqual(['a.txt', 'b.txt', 'c.txt'])
 	})
 
 	test('picking a directory', async ({ mount, page }) => {
-		const { promise: filesAttached, resolve: filesAttachedResolve } = Promise.withResolvers<void>()
-		page.on('filechooser', async (fileChooser) => {
-			expect(fileChooser.isMultiple()).toBe(false)
-			await fileChooser.setFiles(join(import.meta.dirname, 'folder'))
-			filesAttachedResolve()
-		})
-
+		const fileChooserPromise = page.waitForEvent('filechooser')
 		const { promise, resolve } = Promise.withResolvers<string[]>()
 		await mount(NcFilePickerEmitStory, {
 			props: {
@@ -176,18 +168,15 @@ test.describe('file picking', () => {
 
 		await page.getByRole('button', { name: 'Pick folder' })
 			.click()
-		await filesAttached
+		const fileChooser = await fileChooserPromise
+		expect(fileChooser.isMultiple()).toBe(false)
+		await fileChooser.setFiles(join(import.meta.dirname, 'folder'))
+
 		expect(await promise).toEqual(['folder/.gitkeep'])
 	})
 
 	test('picking a directory when having the menu', async ({ mount, page }) => {
-		const { promise: filesAttached, resolve: filesAttachedResolve } = Promise.withResolvers<void>()
-		page.on('filechooser', async (fileChooser) => {
-			expect(fileChooser.isMultiple()).toBe(false)
-			await fileChooser.setFiles(join(import.meta.dirname, 'folder'))
-			filesAttachedResolve()
-		})
-
+		const fileChooserPromise = page.waitForEvent('filechooser')
 		const { promise, resolve } = Promise.withResolvers<string[]>()
 		await mount(NcFilePickerEmitStory, {
 			props: {
@@ -202,8 +191,10 @@ test.describe('file picking', () => {
 			.click()
 		await page.getByRole('menuitem', { name: 'Upload folder' })
 			.click()
+		const fileChooser = await fileChooserPromise
+		expect(fileChooser.isMultiple()).toBe(false)
+		await fileChooser.setFiles(join(import.meta.dirname, 'folder'))
 
-		await filesAttached
 		expect(await promise).toEqual(['folder/.gitkeep'])
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

Resolves flaky test that occurred locally for me and sometimes [on CI](https://github.com/nextcloud-libraries/nextcloud-vue/actions/runs/27088521279). The issue was a race condition.

```
  1) [chromium] › tests/component/components/NcFilePicker/NcFilePicker.spec.ts:132:2 › file picking › picking multiple files 

    Error: fileChooser.setFiles: Test ended.

      133 |             page.on('filechooser', async (fileChooser) => {
      134 |                     expect(fileChooser.isMultiple()).toBe(true)
    > 135 |                     await fileChooser.setFiles([
          |                     ^
      136 |                             { name: 'a.txt', mimeType: 'text/plain', buffer: Buffer.from('Hello') },
      137 |                             { name: 'b.txt', mimeType: 'text/plain', buffer: Buffer.from('Hallo') },
      138 |                             { name: 'c.txt', mimeType: 'text/plain', buffer: Buffer.from('Hola') },
        at _Page.<anonymous> (/workspaces/nextcloud-vue/tests/component/components/NcFilePicker/NcFilePicker.spec.ts:135:4)

    Error Context: test-results/components-NcFilePicker-Nc-6015b-king-picking-multiple-files-chromium/error-context.md
```

```
      14) [firefox] › tests/component/components/NcFilePicker/NcFilePicker.spec.ts:112:2 › file picking › picking a single file 

    Error: fileChooser.setFiles: Test ended.

      113 |             page.on('filechooser', async (fileChooser) => {
      114 |                     expect(fileChooser.isMultiple()).toBe(false)
    > 115 |                     await fileChooser.setFiles({ name: 'testfile.txt', mimeType: 'text/plain', buffer: Buffer.from('Hello World') })
          |                     ^
      116 |             })
      117 |
      118 |             const { promise, resolve } = Promise.withResolvers<string[]>()
        at _Page.<anonymous> (/workspaces/nextcloud-vue/tests/component/components/NcFilePicker/NcFilePicker.spec.ts:115:4)

    Error Context: test-results/components-NcFilePicker-Nc-afac6-cking-picking-a-single-file-firefox-repeat1/error-context.md
 ```
### 🖼️ Screenshots

### 🚧 Tasks

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
  - `stable8` does not use Playwright
  
### Info
  
Locally, you could observe failing test by running them repeatably:

```sh
npm run test:component -- NcFilePicker.spec.ts --repeat-each=10
```
