### PR TITLE
build: initialize a release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ npm run l10n:extract
 
 ## 📤 Releasing a new version
 
+`npm run release` automates everything up to the release commit: it pulls the
+base branch, bumps the version (detecting patch/minor/major from the changes),
+creates the `chore/release-<version>` branch, and updates and commits
+`CHANGELOG.md`. Pushing and opening the PR stay manual — the script prints the
+commands to run.
+
+```sh
+npm run release                       # detect the bump on the current branch
+npm run release -- minor --base main  # override the bump and/or base branch
+```
+
+Requires `git`, `gh` (run `gh auth login` first) and `npm`. Each step is a
+confirmation navigated with `↑`/`↓` + `Enter` (no typing); pass `--yes` to skip
+them, or `--help` for all options.
+
+<details>
+<summary>Doing these steps manually</summary>
+
 - Pull the latest changes from `main` or `stableX`
 - Checkout a new branch with the tag name (e.g `v4.0.1`): `git checkout -b v<version>`
 - Run `npm version patch --no-git-tag-version` (`npm version minor --no-git-tag-version` if minor).
@@ -172,7 +190,12 @@ npm run l10n:extract
      Which this as the replacement: `[\#$4]($2) \([$1]($3$1)\)`
   2. use the the version as tag AND title (e.g `v4.0.1`)
   3. add the changelog content as description (https://github.com/nextcloud-libraries/nextcloud-vue/releases)
-- Commit, push and create PR
+- Stage and commit the changes:
+  `git add package.json package-lock.json CHANGELOG.md && git commit --signoff --message "chore(release): v<version>"`
+
+</details>
+
+- Push and create PR
 - Get your PR reviewed and merged
 - Create a milestone with the follow-up version at https://github.com/nextcloud-libraries/nextcloud-vue/milestones
 - Move all open tickets and PRs to the follow-up

--- a/build/cli-utils.mjs
+++ b/build/cli-utils.mjs
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* eslint-disable no-console */
+
+/**
+ * Generic command-line helpers shared by the build scripts: coloured terminal
+ * output, fail-fast subprocess runners and keyboard-driven prompts. Nothing
+ * here is specific to the release process.
+ */
+
+import { spawnSync } from 'node:child_process'
+import process, { stdin, stdout } from 'node:process'
+import { emitKeypressEvents } from 'node:readline'
+
+// --- Terminal helpers ------------------------------------------------------
+export const c = {
+	info: (m) => console.info(`\x1b[1;34m➜\x1b[0m ${m}`),
+	ok: (m) => console.info(`\x1b[1;32m✔\x1b[0m ${m}`),
+	warn: (m) => console.warn(`\x1b[1;33m!\x1b[0m ${m}`),
+	err: (m) => console.error(`\x1b[1;31m✖\x1b[0m ${m}`),
+}
+
+/**
+ * Run a command, inheriting stdio, and exit the process on failure.
+ *
+ * @param {string} cmd command to run
+ * @param {string[]} args arguments
+ * @param {object} [options] extra spawn options; `capture` pipes stdout back
+ * @return {string} captured stdout (trimmed) when `capture` is set, else ''
+ */
+export function run(cmd, args, options = {}) {
+	const { capture = false, ...rest } = options
+	const result = spawnSync(cmd, args, {
+		encoding: 'utf-8',
+		stdio: capture ? ['inherit', 'pipe', 'inherit'] : 'inherit',
+		...rest,
+	})
+	if (result.status !== 0) {
+		c.err(`Command failed: ${cmd} ${args.join(' ')}`)
+		process.exit(result.status ?? 1)
+	}
+	return capture ? (result.stdout ?? '').trim() : ''
+}
+
+/**
+ * Run a command only to read its output, returning null on failure.
+ *
+ * @param {string} cmd command to run
+ * @param {string[]} args arguments
+ * @param {object} [options] extra spawn options
+ * @return {string|null} trimmed stdout, or null if the command failed
+ */
+export function tryRead(cmd, args, options = {}) {
+	const result = spawnSync(cmd, args, { encoding: 'utf-8', ...options })
+	return result.status === 0 ? (result.stdout ?? '').trim() : null
+}
+
+/**
+ * Prompt with an arrow-key list (↑/↓ or k/j, Enter to pick, Esc/Ctrl+C to
+ * abort). Returns the default without prompting when autoYes is set or stdin is
+ * not a TTY, so callers still run unattended.
+ *
+ * @param {string} question the prompt to display
+ * @param {Array<{label: string, value: boolean|string}>} choices the selectable options
+ * @param {object} [options] prompt options
+ * @param {boolean|string} [options.defaultValue] value highlighted first / used non-interactively
+ * @param {boolean} [options.autoYes] skip the prompt and return the default
+ * @return {Promise<boolean|string>} the chosen value
+ */
+export function select(question, choices, { defaultValue, autoYes = false } = {}) {
+	let index = choices.findIndex((choice) => choice.value === defaultValue)
+	if (index === -1) {
+		index = 0
+	}
+
+	if (autoYes || !stdin.isTTY) {
+		const reason = autoYes ? 'auto-confirm' : 'non-interactive shell'
+		c.info(`${question} — ${choices[index].label} (auto-selected, ${reason})`)
+		return Promise.resolve(choices[index].value)
+	}
+
+	return new Promise((resolve) => {
+		const render = (first) => {
+			if (!first) {
+				stdout.write(`\x1b[${choices.length}A`) // move back up to redraw the list
+			}
+			for (const [i, choice] of choices.entries()) {
+				const active = i === index
+				const pointer = active ? '\x1b[1;36m❯\x1b[0m' : ' '
+				const label = active ? `\x1b[1;36m${choice.label}\x1b[0m` : choice.label
+				stdout.write(`\x1b[2K${pointer} ${label}\n`)
+			}
+		}
+
+		const cleanup = () => {
+			stdin.removeAllListeners('keypress')
+			stdin.setRawMode(false)
+			stdin.pause()
+		}
+
+		const onKeypress = (_str, key) => {
+			if (key.name === 'up' || key.name === 'k') {
+				index = (index - 1 + choices.length) % choices.length
+				render(false)
+			} else if (key.name === 'down' || key.name === 'j') {
+				index = (index + 1) % choices.length
+				render(false)
+			} else if (key.name === 'return' || key.name === 'enter') {
+				cleanup()
+				// Replace the header + list with a one-line summary.
+				stdout.write(`\x1b[${choices.length + 1}A\x1b[0J`)
+				stdout.write(`\x1b[1;32m✔\x1b[0m ${question} \x1b[1;36m${choices[index].label}\x1b[0m\n`)
+				resolve(choices[index].value)
+			} else if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
+				cleanup()
+				c.err('Aborted.')
+				process.exit(130)
+			}
+		}
+
+		stdout.write(`\x1b[1;36m?\x1b[0m ${question} \x1b[2m(↑/↓ to move, Enter to select)\x1b[0m\n`)
+		emitKeypressEvents(stdin)
+		stdin.setRawMode(true)
+		stdin.resume()
+		render(true)
+		stdin.on('keypress', onKeypress)
+	})
+}
+
+/**
+ * Ask a yes/no question via an arrow-key select.
+ *
+ * @param {string} question the prompt to display
+ * @param {object} [options] prompt options
+ * @param {boolean} [options.autoYes] skip the prompt and confirm automatically
+ * @return {Promise<boolean>} true when the user confirms
+ */
+export function confirm(question, { autoYes = false } = {}) {
+	return select(question, [
+		{ label: 'Yes', value: true },
+		{ label: 'No', value: false },
+	], { defaultValue: true, autoYes })
+}

--- a/build/release.mjs
+++ b/build/release.mjs
@@ -1,0 +1,415 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* eslint-disable no-console */
+
+/**
+ * Automates the "📤 Releasing a new version" steps from README.md, up to and
+ * including the release commit (pushing and opening the PR stay manual).
+ *
+ * Prompts are arrow-key selects (↑/↓ + Enter, no typing). Before each step
+ * (unless --yes is passed) it will:
+ *   1. Check out and pull the latest changes of the base branch (main or stableX)
+ *   2. Show GitHub's categorised changes since the last tag, then bump the
+ *      version (`npm version <type> --no-git-tag-version`). The bump type is
+ *      inferred from those changes (💥 Breaking → major, 🚀 Enhancements →
+ *      minor, otherwise patch) and offered as the default; pass an explicit
+ *      [patch|minor|major] argument to override it.
+ *   3. Create the release branch `chore/release-<version>`
+ *   4. Prepend those (formatted) release notes to CHANGELOG.md, then stage and
+ *      commit the release (`chore(release): <version>`, signed off)
+ *
+ * Requirements: git, gh (authenticated), npm.
+ *
+ * Usage:
+ *   npm run release -- [patch|minor|major] [options]
+ *   node build/release.mjs [patch|minor|major] [options]
+ *
+ * The [patch|minor|major] argument is optional — when omitted the bump is
+ * detected from the categorised changes since the last tag.
+ *
+ * Options:
+ *   -b, --base <branch>   Branch to base the release on (e.g. main, stable8).
+ *                         Defaults to the currently checked-out branch.
+ *   -y, --yes             Auto-confirm every step (no prompts); uses the
+ *                         detected bump unless one is given explicitly
+ *   -h, --help            Show this help
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import process from 'node:process'
+import { c, confirm as confirmPrompt, tryRead as readCommand, run as runCommand, select } from './cli-utils.mjs'
+import { formatChangelog } from './format-changelog.mjs'
+
+const REPO_SLUG = 'nextcloud-libraries/nextcloud-vue'
+const REPO_URL = `https://github.com/${REPO_SLUG}`
+const ROOT = join(import.meta.dirname, '..')
+
+// Bind the generic runners to the repository root, so every git/gh/npm call
+// operates on this repository regardless of the caller's working directory.
+const run = (cmd, args, options = {}) => runCommand(cmd, args, { cwd: ROOT, ...options })
+const tryRead = (cmd, args) => readCommand(cmd, args, { cwd: ROOT })
+
+/**
+ * Fetch GitHub's categorised release notes for the range `previousTag..target`.
+ * The tag need not exist yet — the notes only depend on the range's commits.
+ *
+ * @param {string} tagName tag label for the notes (may be a placeholder)
+ * @param {string} previousTag the previous release tag
+ * @param {string} target branch or commit the release is built from
+ * @return {string} the generated markdown body
+ */
+function generateNotes(tagName, previousTag, target) {
+	return run(
+		'gh',
+		[
+			'api',
+			`repos/${REPO_SLUG}/releases/generate-notes`,
+			'-f',
+			`tag_name=${tagName}`,
+			'-f',
+			`target_commitish=${target}`,
+			'-f',
+			`previous_tag_name=${previousTag}`,
+			'--jq',
+			'.body',
+		],
+		{ capture: true },
+	)
+}
+
+/**
+ * Strip GitHub boilerplate (leading HTML comment, trailing "Full Changelog"
+ * line and trailing blank lines) so the notes match the CHANGELOG.md style.
+ *
+ * @param {string} rawBody the raw generated notes body
+ * @return {string} the cleaned markdown
+ */
+function cleanNotes(rawBody) {
+	return rawBody
+		.split('\n')
+		.filter((line) => !line.startsWith('<!--') && !line.startsWith('**Full Changelog**:'))
+		.join('\n')
+		.trim()
+}
+
+/**
+ * Condense the "### Other Changes" section to the CHANGELOG.md style: collapse
+ * Transifex PRs into one "Updated translations" line, and add an "Updated
+ * dependencies" line when the range has dependency-bump commits.
+ *
+ * @param {string} notes the cleaned release notes
+ * @param {boolean} hasDependencyBumps whether the git log contains bump commits
+ * @return {string} the condensed release notes
+ */
+function condenseOtherChanges(notes, hasDependencyBumps) {
+	const lines = notes.split('\n')
+	let start = lines.findIndex((line) => line.startsWith('### Other Changes'))
+
+	// Create the section if it is missing but there are bumps to record.
+	if (start === -1) {
+		if (!hasDependencyBumps) {
+			return notes
+		}
+		const contribIndex = lines.findIndex((line) => line.startsWith('## New Contributors'))
+		if (contribIndex === -1) {
+			lines.push('', '### Other Changes')
+			start = lines.length - 1
+		} else {
+			lines.splice(contribIndex, 0, '### Other Changes', '')
+			start = contribIndex
+		}
+	}
+
+	// The section body runs until the next heading (or the end of the notes).
+	let end = lines.length
+	for (let i = start + 1; i < lines.length; i++) {
+		if (/^#{2,3} /.test(lines[i])) {
+			end = i
+			break
+		}
+	}
+
+	const head = lines.slice(0, start + 1)
+	const tail = lines.slice(end)
+	let body = lines.slice(start + 1, end)
+
+	// Collapse all Transifex PRs into a single "Updated translations" line.
+	const hasTranslations = body.some((line) => /transifex/i.test(line))
+	body = body.filter((line) => !/transifex/i.test(line))
+
+	// Append the summary lines at the end of the section.
+	while (body.length && body[body.length - 1].trim() === '') {
+		body.pop()
+	}
+	if (hasDependencyBumps) {
+		body.push('* Updated dependencies')
+	}
+	if (hasTranslations) {
+		body.push('* Updated translations')
+	}
+
+	const rebuilt = [...head, ...body]
+	if (tail.length) {
+		rebuilt.push('', ...tail)
+	}
+	return rebuilt.join('\n')
+}
+
+/**
+ * Infer the semver bump from the highest-priority section in the notes:
+ * 💥 Breaking Changes → major, 🚀 Enhancements → minor, everything else → patch.
+ * Only a suggestion — the maintainer confirms or overrides it.
+ *
+ * @param {string} notes the categorised release notes
+ * @return {'patch'|'minor'|'major'} the inferred bump
+ */
+function detectBump(notes) {
+	if (/^#{2,3} .*\bBreaking Changes\b/im.test(notes)) {
+		return 'major'
+	}
+	if (/^#{2,3} .*\bEnhancements\b/im.test(notes)) {
+		return 'minor'
+	}
+	return 'patch'
+}
+
+// --- Argument parsing ------------------------------------------------------
+let bump = null
+let autoYes = false
+let baseArg = null
+
+const argv = process.argv.slice(2)
+for (let i = 0; i < argv.length; i++) {
+	const arg = argv[i]
+	if (['patch', 'minor', 'major'].includes(arg)) {
+		bump = arg
+	} else if (arg === '-b' || arg === '--base') {
+		baseArg = argv[++i]
+		if (!baseArg) {
+			c.err(`Missing branch name after '${arg}'.`)
+			process.exit(1)
+		}
+	} else if (arg.startsWith('--base=')) {
+		baseArg = arg.slice('--base='.length)
+	} else if (arg === '-y' || arg === '--yes') {
+		autoYes = true
+	} else if (arg === '-h' || arg === '--help') {
+		// Print the JSDoc block that documents usage as help text.
+		const self = await readFile(new URL(import.meta.url), 'utf-8')
+		const block = self.match(/\/\*\*[\s\S]*?Usage:[\s\S]*?\*\//)?.[0] ?? ''
+		console.info(block
+			.split('\n')
+			.slice(1, -1)
+			.map((l) => l.replace(/^\s*\*\s?/, ''))
+			.join('\n'))
+		process.exit(0)
+	} else {
+		c.err(`Unknown argument: ${arg}`)
+		process.exit(1)
+	}
+}
+
+// --- Interactive prompts (bound to this run's --yes toggle) ----------------
+
+/**
+ * Ask a yes/no question, honouring the --yes toggle.
+ *
+ * @param {string} question the prompt to display
+ * @return {Promise<boolean>} true when the user confirms
+ */
+function confirm(question) {
+	return confirmPrompt(question, { autoYes })
+}
+
+/**
+ * Ask which semver bump to apply via an arrow-key select. Honours the --yes
+ * toggle (returns fallback).
+ *
+ * @param {string} fallback the bump highlighted first / used with --yes
+ * @return {Promise<'patch'|'minor'|'major'>} the chosen bump
+ */
+function chooseBump(fallback) {
+	return select('Release type?', [
+		{ label: 'patch', value: 'patch' },
+		{ label: 'minor', value: 'minor' },
+		{ label: 'major', value: 'major' },
+	], { defaultValue: fallback, autoYes })
+}
+
+/** Abort the release because a mandatory step was skipped. */
+function skipAbort() {
+	c.err('Step skipped — aborting release. No further changes made.')
+	process.exit(1)
+}
+
+// --- Pre-flight ------------------------------------------------------------
+for (const bin of ['git', 'gh', 'npm']) {
+	if (tryRead(bin, ['--version']) === null) {
+		c.err(`Required command '${bin}' not found in PATH.`)
+		process.exit(1)
+	}
+}
+
+if (tryRead('git', ['status', '--porcelain'])) {
+	c.err('Working tree is not clean. Commit or stash your changes first.')
+	run('git', ['status', '--short'])
+	process.exit(1)
+}
+
+if (tryRead('gh', ['auth', 'status']) === null) {
+	c.err("GitHub CLI is not authenticated. Run 'gh auth login' first.")
+	process.exit(1)
+}
+
+const currentBranch = run('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { capture: true })
+const baseBranch = baseArg ?? currentBranch
+c.info(`Release type : ${bump}`)
+c.info(`Base branch  : ${baseBranch}${baseArg && baseArg !== currentBranch ? ` (currently on '${currentBranch}')` : ''}`)
+c.info(`Repository   : ${REPO_SLUG}`)
+c.info(`Prompts      : ${autoYes ? 'OFF (--yes)' : 'ON (confirm each step)'}`)
+console.info('')
+
+// --- Step 1: Check out and pull the base branch ----------------------------
+const needsCheckout = baseBranch !== currentBranch
+const step1 = needsCheckout
+	? `Step 1/4: Check out '${baseBranch}' and pull latest changes from origin?`
+	: `Step 1/4: Pull latest changes of '${baseBranch}' from origin?`
+if (await confirm(step1)) {
+	if (needsCheckout) {
+		run('git', ['checkout', baseBranch])
+	}
+	run('git', ['pull', '--ff-only', 'origin', baseBranch])
+	c.ok(`On '${baseBranch}' with latest changes.`)
+} else {
+	skipAbort()
+}
+console.info('')
+
+// --- Step 2: Review changes and choose the version bump --------------------
+const prevTag = run('git', ['describe', '--tags', '--abbrev=0'], { capture: true })
+const currentVersion = JSON.parse(await readFile(join(ROOT, 'package.json'), 'utf-8')).version
+c.info(`Current version : ${currentVersion}`)
+c.info(`Previous tag    : ${prevTag}`)
+
+// The notes are built once here and reused verbatim for the changelog in step
+// 4. `release-preview` is a placeholder tag; GitHub then uses `baseBranch` as
+// the range's upper bound, and cleanNotes strips the label anyway.
+c.info(`Step 2/4: Fetching changes since ${prevTag} from GitHub…`)
+// Dependency bumps are excluded from GitHub's notes; detect them from the log
+// so they collapse into a single "Updated dependencies" line.
+const commitSubjects = run('git', ['log', `${prevTag}..HEAD`, '--pretty=format:%s'], { capture: true })
+const hasDependencyBumps = /\bbump\b/i.test(commitSubjects)
+const releaseNotes = formatChangelog(condenseOtherChanges(cleanNotes(generateNotes('release-preview', prevTag, baseBranch)), hasDependencyBumps))
+console.info('')
+console.info(releaseNotes)
+console.info('')
+c.info('Review the changes above (🚀 Enhancements → minor, 🐛 Fixed bugs → patch, breaking → major).')
+
+// A bump given on the command line always wins over the detected one.
+const detectedBump = detectBump(releaseNotes)
+if (bump) {
+	c.info(`Release type '${bump}' taken from the command line (detected from changes: '${detectedBump}').`)
+} else {
+	c.info(`Detected release type from the changes above: '${detectedBump}'.`)
+}
+bump = await chooseBump(bump ?? detectedBump)
+
+// npm version prints the new version prefixed with 'v', e.g. v9.8.3
+const newTag = run('npm', ['version', bump, '--no-git-tag-version'], { capture: true })
+c.ok(`New version: ${currentVersion} → ${newTag} (${bump})`)
+if (!(await confirm(`  → Does '${newTag}' match what you expect?`))) {
+	c.err('Version mismatch. Reverting package.json changes.')
+	run('git', ['checkout', '--', 'package.json', 'package-lock.json'])
+	skipAbort()
+}
+console.info('')
+
+// e.g. tag v9.8.3 → branch chore/release-9.8.3
+const releaseBranch = `chore/release-${newTag.replace(/^v/, '')}`
+
+// --- Step 3: Create the release branch -------------------------------------
+if (tryRead('git', ['show-ref', '--verify', '--quiet', `refs/heads/${releaseBranch}`]) !== null) {
+	c.err(`Branch '${releaseBranch}' already exists. Delete it or pick another version.`)
+	run('git', ['checkout', '--', 'package.json', 'package-lock.json'])
+	process.exit(1)
+}
+
+if (await confirm(`Step 3/4: Create and switch to branch '${releaseBranch}'?`)) {
+	// The uncommitted version bump is carried over to the new branch.
+	run('git', ['checkout', '-b', releaseBranch])
+	c.ok(`On branch '${releaseBranch}'.`)
+} else {
+	c.warn('Reverting version bump.')
+	run('git', ['checkout', '--', 'package.json', 'package-lock.json'])
+	skipAbort()
+}
+console.info('')
+
+// --- Step 4: Update the changelog and commit the release -------------------
+const commitFiles = ['package.json', 'package-lock.json', 'CHANGELOG.md']
+const commitMessage = `chore(release): ${newTag}`
+let committed = false
+if (await confirm(`Step 4/4: Prepend the changelog entry (${prevTag} → ${newTag}) to CHANGELOG.md, then commit?`)) {
+	const releaseDate = new Date().toISOString().slice(0, 10)
+
+	// Reuse the release notes fetched in step 2 — the content is identical.
+	const entry = [
+		`## [${newTag}](${REPO_URL}/tree/${newTag}) (${releaseDate})`,
+		`[Full Changelog](${REPO_URL}/compare/${prevTag}...${newTag})`,
+		'',
+		releaseNotes,
+		'',
+		'',
+	].join('\n')
+
+	// Insert the new entry right before the first existing "## [vX.Y.Z]" heading.
+	const changelogPath = join(ROOT, 'CHANGELOG.md')
+	const changelog = await readFile(changelogPath, 'utf-8')
+	const firstEntry = changelog.search(/^## \[v/m)
+	if (firstEntry === -1) {
+		c.err('Could not locate an existing "## [vX.Y.Z]" entry in CHANGELOG.md.')
+		process.exit(1)
+	}
+	const updated = changelog.slice(0, firstEntry) + entry + changelog.slice(firstEntry)
+	await writeFile(changelogPath, updated)
+
+	c.ok(`Changelog entry prepended for ${newTag}.`)
+	c.warn('Review CHANGELOG.md — auto-generated notes usually need manual polishing.')
+
+	// Separate confirmation so the changelog can be polished before committing.
+	if (await confirm('  → Stage and commit these changes now?')) {
+		run('git', ['add', ...commitFiles])
+		run('git', ['commit', '--signoff', '--message', commitMessage]) // --signoff for DCO
+		committed = true
+		c.ok(`Committed as '${commitMessage}'.`)
+	} else {
+		c.warn('Skipping commit. Review CHANGELOG.md, then commit manually.')
+	}
+} else {
+	c.warn('Skipping changelog generation. You can edit CHANGELOG.md manually.')
+}
+console.info('')
+
+// --- Done — push and PR remain manual --------------------------------------
+c.ok(`Automated steps complete for ${newTag} on branch '${releaseBranch}'.`)
+console.info('')
+if (committed) {
+	c.info('Review the release commit:')
+	console.info('    git show')
+	console.info('')
+	c.info("Next (manual) steps from README.md — 'push and create PR':")
+	console.info(`    git push -u origin ${releaseBranch}
+    gh pr create --fill --base ${baseBranch}`)
+} else {
+	c.info('Review your changes:')
+	console.info('    git diff; git status')
+	console.info('')
+	c.info("Next (manual) steps from README.md — 'Commit, push and create PR':")
+	console.info(`    git add ${commitFiles.join(' ')}
+    git commit --signoff --message "${commitMessage}"
+    git push -u origin ${releaseBranch}
+    gh pr create --fill --base ${baseBranch}`)
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prerelease:format-changelog": "node build/format-changelog.mjs",
+    "release": "node build/release.mjs",
     "styleguide": "vue-styleguidist --config styleguide.config.cjs server",
     "styleguide:build": "vue-styleguidist --config styleguide.config.cjs build",
     "stylelint": "stylelint \"src/**/*.vue\" \"src/**/*.scss\" \"src/**/*.css\"",


### PR DESCRIPTION
### ☑️ Resolves

Follow-up to #8731
Automates following functionality:
- prepare and read changelog
- derive required version bump
- checkout new branch and commit changes

Supports --yes and --base flags for further release automations with GH actions

### 🖼️ Screenshots

<img width="935" height="501" alt="image" src="https://github.com/user-attachments/assets/e520346c-80dd-46b3-8127-dd0e125dc2e5" />
<img width="985" height="549" alt="image" src="https://github.com/user-attachments/assets/dc7c11b1-2e03-4f72-8d6d-a04fd9ec3932" />


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
