### PR TITLE
chore: prepare release v8.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 # Changelog
 
+## [v8.40.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.40.0) (2026-07-13)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.39.0...v8.40.0)
+
+## What's Changed
+### 🚀 Enhancements
+* [stable8] feat: Semantic font weights for interactive elements [\#8519](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8519) \([kra-mo](https://github.com/kra-mo)\)
+* [stable8] feat(NcReferenceWidget): allow to enable resizable widget height [\#8665](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8665) \([mejo-](https://github.com/mejo-)\)
+### 🐛 Fixed bugs
+* [stable8] fix: use correct boundaries of CSS breakpoints [\#8543](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8543)
+* fix(NcAppNavigationItem): Make active state darker than hover [\#8533](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8533) \([nfebe](https://github.com/nfebe)\)
+* [stable8] fix(NcAppContent): background blur may be missing after minification [\#8566](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8566)
+* [stable8] fix(NcRichText): handle new lines when parsing reference links [\#8568](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8568)
+* [stable8] fix(NcAppSidebarTab): Reduce pill height [\#8553](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8553) \([kra-mo](https://github.com/kra-mo)\)
+* [stable8] fix(build): include full package version for CSS hash prefix [\#8584](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8584) \([Antreesy](https://github.com/Antreesy)\)
+* [stable8] fix(NcGuestContent): migrate style assignment fully to CSS [\#8696](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8696)
+
+### Other Changes
+* Updated dependencies
+
 ## [v8.39.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.39.0) (2026-05-07)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.38.0...v8.39.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.39.0",
+  "version": "8.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.39.0",
+      "version": "8.40.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.39.0",
+  "version": "8.40.0",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.40.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.40.0) (2026-07-13)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.39.0...v8.40.0)

## What's Changed
### 🚀 Enhancements
* [stable8] feat: Semantic font weights for interactive elements [\#8519](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8519) \([kra-mo](https://github.com/kra-mo)\)
* [stable8] feat(NcReferenceWidget): allow to enable resizable widget height [\#8665](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8665) \([mejo-](https://github.com/mejo-)\)
### 🐛 Fixed bugs
* [stable8] fix: use correct boundaries of CSS breakpoints [\#8543](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8543) \([backportbot[bot]](https://github.com/backportbot[bot])\)
* fix(NcAppNavigationItem): Make active state darker than hover [\#8533](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8533) \([nfebe](https://github.com/nfebe)\)
* [stable8] fix(NcAppContent): background blur may be missing after minification [\#8566](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8566) \([backportbot[bot]](https://github.com/backportbot[bot])\)
* [stable8] fix(NcRichText): handle new lines when parsing reference links [\#8568](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8568) \([backportbot[bot]](https://github.com/backportbot[bot])\)
* [stable8] fix(NcAppSidebarTab): Reduce pill height [\#8553](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8553) \([kra-mo](https://github.com/kra-mo)\)
* [stable8] fix(build): include full package version for CSS hash prefix [\#8584](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8584) \([Antreesy](https://github.com/Antreesy)\)
* [stable8] fix(NcGuestContent): migrate style assignment fully to CSS [\#8696](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8696) \([backportbot[bot]](https://github.com/backportbot[bot])\)

### Other Changes
* Updated dependencies