### PR TITLE
fix(NcAppNavigation): deactivate focus on resize

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -140,7 +140,7 @@ import type { Slot } from 'vue'
 
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { createFocusTrap } from 'focus-trap'
-import { inject, onMounted, onUnmounted, ref, useTemplateRef, warn, watch, watchEffect } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, warn, watch, watchEffect } from 'vue'
 import NcAppNavigationList from '../NcAppNavigationList/NcAppNavigationList.vue'
 import NcAppNavigationToggle from './NcAppNavigationToggle.vue'
 import { useIsMobile } from '../../composables/useIsMobile/index.ts'
@@ -191,6 +191,7 @@ const setHasAppNavigation = inject(
 const appNavigationContainerElement = useTemplateRef('appNavigationContainer')
 const isMobile = useIsMobile()
 const open = ref(!isMobile.value)
+const shouldActivateFocusTrap = computed(() => isMobile.value && open.value)
 
 watchEffect(() => {
 	if (!props.ariaLabel && !props.ariaLabelledby) {
@@ -202,7 +203,7 @@ watch(isMobile, () => {
 	open.value = !isMobile.value
 })
 
-watch(open, () => {
+watch(shouldActivateFocusTrap, () => {
 	toggleFocusTrap()
 })
 
@@ -276,7 +277,7 @@ function toggleNavigationByEventBus({ open }: { open: boolean }): void {
  * Activate focus trap if it is currently needed, otherwise deactivate
  */
 function toggleFocusTrap(): void {
-	if (isMobile.value && open.value) {
+	if (shouldActivateFocusTrap.value) {
 		focusTrap.activate()
 	} else {
 		focusTrap.deactivate()


### PR DESCRIPTION
### ☑️ Resolves

- Fix case when `isMobile` changed `true -> false` with `open: true` was never considered, and trap stayed active

Reproduction steps:
1. Load the app on ≥ 1024px — isMobile = false, open = true
2. Resize window to below 1024px — isMobile = true → watch(isMobile) fires → open changes from true to false → watch(open) fires → toggleFocusTrap() called, trap deactivates
3. Open the navigation on mobile — open = true → watch(open) fires → toggleFocusTrap() called → isMobile=true && open=true → trap activates
4. Resize back to ≥ 1024px — isMobile = false → watch(isMobile) fires → sets open.value = !false = true.
  - open was already true → Vue sees no change → watch(open) does NOT fire.
  - toggleFocusTrap() is never called.
  - Focus-trap remains active on desktop. ← BUG

### 🚧 Tasks

- [ ] Manual tests:
	Bug is happening sometimes on production, so far it's the only reliable steps to reproduce it

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
