### PR TITLE
[stable8] feat(NcReferenceWidget): allow to enable resizable widget height

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -360,9 +360,6 @@ msgstr ""
 msgid "Rename project"
 msgstr ""
 
-msgid "Resize widget height"
-msgstr ""
-
 #. TRANSLATORS: A color name for RGB(191, 103, 139)
 msgid "Rosy brown"
 msgstr ""
@@ -494,6 +491,9 @@ msgid "Whiskey"
 msgstr ""
 
 msgid "White"
+msgstr ""
+
+msgid "Widget height"
 msgstr ""
 
 msgid "Write a message …"

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -360,6 +360,9 @@ msgstr ""
 msgid "Rename project"
 msgstr ""
 
+msgid "Resize widget height"
+msgstr ""
+
 #. TRANSLATORS: A color name for RGB(191, 103, 139)
 msgid "Rosy brown"
 msgstr ""

--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -9,7 +9,21 @@
 			v-if="reference && hasCustomWidget"
 			ref="customWidget"
 			class="widget-custom"
-			:class="{ 'full-width': hasFullWidth }" />
+			:class="{
+				'full-width': hasFullWidth,
+			}"
+			:style="customWidgetStyle">
+			<div ref="customWidgetContent" class="widget-custom__content" />
+			<div
+				v-if="isResizable"
+				class="widget-custom__resize-handle"
+				role="slider"
+				tabindex="0"
+				aria-orientation="vertical"
+				:aria-label="t('Resize widget height')"
+				@pointerdown.stop.prevent="startResize"
+				@keydown="onResizeKeydown" />
+		</div>
 
 		<component
 			:is="referenceWidgetLinkComponent"
@@ -42,10 +56,11 @@ import { nextTick, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import NcButton from '../../components/NcButton/index.js'
 import { t } from '../../l10n.js'
-import { destroyWidget, hasFullWidth, hasInteractiveView, isWidgetRegistered, renderWidget } from './../../functions/reference/widgets.ts'
+import { destroyWidget, hasFullWidth, hasInteractiveView, isResizable, isWidgetRegistered, renderWidget } from './../../functions/reference/widgets.ts'
 import { getRoute } from './autolink.js'
 
 const IDLE_TIMEOUT = 3 * 60 * 1000 // 3 minutes outside of viewport before widget is removed from the DOM
+const RESIZE_KEYBOARD_STEP = 10
 
 export default {
 	name: 'NcReferenceWidget',
@@ -96,6 +111,12 @@ export default {
 			showInteractive: false,
 			rendered: false,
 			idleTimeout: null,
+			isResizing: false,
+			resizedHeight: null,
+			resizeStartY: 0,
+			resizeStartHeight: 0,
+			resizeMinHeight: 100,
+			resizeMaxHeight: null,
 		}
 	},
 
@@ -108,8 +129,19 @@ export default {
 			return hasFullWidth(this.reference.richObjectType)
 		},
 
+		isResizable() {
+			return isResizable(this.reference.richObjectType)
+		},
+
 		hasCustomWidget() {
 			return isWidgetRegistered(this.reference.richObjectType)
+		},
+
+		customWidgetStyle() {
+			if (!this.resizedHeight) {
+				return null
+			}
+			return { height: `${this.resizedHeight}px !important` }
 		},
 
 		hasInteractiveView() {
@@ -197,6 +229,11 @@ export default {
 	},
 
 	beforeDestroy() {
+		if (this.idleTimeout) {
+			clearTimeout(this.idleTimeout)
+			this.idleTimout = null
+		}
+		this.stopResize()
 		this.destroyWidget()
 	},
 
@@ -209,7 +246,7 @@ export default {
 		},
 
 		renderWidget() {
-			if (!this.$refs.customWidget) {
+			if (!this.$refs.customWidgetContent) {
 				return
 			}
 
@@ -217,12 +254,12 @@ export default {
 				return
 			}
 
-			this.$refs.customWidget.innerHTML = ''
+			this.$refs.customWidgetContent.innerHTML = ''
 
 			// create a separate element so we can rerender on the ref again
 			const widget = document.createElement('div')
 			widget.style = 'width: 100%;'
-			this.$refs.customWidget.appendChild(widget)
+			this.$refs.customWidgetContent.appendChild(widget)
 			this.$nextTick(() => {
 				// Waiting for the ref to become available
 				renderWidget(widget, {
@@ -238,6 +275,86 @@ export default {
 				destroyWidget(this.reference.richObjectType, this.$el)
 				this.rendered = false
 			}
+		},
+
+		initResizeLimits() {
+			// Use min/max height from rendered widget element if set
+			const widgetEl = this.$refs.customWidgetContent?.firstElementChild
+			if (widgetEl) {
+				const computedStyle = window.getComputedStyle(widgetEl)
+				const parsedMin = parseFloat(computedStyle.minHeight)
+				const parsedMax = parseFloat(computedStyle.maxHeight)
+				this.resizeMinHeight = parsedMin > 0 ? parsedMin : 100
+				this.resizeMaxHeight = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : null
+			} else {
+				this.resizeMinHeight = 100
+				this.resizeMaxHeight = null
+			}
+		},
+
+		startResize(event) {
+			if (!this.isResizable || !this.$refs.customWidget) {
+				return
+			}
+
+			this.initResizeLimits()
+			this.isResizing = true
+			this.resizeStartY = event.clientY
+			this.resizeStartHeight = this.$refs.customWidget.getBoundingClientRect().height
+
+			window.addEventListener('pointermove', this.onResize)
+			window.addEventListener('pointerup', this.stopResize)
+		},
+
+		onResizeKeydown(event) {
+			if (!this.isResizable || !this.$refs.customWidget) {
+				return
+			}
+
+			if (!['ArrowDown', 'ArrowUp'].includes(event.key)) {
+				return
+			}
+
+			// Establish limits once per interaction
+			this.initResizeLimits()
+
+			const maxHeight = this.resizeMaxHeight ?? (window.innerHeight - 120)
+			const currentHeight = this.resizedHeight ?? this.resizeStartHeight
+
+			let next
+			switch (event.key) {
+				case 'ArrowDown':
+					next = currentHeight + RESIZE_KEYBOARD_STEP
+					break
+				case 'ArrowUp':
+					next = currentHeight - RESIZE_KEYBOARD_STEP
+					break
+				default:
+					return
+			}
+
+			event.preventDefault()
+			this.resizedHeight = Math.min(maxHeight, Math.max(this.resizeMinHeight, next))
+		},
+
+		onResize(event) {
+			if (!this.isResizing || !this.$refs.customWidget) {
+				return
+			}
+
+			const deltaY = event.clientY - this.resizeStartY
+			const maxHeight = this.resizeMaxHeight ?? (window.innerHeight - 120)
+			this.resizedHeight = Math.min(maxHeight, Math.max(this.resizeMinHeight, this.resizeStartHeight + deltaY))
+		},
+
+		stopResize() {
+			if (!this.isResizing) {
+				return
+			}
+
+			this.isResizing = false
+			window.removeEventListener('pointermove', this.onResize)
+			window.removeEventListener('pointerup', this.stopResize)
 		},
 	},
 }
@@ -259,11 +376,51 @@ export default {
 
 .widget-custom {
 	@include widget;
+	position: relative;
 
 	&.full-width {
 		width: var(--widget-full-width, 100%) !important;
 		inset-inline-start: calc( (var(--widget-full-width, 100%) - 100%) / 2 * -1);
 		position: relative;
+	}
+
+	&__content {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	&__resize-handle {
+		position: absolute;
+		bottom: 0;
+		inset-inline-start: 0;
+		width: 100%;
+		height: calc(var(--default-grid-baseline) * 2);
+		border-top: 1px solid var(--color-border);
+		margin-top: -1px;
+		cursor: row-resize;
+		touch-action: none;
+
+		&::before, &::after {
+			content: '';
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			background-color: var(--color-border);
+			margin-top: 1px;
+			transform: translateX(-50%);
+			width: 30px;
+			height: 1px;
+		}
+
+		&::before {
+			margin-top: -2px;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: -4px;
+		}
 	}
 }
 

--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -7,6 +7,7 @@
 	<div ref="widgetRoot" :class="{ 'toggle-interactive': hasInteractiveView && !isInteractive }">
 		<div
 			v-if="reference && hasCustomWidget"
+			:id="widgetId"
 			ref="customWidget"
 			class="widget-custom"
 			:class="{
@@ -20,7 +21,11 @@
 				role="slider"
 				tabindex="0"
 				aria-orientation="vertical"
-				:aria-label="t('Resize widget height')"
+				:aria-label="t('Widget height')"
+				:aria-valuenow="ariaValueNow"
+				:aria-valuemin="resizeMinHeight"
+				:aria-valuemax="resizeMaxHeight"
+				:aria-controls="widgetId"
 				@pointerdown.stop.prevent="startResize"
 				@keydown="onResizeKeydown" />
 		</div>
@@ -56,6 +61,7 @@ import { nextTick, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import NcButton from '../../components/NcButton/index.js'
 import { t } from '../../l10n.js'
+import { createElementId } from '../../utils/createElementId.ts'
 import { destroyWidget, hasFullWidth, hasInteractiveView, isResizable, isWidgetRegistered, renderWidget } from './../../functions/reference/widgets.ts'
 import { getRoute } from './autolink.js'
 
@@ -88,10 +94,14 @@ export default {
 	},
 
 	setup() {
+		const widgetId = `nc-reference-widget-${createElementId()}`
+
 		const isVisible = ref(false)
 		// This is the widget root node
 		const widgetRoot = ref()
+		const customWidget = ref()
 		const { width } = useElementSize(widgetRoot)
+		const { height: customWidgetHeight } = useElementSize(customWidget)
 
 		useIntersectionObserver(widgetRoot, ([entry]) => {
 			nextTick(() => {
@@ -103,6 +113,9 @@ export default {
 			width,
 			isVisible,
 			widgetRoot,
+			customWidget,
+			customWidgetHeight,
+			widgetId,
 		}
 	},
 
@@ -116,7 +129,7 @@ export default {
 			resizeStartY: 0,
 			resizeStartHeight: 0,
 			resizeMinHeight: 100,
-			resizeMaxHeight: null,
+			resizeMaxHeight: window.innerHeight - 120,
 		}
 	},
 
@@ -142,6 +155,10 @@ export default {
 				return null
 			}
 			return { height: `${this.resizedHeight}px !important` }
+		},
+
+		ariaValueNow() {
+			return Math.round(this.resizedHeight ?? this.customWidgetHeight)
 		},
 
 		hasInteractiveView() {
@@ -285,10 +302,10 @@ export default {
 				const parsedMin = parseFloat(computedStyle.minHeight)
 				const parsedMax = parseFloat(computedStyle.maxHeight)
 				this.resizeMinHeight = parsedMin > 0 ? parsedMin : 100
-				this.resizeMaxHeight = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : null
+				this.resizeMaxHeight = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : (window.innerHeight - 120)
 			} else {
 				this.resizeMinHeight = 100
-				this.resizeMaxHeight = null
+				this.resizeMaxHeight = window.innerHeight - 120
 			}
 		},
 
@@ -318,7 +335,6 @@ export default {
 			// Establish limits once per interaction
 			this.initResizeLimits()
 
-			const maxHeight = this.resizeMaxHeight ?? (window.innerHeight - 120)
 			const currentHeight = this.resizedHeight ?? this.resizeStartHeight
 
 			let next
@@ -334,7 +350,7 @@ export default {
 			}
 
 			event.preventDefault()
-			this.resizedHeight = Math.min(maxHeight, Math.max(this.resizeMinHeight, next))
+			this.resizedHeight = Math.min(this.resizeMaxHeight, Math.max(this.resizeMinHeight, next))
 		},
 
 		onResize(event) {
@@ -343,8 +359,7 @@ export default {
 			}
 
 			const deltaY = event.clientY - this.resizeStartY
-			const maxHeight = this.resizeMaxHeight ?? (window.innerHeight - 120)
-			this.resizedHeight = Math.min(maxHeight, Math.max(this.resizeMinHeight, this.resizeStartHeight + deltaY))
+			this.resizedHeight = Math.min(this.resizeMaxHeight, Math.max(this.resizeMinHeight, this.resizeStartHeight + deltaY))
 		},
 
 		stopResize() {

--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -27,7 +27,8 @@
 				:aria-valuemax="resizeMaxHeight"
 				:aria-controls="widgetId"
 				@pointerdown.stop.prevent="startResize"
-				@keydown="onResizeKeydown" />
+				@keydown.up.stop.prevent="onResizeKeydown(-RESIZE_KEYBOARD_STEP)"
+				@keydown.down.stop.prevent="onResizeKeydown(RESIZE_KEYBOARD_STEP)" />
 		</div>
 
 		<component
@@ -116,6 +117,7 @@ export default {
 			customWidget,
 			customWidgetHeight,
 			widgetId,
+			RESIZE_KEYBOARD_STEP,
 		}
 	},
 
@@ -323,12 +325,8 @@ export default {
 			window.addEventListener('pointerup', this.stopResize)
 		},
 
-		onResizeKeydown(event) {
+		onResizeKeydown(delta) {
 			if (!this.isResizable || !this.$refs.customWidget) {
-				return
-			}
-
-			if (!['ArrowDown', 'ArrowUp'].includes(event.key)) {
 				return
 			}
 
@@ -336,20 +334,7 @@ export default {
 			this.initResizeLimits()
 
 			const currentHeight = this.resizedHeight ?? this.resizeStartHeight
-
-			let next
-			switch (event.key) {
-				case 'ArrowDown':
-					next = currentHeight + RESIZE_KEYBOARD_STEP
-					break
-				case 'ArrowUp':
-					next = currentHeight - RESIZE_KEYBOARD_STEP
-					break
-				default:
-					return
-			}
-
-			event.preventDefault()
+			const next = currentHeight + delta
 			this.resizedHeight = Math.min(this.resizeMaxHeight, Math.max(this.resizeMinHeight, next))
 		},
 

--- a/src/functions/reference/widgets.ts
+++ b/src/functions/reference/widgets.ts
@@ -19,6 +19,7 @@ export interface ReferenceWidgetProps {
 	id: string
 	hasInteractiveView: boolean
 	fullWidth: boolean
+	isResizable: boolean
 	callback: ReferenceWidgetRenderCallback
 	onDestroy: ReferenceWidgetDestroyCallback
 }
@@ -34,7 +35,10 @@ window._registerWidget ??= (id: string, callback: ReferenceWidgetRenderCallback,
  * @param id - Id tof the widget
  * @param callback - Render callback
  * @param onDestroy - Cleanup callback
- * @param props - Widget props
+ * @param props - Widget props (all optional)
+ * @param props.hasInteractiveView - Whether the widget exposes an interactive view (default: true)
+ * @param props.fullWidth - Whether the widget renders at full container width (default: false)
+ * @param props.isResizable - Whether the user can drag-resize the widget height (default: false)
  */
 export function registerWidget(
 	id: string,
@@ -45,6 +49,7 @@ export function registerWidget(
 	const propsWithDefaults = {
 		hasInteractiveView: true,
 		fullWidth: false,
+		isResizable: false,
 		...props,
 	}
 
@@ -124,4 +129,13 @@ export function hasInteractiveView(id: string): boolean {
  */
 export function hasFullWidth(id: string): boolean {
 	return !!window._vue_richtext_widgets[id]?.fullWidth
+}
+
+/**
+ * Check if the widget is resizable.
+ *
+ * @param id - Id of the widget
+ */
+export function isResizable(id: string): boolean {
+	return !!window._vue_richtext_widgets[id]?.isResizable
 }


### PR DESCRIPTION
### ☑️ Resolves

Allows widgets to flag themselves as resizable, which adds a resize drag handle to resize them horizontally. Particularly useful for embedded office documents, tables and deck boards in a Text file.

Required to fix https://github.com/nextcloud/text/issues/8279

Developed against stable8 on purpose as Text and Deck apps are still on Vue 2, but already forward-ported locally to `main` branch.

Intending to set `isResizable: true` at least in files and deck board widget for a starter.

### 🖼️ Screencasts

| 🏡 After |
| ---|
| <img width="720" height="777" alt="recording" src="https://github.com/user-attachments/assets/a3e24b4d-99c7-47a6-bd45-0e772669304b" /> |

### 🏁 Checklist

- [] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
