### PR TITLE
feat(NcActions): add wide prop for full-width menus

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -545,6 +545,86 @@ export default {
 </script>
 ```
 
+### Wide buttons
+
+```vue
+<template>
+	<NcActions menu-name="Object management" wide>
+		<template #icon>
+			<IconPencilOutline :size="20" />
+		</template>
+		<NcActionButton>
+			<template #icon>
+				<IconPencilOutline :size="20" />
+			</template>
+			Rename
+		</NcActionButton>
+		<NcActionButton>
+			<template #icon>
+				<IconTrashCanOutline :size="20" />
+			</template>
+			Delete
+		</NcActionButton>
+		<NcActionButton>
+			<template #icon>
+				<IconArrowRight :size="20" />
+			</template>
+			Validate
+		</NcActionButton>
+		<NcActionButton>
+			<template #icon>
+				<IconTrayArrowDown :size="20" />
+			</template>
+			Download
+		</NcActionButton>
+	</NcActions>
+	<NcActions wide>
+		<template #icon>
+			<IconPencilOutline :size="20" />
+		</template>
+		<NcActionButton>
+			<template #icon>
+				<IconPencilOutline :size="20" />
+			</template>
+			Rename
+		</NcActionButton>
+		<NcActionButton>
+			<template #icon>
+				<IconTrashCanOutline :size="20" />
+			</template>
+			Delete
+		</NcActionButton>
+		<NcActionButton>
+			<template #icon>
+				<IconArrowRight :size="20" />
+			</template>
+			Validate
+		</NcActionButton>
+		<NcActionButton>
+			<template #icon>
+				<IconTrayArrowDown :size="20" />
+			</template>
+			Download
+		</NcActionButton>
+	</NcActions>
+</template>
+<script>
+import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
+import IconTrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
+import IconPencilOutline from 'vue-material-design-icons/PencilOutline.vue'
+
+export default {
+	components: {
+		IconArrowRight,
+		IconTrashCanOutline,
+		IconTrayArrowDown,
+		IconPencilOutline,
+	},
+}
+</script>
+```
+
 ### Use cases
 
 ```vue
@@ -1092,6 +1172,14 @@ export default {
 			},
 
 			default: null,
+		},
+
+		/**
+		 * Specifies whether the button should span all the available width.
+		 */
+		wide: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**
@@ -1694,13 +1782,19 @@ export default {
 				mergeProps(
 					propsToForward,
 					{
-						class: 'action-item action-item--single',
+						class: [
+							'action-item action-item--single',
+							{
+								'action-item--wide': this.wide,
+							},
+						],
 						'aria-label': action?.props?.['aria-label'] || text,
 						title,
 						disabled: this.disabled || action?.props?.disabled,
 						pressed: action?.props?.modelValue,
 						size: this.size,
 						type,
+						wide: this.wide,
 						// If it has a menuName, we use a secondary button
 						variant: this.variant || (buttonText ? 'secondary' : 'tertiary'),
 						onFocus: this.onFocus,
@@ -1759,6 +1853,7 @@ export default {
 						disabled: this.disabled,
 						size: this.size,
 						variant: this.triggerButtonVariant,
+						wide: this.wide,
 						ref: 'triggerButton',
 						'aria-label': this.menuName ? null : this.ariaLabel,
 						// 'aria-controls' should only present together with a valid aria-haspopup
@@ -1861,6 +1956,7 @@ export default {
 					`action-item--${this.triggerButtonVariant}`,
 					{
 						'action-item--open': this.opened,
+						'action-item--wide': this.wide,
 					},
 				],
 			},
@@ -1911,6 +2007,10 @@ export default {
 
 	&.action-item--open .action-item__menutoggle {
 		background-color: var(--open-background-color);
+	}
+
+	&.action-item--wide {
+		width: 100%;
 	}
 
 	&__menutoggle__icon {

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -861,7 +861,7 @@ function onClick(event: MouseEvent) {
 	}
 
 	// Icon-only button
-	&:has(#{&}__text:empty) {
+	&:has(#{&}__text:empty):not(#{&}--wide) {
 		--button-padding: var(--button-radius);
 		line-height: 1;
 		width: var(--button-size) !important;


### PR DESCRIPTION
### ☑️ Resolves

- Fix #8582

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="836" height="88" alt="image" src="https://github.com/user-attachments/assets/09319be3-cd8b-4499-8c1a-06b2507f51d8" /> | <img width="820" height="87" alt="image" src="https://github.com/user-attachments/assets/140c398a-f7cb-42e9-8c35-87abf7d12827" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
