### PR TITLE
fix(NcAppNavigationItem): close mobile navigation on router-link click

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -438,6 +438,7 @@ Just set the `pinned` prop.
 </template>
 
 <script>
+import { emit } from '@nextcloud/event-bus'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import Undo from 'vue-material-design-icons/Undo.vue'
 import NcAppNavigationIconCollapsible from './NcAppNavigationIconCollapsible.vue'
@@ -748,6 +749,10 @@ export default {
 			if (routerLinkHref) {
 				navigate?.(event)
 				event.preventDefault()
+				// On mobile, close app-navigation when navigating so it doesn't overlay content
+				if (this.isMobile) {
+					emit('toggle-navigation', { open: false })
+				}
 			}
 		},
 

--- a/tests/unit/components/NcAppNavigation/NcAppNavigationItem.spec.ts
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigationItem.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import NcAppNavigationItem from '../../../../src/components/NcAppNavigationItem/NcAppNavigationItem.vue'
+import { resizeWindowWidth } from '../../testing-utils.ts'
+
+describe('NcAppNavigationItem.vue', () => {
+	describe('router-link navigation on mobile', () => {
+		it('closes the app navigation after navigating', async () => {
+			await resizeWindowWidth(500)
+			const wrapper = mount(NcAppNavigationItem, { props: { name: 'Item' } })
+			const handler = vi.fn()
+			subscribe('toggle-navigation', handler)
+
+			wrapper.vm.onClick(new MouseEvent('click'), vi.fn(), '/href')
+
+			expect(handler).toHaveBeenCalledWith({ open: false })
+			unsubscribe('toggle-navigation', handler)
+		})
+
+		it('does not close the app navigation on desktop', async () => {
+			await resizeWindowWidth(1024)
+			const wrapper = mount(NcAppNavigationItem, { props: { name: 'Item' } })
+			const handler = vi.fn()
+			subscribe('toggle-navigation', handler)
+
+			wrapper.vm.onClick(new MouseEvent('click'), vi.fn(), '/href')
+
+			expect(handler).not.toHaveBeenCalled()
+			unsubscribe('toggle-navigation', handler)
+		})
+	})
+})


### PR DESCRIPTION
On narrower screen sizes, when the app-navigation is overlaid over the content and can be toggled, clicking on any folder/mailbox to open it keeps the app-navigation open which results in it overlaying the message list. Instead, clicking on any folder/mailbox in the app-navigation should close the app-navigation.

This is an issue in Files, Activity, Photos, Mail, Contacts, Calendar, Notes, Deck, Tables, Office, and probably more apps.
In Talk, Collectives and Forms, the issue does not occur cause custom fixes were used.

This is an annoyance in every app, hence solving it on the components level makes most sense.

### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/2523

### 🖼️ Screenshots

#### 🏚️ Before

[Screencast From 2026-07-13 21-53-52.webm](https://github.com/user-attachments/assets/10e66b58-0951-4fc5-a9f7-1ef48bdd76cb)

#### 🏡 After

[Screencast From 2026-07-13 21-53-19.webm](https://github.com/user-attachments/assets/f77baf97-4003-46a3-ac5f-9dff39a37435)




### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable


Assisted-by: ClaudeCode:claude-opus-4-8