### PR TITLE
fix(NcGuestContent): migrate style assignment fully to CSS

### DIFF
--- a/src/components/NcGuestContent/NcGuestContent.vue
+++ b/src/components/NcGuestContent/NcGuestContent.vue
@@ -29,19 +29,9 @@ It can't be used multiple times on the same page.
 <script setup lang="ts">
 import type { Slot } from 'vue'
 
-import { onMounted, onUnmounted } from 'vue'
-
 defineSlots<{
 	default?: Slot
 }>()
-
-onMounted(() => {
-	document.getElementById('content')!.classList.add('nc-guest-content')
-})
-
-onUnmounted(() => {
-	document.getElementById('content')!.classList.remove('nc-guest-content')
-})
 </script>
 
 <template>
@@ -64,7 +54,7 @@ onUnmounted(() => {
 </style>
 
 <style lang="scss">
-#content.nc-guest-content {
+#content:has(#guest-content-vue) {
 	// Enable scrolling
 	overflow: auto;
 


### PR DESCRIPTION
### ☑️ Resolves

- Suppress mentioned TypeError in production code
	- There is nothing relevant for end-user to see, and should be handled by developer
- Assisted-by: ClaudeCode:claude-sonnet-4-6

### 🖼️ Screenshots

<img width="331" height="120" alt="2026-06-25_10h37_33" src="https://github.com/user-attachments/assets/aea0e8b4-dc6a-4b21-ab59-723dbb240c66" />


### 🚧 Tasks

- [ ] Check upstream pages that render it (maintenance / upgrade / pass protection)?
- [ ] Are added styles required at all?

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
